### PR TITLE
Add `servicrab up`: dependency-ordered multi-service supervision

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - `servicrab check` — validate your config before running anything
 - `servicrab list` — see all services and their restart policies at a glance
 - `servicrab run <service>` — supervise a single service in the foreground with live stdout/stderr, restart policy, and process-group shutdown (Linux/macOS)
+- `servicrab up` — run your whole stack in the foreground: dependency-ordered start, interleaved and colour-prefixed output, reverse-order shutdown (Linux/macOS)
 - Restart policies: `never`, `on-failure`, `always`, with exponential backoff
 - Per-service environment variables and working directories
-- Dependency declarations and a deterministic start order (ordering is enforced once multi-service supervision lands)
+- Dependency declarations and a deterministic start order
 
 ---
 
@@ -56,6 +57,9 @@ servicrab list
 
 # 5. Run a service in the foreground
 servicrab run api
+
+# 6. …or bring the whole stack up
+servicrab up
 ```
 
 ---
@@ -115,6 +119,7 @@ if you want shell semantics.
 | `servicrab check [--config PATH]` | Parse and validate the config file |
 | `servicrab list [--config PATH] [--json]` | List all services with their restart policies |
 | `servicrab run <SERVICE> [--config PATH] [--no-restart]` | Supervise one service in the foreground |
+| `servicrab up [SERVICE...] [--config PATH] [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure]` | Supervise a whole stack in the foreground |
 
 If `--config` is omitted, Servicrab discovers `servicrab.toml` by walking up
 from the current directory.
@@ -224,13 +229,76 @@ exits, so no descendant outlives the run.
 `servicrab run` supports **Linux and macOS**. Windows is out of scope for now;
 the command reports an unsupported-platform error there.
 
-Current limitations:
+---
 
-- one service per invocation — `depends_on` is validated but not yet acted on;
-- no background daemon, no `up` / `down`;
-- no health or readiness checks;
-- no log files or log rotation — output is inherited, so redirect it yourself;
-- no `--json` event stream yet.
+## Running a whole stack in the foreground
+
+```sh
+servicrab up                       # start every service with autostart = true
+servicrab up api                   # start `api` and everything it depends on
+servicrab up --no-restart          # ignore every configured restart policy
+servicrab up --timestamps          # prefix each line with a UTC timestamp
+servicrab up --no-prefix           # raw output, no service prefix
+servicrab up --abort-on-failure    # tear the stack down when a service fails
+```
+
+Output is interleaved and prefixed with the service name, each service getting
+its own colour:
+
+```
+servicrab up acme-stack → redis, api
+redis | ▶ started (pgid 41234)
+redis | Ready to accept connections
+api   | ▶ started (pgid 41235)
+api   | listening on 0.0.0.0:3000
+```
+
+A service's own stdout is written to Servicrab's stdout and its stderr to
+Servicrab's stderr, so `servicrab up > stack.log` keeps the two apart. Colour is
+disabled automatically when the output is not a terminal, when `NO_COLOR` is
+set, or when `TERM=dumb`.
+
+### Which services are started
+
+- with no arguments: every service with `autostart = true`;
+- with explicit names: those services only;
+- in both cases every transitive `depends_on` entry is pulled in, even when it
+  has `autostart = false`.
+
+### Start and stop ordering
+
+Services start in the configuration's deterministic topological order, and a
+service is only spawned once every service it depends on is **running**. Note
+that "running" currently means "the process was spawned" — real readiness
+probes are a later milestone, so a dependent may still need to retry its first
+connection.
+
+Shutdown happens in reverse: dependents are stopped (and fully reaped) before
+the services they depend on, each with its own `shutdown_signal` and
+`shutdown_timeout`, escalating to `SIGKILL` per service exactly as `run` does.
+
+If a dependency never comes up — it fails to spawn, or exhausts its restart
+budget — its dependents are **skipped** rather than started against a missing
+backend, and the run is reported as failed.
+
+### Exit codes for `up`
+
+| Situation | Exit code |
+|---|---|
+| Every service ended cleanly | `0` |
+| Ctrl+C (SIGINT) | `130` |
+| SIGTERM | `143` |
+| A service failed or was skipped | `1` |
+
+### Platform support and current limitations
+
+`servicrab up` supports **Linux and macOS**. Current limitations:
+
+- no background daemon: `up` runs in the foreground and stops with your shell;
+- no health or readiness checks — dependency gating is "process is up";
+- no log files or log rotation — redirect the output yourself;
+- no `--json` event stream yet;
+- `servicrab down` does not exist yet (Ctrl+C is the way to stop a stack).
 
 ---
 
@@ -282,15 +350,18 @@ cargo test -p servicrab-core config::tests
 - [x] Restart policy enforcement with exponential backoff
 - [x] Graceful shutdown with `SIGKILL` escalation
 
+### Phase 1.6 (current) — Stack runner ✅
+- [x] `servicrab up` — concurrent supervision of the whole stack
+- [x] Dependency ordering on start, reverse order on shutdown
+- [x] Interleaved, prefixed, colourised output
+
 ### Phase 2 — Background daemon
 - [ ] Background daemon process with Unix socket / named-pipe API
 - [ ] `servicrab start` / `stop` / `restart` / `status` commands
-- [ ] Dependency ordering on start
-- [ ] Concurrent supervision of the whole stack
 - [ ] `servicrab logs <service>` — stream live logs
 
 ### Phase 3 — Stack management
-- [ ] `servicrab up` / `servicrab down` — whole-stack lifecycle
+- [ ] `servicrab down` — stop a detached stack
 - [ ] `servicrab watch` — restart on file changes (à la `watchexec`)
 - [ ] `.env` file support per service
 - [ ] Health-check probes (HTTP + command)

--- a/crates/servicrab-cli/src/commands/mod.rs
+++ b/crates/servicrab-cli/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod check;
 pub mod init;
 pub mod list;
 pub mod run;
+pub mod up;

--- a/crates/servicrab-cli/src/commands/run.rs
+++ b/crates/servicrab-cli/src/commands/run.rs
@@ -6,9 +6,8 @@
 
 use std::path::Path;
 
-use servicrab_core::runtime::{RunOptions, RunOutcome};
+use servicrab_core::runtime::{lookup_service, OutputMode, RunOptions, RunOutcome};
 use servicrab_core::{load, resolve_config_path, ExitReason, ForegroundRunner, ShutdownReason};
-use servicrab_core::{RuntimeError, ServiceName};
 
 /// Exit code used when a run is cut short by Ctrl+C (`128 + SIGINT`).
 const EXIT_SIGINT: i32 = 130;
@@ -33,9 +32,12 @@ pub fn run(service: &str, config: Option<&Path>, no_restart: bool) -> Result<i32
         eprintln!("⚠  {warning}");
     }
 
-    let service = lookup(&cfg, service).map_err(|e| e.to_string())?;
+    let service = lookup_service(&cfg, service).map_err(|e| e.to_string())?;
 
-    let options = RunOptions { no_restart };
+    let options = RunOptions {
+        no_restart,
+        output: OutputMode::Inherit,
+    };
     let mut runner = ForegroundRunner::new(service, options);
 
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -49,35 +51,6 @@ pub fn run(service: &str, config: Option<&Path>, no_restart: bool) -> Result<i32
     }
 }
 
-/// Find a service by name, producing a structured error listing the known
-/// services when it does not exist.
-fn lookup<'a>(
-    cfg: &'a servicrab_core::Config,
-    requested: &str,
-) -> Result<&'a servicrab_core::Service, RuntimeError> {
-    cfg.services
-        .iter()
-        .find(|(name, _)| name.as_str() == requested)
-        .map(|(_, svc)| svc)
-        .ok_or_else(|| RuntimeError::UnknownService {
-            service: requested.to_string(),
-            known: known_services(&cfg.services),
-        })
-}
-
-fn known_services(
-    services: &std::collections::BTreeMap<ServiceName, servicrab_core::Service>,
-) -> String {
-    if services.is_empty() {
-        return "(none)".to_string();
-    }
-    services
-        .keys()
-        .map(|n| n.as_str())
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
 /// Map a terminal [`RunOutcome`] to a process exit code.
 fn exit_code(outcome: RunOutcome) -> i32 {
     match outcome {
@@ -89,7 +62,7 @@ fn exit_code(outcome: RunOutcome) -> i32 {
         RunOutcome::Stopped { reason } => match reason {
             ShutdownReason::UserInterrupt => EXIT_SIGINT,
             ShutdownReason::Terminated => EXIT_SIGTERM,
-            ShutdownReason::RestartLimit => 1,
+            ShutdownReason::RestartLimit | ShutdownReason::StackFailure => 1,
         },
     }
 }

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -1,0 +1,327 @@
+//! `servicrab up [SERVICE...]` — run a whole stack in the foreground.
+//!
+//! This module only renders events; starting, restarting, and stopping the
+//! services is entirely [`servicrab_core::runtime::stack`]'s job.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::Path;
+
+use servicrab_core::runtime::stack::{ServiceResult, StackOptions, StackSupervisor};
+use servicrab_core::{
+    event_channel, load, plan_stack, resolve_config_path, Config, EventKind, EventReceiver,
+    ServiceName, ShutdownReason, SignalWatcher, Stream,
+};
+
+use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
+
+/// Exit code used when a run is cut short by Ctrl+C (`128 + SIGINT`).
+const EXIT_SIGINT: i32 = 130;
+/// Exit code used when the supervisor itself was terminated (`128 + SIGTERM`).
+const EXIT_SIGTERM: i32 = 143;
+
+/// Command-line options for `up`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UpOptions {
+    /// Disable automatic restarts for every service.
+    pub no_restart: bool,
+    /// Do not prefix output lines with the service name.
+    pub no_prefix: bool,
+    /// Prefix output lines with a UTC timestamp.
+    pub timestamps: bool,
+    /// Stop the whole stack as soon as one service fails.
+    pub abort_on_failure: bool,
+}
+
+/// Run the `up` subcommand, returning the process exit code to use.
+pub fn run(services: &[String], config: Option<&Path>, options: UpOptions) -> Result<i32, String> {
+    let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
+
+    let (cfg, warnings) = load(&path).map_err(|errors| {
+        let msgs: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
+        format!(
+            "✗ {} has {} error(s):\n{}",
+            path.display(),
+            errors.len(),
+            msgs.join("\n")
+        )
+    })?;
+
+    for warning in &warnings {
+        eprintln!("⚠  {warning}");
+    }
+
+    let plan = plan_stack(&cfg, services).map_err(|e| e.to_string())?;
+    if plan.is_empty() {
+        return Err(
+            "no services to start: none of the configured services have autostart = true"
+                .to_string(),
+        );
+    }
+
+    let printer = Printer::new(&plan, options);
+    printer.banner(&cfg, &plan);
+
+    let stack_options = StackOptions {
+        no_restart: options.no_restart,
+        abort_on_failure: options.abort_on_failure,
+    };
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("failed to start the async runtime: {e}"))?;
+
+    let outcome = runtime.block_on(async move {
+        let signals = SignalWatcher::install(cfg.project.name.as_str())?;
+        let mut shutdown = signals.subscribe();
+
+        let (events_tx, events_rx) = event_channel();
+        let renderer = tokio::spawn(render(events_rx, printer));
+
+        let supervisor = StackSupervisor::new(&cfg, plan, stack_options, events_tx);
+        let outcome = supervisor.run(&mut shutdown).await;
+
+        // The supervisor owned the last sender, so the renderer stops as soon
+        // as it has drained the queue.
+        let printer = renderer.await.expect("renderer task");
+        printer.summary(&outcome);
+
+        Ok::<_, servicrab_core::RuntimeError>(outcome)
+    });
+
+    let outcome = outcome.map_err(|e| e.to_string())?;
+
+    if !outcome.is_success() {
+        return Ok(1);
+    }
+    Ok(match outcome.shutdown {
+        Some(ShutdownReason::UserInterrupt) => EXIT_SIGINT,
+        Some(ShutdownReason::Terminated) => EXIT_SIGTERM,
+        Some(_) => 1,
+        None => 0,
+    })
+}
+
+/// Drain the event stream, rendering everything as it arrives.
+async fn render(mut events: EventReceiver, printer: Printer) -> Printer {
+    while let Some(event) = events.recv().await {
+        printer.event(&event.service, &event.kind);
+    }
+    printer
+}
+
+/// Renders runtime events for a terminal.
+struct Printer {
+    colors: BTreeMap<ServiceName, &'static str>,
+    width: usize,
+    color: bool,
+    options: UpOptions,
+}
+
+impl Printer {
+    fn new(plan: &[ServiceName], options: UpOptions) -> Self {
+        let color = style::color_enabled();
+        let width = plan.iter().map(|n| n.as_str().len()).max().unwrap_or(0);
+        let colors = plan
+            .iter()
+            .enumerate()
+            .map(|(index, name)| (name.clone(), SERVICE_COLORS[index % SERVICE_COLORS.len()]))
+            .collect();
+        Self {
+            colors,
+            width,
+            color,
+            options,
+        }
+    }
+
+    fn banner(&self, config: &Config, plan: &[ServiceName]) {
+        let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
+        eprintln!(
+            "{} {} → {}",
+            style::paint(self.color, BOLD, "servicrab up"),
+            config.project.name,
+            names.join(", ")
+        );
+    }
+
+    /// `api    | ` (or an empty string when prefixes are disabled).
+    fn prefix(&self, service: &ServiceName) -> String {
+        if self.options.no_prefix {
+            return String::new();
+        }
+        let color = self.colors.get(service).copied().unwrap_or(RESET);
+        let label = format!("{:width$}", service.as_str(), width = self.width);
+        format!("{} {} ", style::paint(self.color, color, &label), "|")
+    }
+
+    fn timestamp(&self) -> String {
+        if !self.options.timestamps {
+            return String::new();
+        }
+        let now = style::utc_hms(std::time::SystemTime::now());
+        format!("{} ", style::paint(self.color, DIM, &now))
+    }
+
+    fn event(&self, service: &ServiceName, kind: &EventKind) {
+        match kind {
+            EventKind::Log { stream, line } => self.log(service, *stream, line),
+            EventKind::Started { pgid } => {
+                self.status(service, "▶", &format!("started (pgid {pgid})"))
+            }
+            EventKind::Exited { reason, uptime } => self.status(
+                service,
+                "■",
+                &format!("{reason} after {}", humanize(*uptime)),
+            ),
+            EventKind::Backoff { delay, attempt } => self.status(
+                service,
+                "↻",
+                &format!("restarting in {} (attempt {attempt})", humanize(*delay)),
+            ),
+            EventKind::Stopping { reason } => {
+                self.status(service, "◼", &format!("stopping: {reason}"))
+            }
+            EventKind::Skipped { dependency } => self.status(
+                service,
+                "⊘",
+                &format!("skipped: dependency {dependency} never became available"),
+            ),
+            EventKind::Failed { message } => self.status(service, "✗", message),
+            // State transitions and the final summary are already conveyed by
+            // the events above; showing them too would only add noise.
+            EventKind::State(_) | EventKind::Finished { .. } => {}
+        }
+    }
+
+    fn log(&self, service: &ServiceName, stream: Stream, line: &str) {
+        let text = format!("{}{}{}", self.timestamp(), self.prefix(service), line);
+        match stream {
+            Stream::Stdout => {
+                let mut out = std::io::stdout().lock();
+                let _ = writeln!(out, "{text}");
+                let _ = out.flush();
+            }
+            Stream::Stderr => {
+                let mut err = std::io::stderr().lock();
+                let _ = writeln!(err, "{text}");
+                let _ = err.flush();
+            }
+        }
+    }
+
+    fn status(&self, service: &ServiceName, symbol: &str, message: &str) {
+        let mut err = std::io::stderr().lock();
+        let _ = writeln!(
+            err,
+            "{}{}{}",
+            self.timestamp(),
+            self.prefix(service),
+            style::paint(self.color, DIM, &format!("{symbol} {message}"))
+        );
+        let _ = err.flush();
+    }
+
+    fn summary(&self, outcome: &servicrab_core::runtime::stack::StackOutcome) {
+        if outcome.is_success() {
+            eprintln!(
+                "{}",
+                style::paint(self.color, DIM, "all services stopped cleanly")
+            );
+            return;
+        }
+        for report in outcome.failures() {
+            let detail = match &report.result {
+                ServiceResult::Failed(err) => err.to_string(),
+                ServiceResult::Skipped { dependency } => {
+                    format!("skipped: dependency {dependency} never became available")
+                }
+                ServiceResult::Finished(_) => continue,
+            };
+            eprintln!("✗ {}: {}", report.service, detail);
+        }
+    }
+}
+
+/// Render a duration the way a human would say it.
+fn humanize(duration: std::time::Duration) -> String {
+    let secs = duration.as_secs();
+    if secs >= 60 {
+        return format!("{}m{}s", secs / 60, secs % 60);
+    }
+    if secs > 0 {
+        return format!("{secs}s");
+    }
+    format!("{}ms", duration.as_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn service(name: &str) -> ServiceName {
+        // Round-trip through the public planner types is overkill here; the
+        // list command already proves name validation, so build the plan from
+        // a real config instead.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("servicrab.toml");
+        std::fs::write(
+            &path,
+            format!("version = 1\n\n[project]\nname = \"demo\"\n\n[services.{name}]\ncommand = [\"true\"]\n"),
+        )
+        .expect("write config");
+        let (config, _) = load(&path).expect("valid config");
+        config.services.keys().next().expect("one service").clone()
+    }
+
+    #[test]
+    fn durations_are_humanized() {
+        assert_eq!(humanize(Duration::from_millis(250)), "250ms");
+        assert_eq!(humanize(Duration::from_secs(5)), "5s");
+        assert_eq!(humanize(Duration::from_secs(125)), "2m5s");
+    }
+
+    #[test]
+    fn prefixes_are_padded_to_the_longest_name() {
+        let plan = vec![service("api"), service("database")];
+        let printer = Printer::new(&plan, UpOptions::default());
+        let prefix = printer.prefix(&plan[0]);
+        assert!(
+            prefix.starts_with("api     "),
+            "unexpected prefix {prefix:?}"
+        );
+        assert!(prefix.ends_with("| "));
+    }
+
+    #[test]
+    fn prefixes_can_be_disabled() {
+        let plan = vec![service("api")];
+        let printer = Printer::new(
+            &plan,
+            UpOptions {
+                no_prefix: true,
+                ..UpOptions::default()
+            },
+        );
+        assert_eq!(printer.prefix(&plan[0]), "");
+    }
+
+    #[test]
+    fn timestamps_are_only_added_when_requested() {
+        let plan = vec![service("api")];
+        let plain = Printer::new(&plan, UpOptions::default());
+        assert_eq!(plain.timestamp(), "");
+
+        let stamped = Printer::new(
+            &plan,
+            UpOptions {
+                timestamps: true,
+                ..UpOptions::default()
+            },
+        );
+        let stamp = stamped.timestamp();
+        assert_eq!(stamp.trim().len(), 8, "expected HH:MM:SS, got {stamp:?}");
+    }
+}

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -7,6 +7,8 @@
 //! - `servicrab list [--config PATH] [--json]` — list services
 //! - `servicrab run <SERVICE> [--config PATH] [--no-restart]` — run one
 //!   service in the foreground (Linux/macOS)
+//! - `servicrab up [SERVICE...]` — run a whole stack in the foreground
+//!   (Linux/macOS)
 //!
 //! ## Future phases (TODOs)
 //!
@@ -14,12 +16,13 @@
 //!   a background daemon over a Unix socket.
 //! - TODO(phase-2): Add `status` to show a rich process table.
 //! - TODO(phase-2): Add `logs <service>` to stream logs from the daemon.
-//! - TODO(phase-3): Add `up` / `down` for whole-stack lifecycle.
+//! - TODO(phase-3): Add `down` for stopping a detached stack.
 
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
 mod commands;
+mod style;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -83,20 +86,59 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         no_restart: bool,
     },
+
+    /// Run a whole stack in the foreground: start every service in dependency
+    /// order, interleave their output, and stop them in reverse order on
+    /// Ctrl+C.  Linux and macOS only.
+    Up {
+        /// Services to start.  Their dependencies are always started too.
+        /// With no names, every service with autostart = true is started.
+        services: Vec<String>,
+
+        /// Path to the configuration file.  If omitted, discovers
+        /// servicrab.toml by walking up from the current directory.
+        #[arg(long, short = 'c')]
+        config: Option<std::path::PathBuf>,
+
+        /// Never restart services, whatever their configured policy says.
+        #[arg(long, default_value_t = false)]
+        no_restart: bool,
+
+        /// Do not prefix output lines with the service name.
+        #[arg(long, default_value_t = false)]
+        no_prefix: bool,
+
+        /// Prefix output lines with a UTC timestamp.
+        #[arg(long, default_value_t = false)]
+        timestamps: bool,
+
+        /// Stop the whole stack as soon as one service fails.
+        #[arg(long, default_value_t = false)]
+        abort_on_failure: bool,
+    },
 }
 
 fn main() {
-    // Initialise structured logging.  The log level can be overridden via the
-    // RUST_LOG environment variable (e.g. `RUST_LOG=debug servicrab list`).
+    let cli = Cli::parse();
+
+    // `run` has no other progress output, so its lifecycle transitions are
+    // logged by default.  `up` renders its own event stream, and the remaining
+    // commands are one-shot, so those stay quiet unless asked otherwise.
+    // Either way `RUST_LOG` wins (e.g. `RUST_LOG=debug servicrab up`).
+    let default_filter = match cli.command {
+        Commands::Run { .. } => "servicrab_core=info",
+        _ => "warn",
+    };
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter)),
         )
+        // Diagnostics belong on stderr; stdout is reserved for command output
+        // and for the stdout of supervised services.
+        .with_writer(std::io::stderr)
         .with_target(false)
         .compact()
         .init();
-
-    let cli = Cli::parse();
 
     // Commands return the process exit code to use; `0` means success.
     let result = match cli.command {
@@ -108,6 +150,23 @@ fn main() {
             config,
             no_restart,
         } => commands::run::run(&service, config.as_deref(), no_restart),
+        Commands::Up {
+            services,
+            config,
+            no_restart,
+            no_prefix,
+            timestamps,
+            abort_on_failure,
+        } => commands::up::run(
+            &services,
+            config.as_deref(),
+            commands::up::UpOptions {
+                no_restart,
+                no_prefix,
+                timestamps,
+                abort_on_failure,
+            },
+        ),
     };
 
     match result {

--- a/crates/servicrab-cli/src/style.rs
+++ b/crates/servicrab-cli/src/style.rs
@@ -1,0 +1,89 @@
+//! Terminal styling helpers.
+//!
+//! Servicrab deliberately avoids a colour crate: the handful of ANSI escapes it
+//! needs are easier to audit than another dependency.  Colour is disabled when
+//! the stream is not a terminal, when `NO_COLOR` is set, or when
+//! `TERM=dumb` — the usual conventions.
+
+use std::io::IsTerminal;
+
+/// Reset all attributes.
+pub const RESET: &str = "\x1b[0m";
+/// Dim / faint text.
+pub const DIM: &str = "\x1b[2m";
+/// Bold text.
+pub const BOLD: &str = "\x1b[1m";
+
+/// The colours cycled through when prefixing service output.
+pub const SERVICE_COLORS: [&str; 6] = [
+    "\x1b[36m", // cyan
+    "\x1b[32m", // green
+    "\x1b[33m", // yellow
+    "\x1b[35m", // magenta
+    "\x1b[34m", // blue
+    "\x1b[31m", // red
+];
+
+/// Whether coloured output should be produced for stdout.
+pub fn color_enabled() -> bool {
+    if std::env::var_os("NO_COLOR").is_some() {
+        return false;
+    }
+    if matches!(std::env::var("TERM").as_deref(), Ok("dumb")) {
+        return false;
+    }
+    std::io::stdout().is_terminal()
+}
+
+/// Wrap `text` in `code` when `enabled`, otherwise return it unchanged.
+pub fn paint(enabled: bool, code: &str, text: &str) -> String {
+    if enabled {
+        format!("{code}{text}{RESET}")
+    } else {
+        text.to_string()
+    }
+}
+
+/// Format the current wall-clock time as `HH:MM:SS` in UTC.
+///
+/// Servicrab has no date/time dependency, and a plain UTC clock is enough for
+/// interleaving log lines.
+pub fn utc_hms(now: std::time::SystemTime) -> String {
+    let secs = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let day = secs % 86_400;
+    format!("{:02}:{:02}:{:02}", day / 3600, (day % 3600) / 60, day % 60)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    #[test]
+    fn paint_is_a_no_op_when_disabled() {
+        assert_eq!(paint(false, BOLD, "api"), "api");
+    }
+
+    #[test]
+    fn paint_wraps_text_when_enabled() {
+        assert_eq!(paint(true, BOLD, "api"), format!("{BOLD}api{RESET}"));
+    }
+
+    #[test]
+    fn utc_hms_formats_seconds_since_midnight() {
+        assert_eq!(utc_hms(UNIX_EPOCH), "00:00:00");
+        assert_eq!(utc_hms(UNIX_EPOCH + Duration::from_secs(3661)), "01:01:01");
+        assert_eq!(
+            utc_hms(UNIX_EPOCH + Duration::from_secs(86_399)),
+            "23:59:59"
+        );
+        // Wraps around into the next day.
+        assert_eq!(
+            utc_hms(UNIX_EPOCH + Duration::from_secs(86_400)),
+            "00:00:00"
+        );
+    }
+}

--- a/crates/servicrab-cli/tests/up.rs
+++ b/crates/servicrab-cli/tests/up.rs
@@ -1,0 +1,687 @@
+//! Integration tests for `servicrab up`.
+//!
+//! Every fixture is generated into a [`TempDir`] at test time, so nothing
+//! depends on repository-specific paths.  All waits are bounded and each test
+//! asserts that no supervised process is left behind.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
+use tempfile::TempDir;
+
+/// Upper bound for any wait in this file; keeps a hung test from stalling CI.
+const CEILING: Duration = Duration::from_secs(10);
+
+fn script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+fn config(dir: &Path, toml: &str) -> PathBuf {
+    let path = dir.join("servicrab.toml");
+    fs::write(&path, toml).unwrap();
+    path
+}
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+/// Run `servicrab up` to completion and return `(exit code, stdout, stderr)`.
+fn up(config_path: &Path, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(binary())
+        .arg("up")
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab up");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Spawn `servicrab up` in the background with stdout captured.
+fn spawn_up(config_path: &Path, args: &[&str]) -> Child {
+    Command::new(binary())
+        .arg("up")
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn servicrab up")
+}
+
+fn wait_for_file(path: &Path) {
+    let deadline = Instant::now() + CEILING;
+    while Instant::now() < deadline {
+        if path.exists() && fs::metadata(path).map(|m| m.len() > 0).unwrap_or(false) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
+fn wait_bounded(child: &mut Child) -> i32 {
+    let deadline = Instant::now() + CEILING;
+    loop {
+        match child.try_wait().unwrap() {
+            Some(status) => return status.code().unwrap_or(-1),
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("supervisor did not exit within {CEILING:?}");
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    }
+}
+
+fn is_alive(pid: i32) -> bool {
+    kill(Pid::from_raw(pid), None).is_ok()
+}
+
+fn read_pid(path: &Path) -> i32 {
+    fs::read_to_string(path)
+        .expect("pid file")
+        .trim()
+        .parse()
+        .expect("numeric pid")
+}
+
+// ── planning ───────────────────────────────────────────────────────────────
+
+#[test]
+fn only_autostart_services_run_by_default() {
+    let dir = TempDir::new().unwrap();
+    script(dir.path(), "hello.sh", "echo hello-from-$1");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.auto]
+command = ["{0}", "auto"]
+
+[services.manual]
+command = ["{0}", "manual"]
+autostart = false
+"#,
+            dir.path().join("hello.sh").display()
+        ),
+    );
+
+    let (code, stdout, _stderr) = up(&cfg, &[]);
+    assert_eq!(code, 0, "stdout: {stdout}");
+    assert!(stdout.contains("hello-from-auto"), "stdout: {stdout}");
+    assert!(!stdout.contains("hello-from-manual"), "stdout: {stdout}");
+}
+
+#[test]
+fn named_services_pull_in_their_dependencies() {
+    let dir = TempDir::new().unwrap();
+    script(dir.path(), "hello.sh", "echo hello-from-$1");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.db]
+command = ["{0}", "db"]
+autostart = false
+
+[services.api]
+command = ["{0}", "api"]
+autostart = false
+depends_on = ["db"]
+"#,
+            dir.path().join("hello.sh").display()
+        ),
+    );
+
+    let (code, stdout, _stderr) = up(&cfg, &["api"]);
+    assert_eq!(code, 0, "stdout: {stdout}");
+    assert!(stdout.contains("hello-from-db"), "stdout: {stdout}");
+    assert!(stdout.contains("hello-from-api"), "stdout: {stdout}");
+}
+
+#[test]
+fn unknown_service_is_reported_clearly() {
+    let dir = TempDir::new().unwrap();
+    let cfg = config(
+        dir.path(),
+        r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["true"]
+"#,
+    );
+
+    let (code, _stdout, stderr) = up(&cfg, &["nope"]);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("unknown service"), "stderr: {stderr}");
+    assert!(stderr.contains("api"), "stderr: {stderr}");
+}
+
+#[test]
+fn a_stack_without_autostart_services_is_an_error() {
+    let dir = TempDir::new().unwrap();
+    let cfg = config(
+        dir.path(),
+        r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["true"]
+autostart = false
+"#,
+    );
+
+    let (code, _stdout, stderr) = up(&cfg, &[]);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("no services to start"), "stderr: {stderr}");
+}
+
+// ── output ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn output_is_prefixed_with_the_service_name() {
+    let dir = TempDir::new().unwrap();
+    script(dir.path(), "hello.sh", "echo line-from-$1");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{0}", "api"]
+"#,
+            dir.path().join("hello.sh").display()
+        ),
+    );
+
+    let (code, stdout, _stderr) = up(&cfg, &[]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.lines().any(|l| l.starts_with("api | ")),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn prefixes_can_be_disabled() {
+    let dir = TempDir::new().unwrap();
+    script(dir.path(), "hello.sh", "echo bare-line");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{0}"]
+"#,
+            dir.path().join("hello.sh").display()
+        ),
+    );
+
+    let (code, stdout, _stderr) = up(&cfg, &["--no-prefix"]);
+    assert_eq!(code, 0);
+    assert!(stdout.lines().any(|l| l == "bare-line"), "stdout: {stdout}");
+}
+
+#[test]
+fn stderr_of_a_service_is_forwarded_to_stderr() {
+    let dir = TempDir::new().unwrap();
+    script(dir.path(), "noisy.sh", "echo to-stdout; echo to-stderr >&2");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{0}"]
+"#,
+            dir.path().join("noisy.sh").display()
+        ),
+    );
+
+    let (code, stdout, stderr) = up(&cfg, &[]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("to-stdout"), "stdout: {stdout}");
+    assert!(stderr.contains("to-stderr"), "stderr: {stderr}");
+    assert!(!stdout.contains("to-stderr"), "stdout: {stdout}");
+}
+
+#[test]
+fn timestamps_can_be_enabled() {
+    let dir = TempDir::new().unwrap();
+    script(dir.path(), "hello.sh", "echo stamped");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{0}"]
+"#,
+            dir.path().join("hello.sh").display()
+        ),
+    );
+
+    let (code, stdout, _stderr) = up(&cfg, &["--timestamps"]);
+    assert_eq!(code, 0);
+    let line = stdout
+        .lines()
+        .find(|l| l.contains("stamped"))
+        .unwrap_or_else(|| panic!("no output line: {stdout}"));
+    let stamp = &line[..8];
+    assert!(
+        stamp.len() == 8 && stamp.chars().filter(|c| *c == ':').count() == 2,
+        "expected a HH:MM:SS prefix, got {line:?}"
+    );
+}
+
+// ── ordering, dependencies, shutdown ───────────────────────────────────────
+
+#[test]
+fn a_dependent_starts_only_after_its_dependency_is_up() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("order.txt");
+    let marker = dir.path().join("db.up");
+    // The dependency records that it is up and then stays alive.
+    script(
+        dir.path(),
+        "db.sh",
+        &format!(
+            "echo db >> {}\necho up > {}\nsleep 1",
+            log.display(),
+            marker.display()
+        ),
+    );
+    // The dependent waits out any shell start-up jitter and then checks
+    // whether the dependency really was up before it got started.
+    script(
+        dir.path(),
+        "api.sh",
+        &format!(
+            "sleep 0.3\nif [ -f {} ]; then echo api-after-db >> {}; else echo api-before-db >> {}; fi",
+            marker.display(),
+            log.display(),
+            log.display()
+        ),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{}"]
+depends_on = ["db"]
+
+[services.db]
+command = ["{}"]
+"#,
+            dir.path().join("api.sh").display(),
+            dir.path().join("db.sh").display()
+        ),
+    );
+
+    let (code, _stdout, _stderr) = up(&cfg, &[]);
+    assert_eq!(code, 0);
+    let order = fs::read_to_string(&log).expect("order log");
+    let lines: Vec<&str> = order.lines().collect();
+    assert_eq!(lines, vec!["db", "api-after-db"], "order: {order}");
+}
+
+#[test]
+fn a_dependent_is_skipped_when_its_dependency_fails_to_start() {
+    let dir = TempDir::new().unwrap();
+    script(dir.path(), "hello.sh", "echo api-started");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.db]
+command = ["{}/definitely-not-here"]
+
+[services.api]
+command = ["{}"]
+depends_on = ["db"]
+"#,
+            dir.path().display(),
+            dir.path().join("hello.sh").display()
+        ),
+    );
+
+    let (code, stdout, stderr) = up(&cfg, &[]);
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(!stdout.contains("api-started"), "stdout: {stdout}");
+    assert!(
+        stderr.contains("never became available"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn ctrl_c_stops_the_whole_stack() {
+    let dir = TempDir::new().unwrap();
+    let ready_a = dir.path().join("a.pid");
+    let ready_b = dir.path().join("b.pid");
+    script(
+        dir.path(),
+        "sleeper.sh",
+        "echo $$ > $1\ntrap 'exit 0' TERM\nwhile true; do sleep 0.1; done",
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.alpha]
+command = ["{0}", "{1}"]
+shutdown_timeout = "2s"
+
+[services.beta]
+command = ["{0}", "{2}"]
+depends_on = ["alpha"]
+shutdown_timeout = "2s"
+"#,
+            dir.path().join("sleeper.sh").display(),
+            ready_a.display(),
+            ready_b.display()
+        ),
+    );
+
+    let mut child = spawn_up(&cfg, &[]);
+    wait_for_file(&ready_a);
+    wait_for_file(&ready_b);
+    let pid_a = read_pid(&ready_a);
+    let pid_b = read_pid(&ready_b);
+
+    kill(Pid::from_raw(child.id() as i32), Signal::SIGINT).expect("send SIGINT");
+    let code = wait_bounded(&mut child);
+    assert_eq!(code, 130, "expected 128+SIGINT");
+
+    std::thread::sleep(Duration::from_millis(200));
+    assert!(!is_alive(pid_a), "alpha survived the shutdown");
+    assert!(!is_alive(pid_b), "beta survived the shutdown");
+}
+
+#[test]
+fn shutdown_runs_in_reverse_dependency_order() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("stops.txt");
+    let ready = dir.path().join("ready");
+    script(
+        dir.path(),
+        "sleeper.sh",
+        &format!(
+            "trap 'echo $1 >> {}; exit 0' TERM\necho up > {}.$1\nwhile true; do sleep 0.1; done",
+            log.display(),
+            ready.display()
+        ),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.db]
+command = ["{0}", "db"]
+shutdown_timeout = "2s"
+
+[services.api]
+command = ["{0}", "api"]
+depends_on = ["db"]
+shutdown_timeout = "2s"
+"#,
+            dir.path().join("sleeper.sh").display()
+        ),
+    );
+
+    let mut child = spawn_up(&cfg, &[]);
+    wait_for_file(&PathBuf::from(format!("{}.db", ready.display())));
+    wait_for_file(&PathBuf::from(format!("{}.api", ready.display())));
+
+    kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM).expect("send SIGTERM");
+    let code = wait_bounded(&mut child);
+    assert_eq!(code, 143, "expected 128+SIGTERM");
+
+    let stops = fs::read_to_string(&log).expect("stop log");
+    let order: Vec<&str> = stops.lines().collect();
+    assert_eq!(order, vec!["api", "db"], "stop order: {stops}");
+}
+
+// ── restart policies and failures ──────────────────────────────────────────
+
+#[test]
+fn no_restart_disables_restarting_for_every_service() {
+    let dir = TempDir::new().unwrap();
+    let counter = dir.path().join("runs.txt");
+    script(
+        dir.path(),
+        "flaky.sh",
+        &format!("echo run >> {}\nexit 1", counter.display()),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.flaky]
+command = ["{0}"]
+restart = "on-failure"
+restart_delay = "100ms"
+max_restarts = 3
+"#,
+            dir.path().join("flaky.sh").display()
+        ),
+    );
+
+    let (code, _stdout, _stderr) = up(&cfg, &["--no-restart"]);
+    assert_eq!(code, 0, "a clean stop without restarts is not a failure");
+    let runs = fs::read_to_string(&counter).unwrap().lines().count();
+    assert_eq!(runs, 1, "the service should have run exactly once");
+}
+
+#[test]
+fn a_service_that_exhausts_its_restart_budget_fails_the_stack() {
+    let dir = TempDir::new().unwrap();
+    let counter = dir.path().join("runs.txt");
+    script(
+        dir.path(),
+        "flaky.sh",
+        &format!("echo run >> {}\nexit 1", counter.display()),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.flaky]
+command = ["{0}"]
+restart = "on-failure"
+restart_delay = "100ms"
+restart_max_delay = "200ms"
+max_restarts = 2
+"#,
+            dir.path().join("flaky.sh").display()
+        ),
+    );
+
+    let (code, _stdout, stderr) = up(&cfg, &[]);
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(stderr.contains("giving up"), "stderr: {stderr}");
+    let runs = fs::read_to_string(&counter).unwrap().lines().count();
+    assert_eq!(runs, 3, "one initial run plus two restarts");
+}
+
+#[test]
+fn abort_on_failure_tears_down_the_rest_of_the_stack() {
+    let dir = TempDir::new().unwrap();
+    let ready = dir.path().join("long.pid");
+    script(
+        dir.path(),
+        "sleeper.sh",
+        "echo $$ > $1\ntrap 'exit 0' TERM\nwhile true; do sleep 0.1; done",
+    );
+    script(dir.path(), "boom.sh", "exit 7");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.long]
+command = ["{0}", "{1}"]
+shutdown_timeout = "2s"
+
+[services.boom]
+command = ["{2}"]
+restart = "on-failure"
+restart_delay = "500ms"
+max_restarts = 2
+"#,
+            dir.path().join("sleeper.sh").display(),
+            ready.display(),
+            dir.path().join("boom.sh").display()
+        ),
+    );
+
+    let mut child = spawn_up(&cfg, &["--abort-on-failure"]);
+    wait_for_file(&ready);
+    let pid = read_pid(&ready);
+
+    let code = wait_bounded(&mut child);
+    assert_eq!(code, 1);
+
+    std::thread::sleep(Duration::from_millis(200));
+    assert!(!is_alive(pid), "the long-running service was not torn down");
+}
+
+#[test]
+fn descendants_do_not_survive_a_stack_shutdown() {
+    let dir = TempDir::new().unwrap();
+    let parent_pid = dir.path().join("parent.pid");
+    let child_pid = dir.path().join("child.pid");
+    script(
+        dir.path(),
+        "tree.sh",
+        &format!(
+            "sh -c 'echo $$ > {}; trap \"\" TERM; while true; do sleep 0.1; done' &\n\
+             echo $$ > {}\n\
+             trap 'exit 0' TERM\n\
+             while true; do sleep 0.1; done",
+            child_pid.display(),
+            parent_pid.display()
+        ),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.tree]
+command = ["{0}"]
+shutdown_timeout = "1s"
+"#,
+            dir.path().join("tree.sh").display()
+        ),
+    );
+
+    let mut child = spawn_up(&cfg, &[]);
+    wait_for_file(&parent_pid);
+    wait_for_file(&child_pid);
+    let descendant = read_pid(&child_pid);
+
+    kill(Pid::from_raw(child.id() as i32), Signal::SIGINT).expect("send SIGINT");
+    wait_bounded(&mut child);
+
+    std::thread::sleep(Duration::from_millis(300));
+    assert!(
+        !is_alive(descendant),
+        "a descendant outlived the stack shutdown"
+    );
+}

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -40,4 +40,8 @@ pub use lifecycle::{
     ShutdownReason, StateMachine,
 };
 pub use load::{discover_config, load, resolve_config_path};
-pub use runtime::{ForegroundRunner, RunOptions, RunOutcome};
+pub use runtime::{
+    event_channel, plan_stack, EventKind, EventReceiver, EventSender, EventSink, ForegroundRunner,
+    OutputMode, RunOptions, RunOutcome, ServiceEvent, ServiceRunner, SignalWatcher, StackOptions,
+    StackOutcome, StackSupervisor, Stream,
+};

--- a/crates/servicrab-core/src/lifecycle.rs
+++ b/crates/servicrab-core/src/lifecycle.rs
@@ -192,6 +192,9 @@ pub enum ShutdownReason {
     Terminated,
     /// The restart limit was exhausted.
     RestartLimit,
+    /// Another service in the stack failed and the whole stack is being torn
+    /// down (`up --abort-on-failure`).
+    StackFailure,
 }
 
 impl ShutdownReason {
@@ -211,6 +214,7 @@ impl std::fmt::Display for ShutdownReason {
             ShutdownReason::UserInterrupt => write!(f, "interrupted by user"),
             ShutdownReason::Terminated => write!(f, "supervisor terminated"),
             ShutdownReason::RestartLimit => write!(f, "restart limit exhausted"),
+            ShutdownReason::StackFailure => write!(f, "another service failed"),
         }
     }
 }

--- a/crates/servicrab-core/src/runtime/event.rs
+++ b/crates/servicrab-core/src/runtime/event.rs
@@ -1,0 +1,188 @@
+//! Events emitted by the runtime while supervising services.
+//!
+//! The runtime never formats output itself: it publishes structured events and
+//! lets the CLI decide how to render them.  This keeps process handling and
+//! user-facing presentation cleanly separated, and gives the future daemon a
+//! ready-made stream to forward over its socket.
+
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use crate::config::ServiceName;
+use crate::lifecycle::{ExitReason, ServiceState, ShutdownReason};
+
+/// Which standard stream a captured log line came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stream {
+    /// The child's standard output.
+    Stdout,
+    /// The child's standard error.
+    Stderr,
+}
+
+impl std::fmt::Display for Stream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Stream::Stdout => f.write_str("stdout"),
+            Stream::Stderr => f.write_str("stderr"),
+        }
+    }
+}
+
+/// What happened to a supervised service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventKind {
+    /// The service moved to a new lifecycle state.
+    State(ServiceState),
+    /// The service's process was spawned.
+    Started {
+        /// Process-group id (equal to the direct child's pid).
+        pgid: i32,
+    },
+    /// A line was read from the service's captured output.
+    Log {
+        /// Which stream the line came from.
+        stream: Stream,
+        /// The line, without its trailing newline.
+        line: String,
+    },
+    /// The service's process stopped.
+    Exited {
+        /// Why the process stopped.
+        reason: ExitReason,
+        /// How long it stayed alive.
+        uptime: Duration,
+    },
+    /// The service is waiting before being restarted.
+    Backoff {
+        /// How long the supervisor will wait.
+        delay: Duration,
+        /// 1-based restart attempt number.
+        attempt: u32,
+    },
+    /// The service will not be started because a dependency never became
+    /// available.
+    Skipped {
+        /// The dependency that blocked the start.
+        dependency: ServiceName,
+    },
+    /// The supervisor is shutting the service down.
+    Stopping {
+        /// Why the shutdown was requested.
+        reason: ShutdownReason,
+    },
+    /// The service stopped for good, and no restart will happen.
+    Finished {
+        /// A human-readable description of the final outcome.
+        summary: String,
+    },
+    /// The service failed fatally.
+    Failed {
+        /// A human-readable description of the failure.
+        message: String,
+    },
+}
+
+/// A single runtime event, tagged with the service it belongs to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceEvent {
+    /// The service the event refers to.
+    pub service: ServiceName,
+    /// What happened.
+    pub kind: EventKind,
+}
+
+impl ServiceEvent {
+    /// Build an event.
+    pub fn new(service: ServiceName, kind: EventKind) -> Self {
+        Self { service, kind }
+    }
+}
+
+/// Sending half of the runtime event stream.
+pub type EventSender = mpsc::UnboundedSender<ServiceEvent>;
+/// Receiving half of the runtime event stream.
+pub type EventReceiver = mpsc::UnboundedReceiver<ServiceEvent>;
+
+/// Create a new event channel.
+pub fn event_channel() -> (EventSender, EventReceiver) {
+    mpsc::unbounded_channel()
+}
+
+/// An optional event sink.
+///
+/// `run` uses no sink (the child inherits the terminal), while `up` collects
+/// every event so it can interleave and prefix the output of many services.
+#[derive(Debug, Clone, Default)]
+pub struct EventSink {
+    sender: Option<EventSender>,
+}
+
+impl EventSink {
+    /// A sink that drops everything.
+    pub fn none() -> Self {
+        Self { sender: None }
+    }
+
+    /// A sink that forwards to `sender`.
+    pub fn new(sender: EventSender) -> Self {
+        Self {
+            sender: Some(sender),
+        }
+    }
+
+    /// Whether anything is listening.
+    pub fn is_active(&self) -> bool {
+        self.sender.is_some()
+    }
+
+    /// Publish an event, ignoring a closed receiver.
+    pub fn emit(&self, service: &ServiceName, kind: EventKind) {
+        if let Some(sender) = &self.sender {
+            let _ = sender.send(ServiceEvent::new(service.clone(), kind));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn name(raw: &str) -> ServiceName {
+        crate::validation::validate_service_name(raw).expect("valid test name")
+    }
+
+    #[test]
+    fn inactive_sink_drops_events() {
+        let sink = EventSink::none();
+        assert!(!sink.is_active());
+        sink.emit(&name("api"), EventKind::State(ServiceState::Running));
+    }
+
+    #[test]
+    fn active_sink_forwards_events() {
+        let (tx, mut rx) = event_channel();
+        let sink = EventSink::new(tx);
+        assert!(sink.is_active());
+        sink.emit(&name("api"), EventKind::State(ServiceState::Running));
+
+        let event = rx.try_recv().expect("event delivered");
+        assert_eq!(event.service.as_str(), "api");
+        assert_eq!(event.kind, EventKind::State(ServiceState::Running));
+    }
+
+    #[test]
+    fn emitting_into_a_closed_channel_is_not_an_error() {
+        let (tx, rx) = event_channel();
+        drop(rx);
+        let sink = EventSink::new(tx);
+        sink.emit(&name("api"), EventKind::State(ServiceState::Failed));
+    }
+
+    #[test]
+    fn streams_display_as_lowercase_names() {
+        assert_eq!(Stream::Stdout.to_string(), "stdout");
+        assert_eq!(Stream::Stderr.to_string(), "stderr");
+    }
+}

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -1,39 +1,101 @@
-//! Process runtime: spawning, signalling, and supervising a single service in
-//! the foreground.
+//! Process runtime: spawning, signalling, and supervising services.
 //!
 //! The pure restart logic lives in [`crate::lifecycle`]; this module only deals
-//! with the operating-system side of running a process.  User-facing formatting
+//! with the operating-system side of running processes.  User-facing formatting
 //! and exit-code mapping belong to the CLI, not here.
+//!
+//! * `ServiceRunner` supervises one service.
+//! * `ForegroundRunner` wraps it with signal handling for `run`.
+//! * `stack::StackSupervisor` runs many services concurrently for `up`.
 //!
 //! Only Linux and macOS are supported.  On other platforms every entry point
 //! returns [`crate::error::RuntimeError::UnsupportedPlatform`].
 //!
 //! ## Future phases (TODOs)
 //!
-//! - TODO(phase-2): Generalise [`ForegroundRunner`] into a multi-service
-//!   supervisor driven by the dependency start order.
-//! - TODO(phase-2): Capture stdout/stderr instead of inheriting them, so the
-//!   daemon can persist logs.
+//! - TODO(phase-3): Replace "dependency is running" with "dependency is
+//!   healthy" once health probes exist.
+//! - TODO(phase-2): Persist captured output to log files for the daemon.
+
+use tokio::sync::watch;
 
 use crate::config::RestartPolicy;
 use crate::lifecycle::{ExitReason, ShutdownReason};
 
+pub mod event;
+pub mod plan;
+
+#[cfg(unix)]
+pub mod stack;
+#[cfg(not(unix))]
+#[path = "stack_stub.rs"]
+pub mod stack;
+
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-pub use unix::{ForegroundRunner, ProcessHandle};
+pub use unix::{ForegroundRunner, ProcessHandle, ServiceRunner, SignalWatcher};
 
 #[cfg(not(unix))]
 mod stub;
 #[cfg(not(unix))]
-pub use stub::ForegroundRunner;
+pub use stub::{ForegroundRunner, ServiceRunner, SignalWatcher};
 
-/// Options controlling a single foreground run.
+pub use event::{
+    event_channel, EventKind, EventReceiver, EventSender, EventSink, ServiceEvent, Stream,
+};
+pub use plan::{known_services, lookup_service, plan_stack};
+pub use stack::{ServiceReport, ServiceResult, StackOptions, StackOutcome, StackSupervisor};
+
+/// Sending half of a shutdown channel.
+///
+/// Sending `Some(reason)` asks every subscribed runner to stop.  Sending again
+/// while a shutdown is already in progress means "do not wait any longer" and
+/// escalates to `SIGKILL`.
+pub type ShutdownTx = watch::Sender<Option<ShutdownReason>>;
+/// Receiving half of a shutdown channel.
+pub type ShutdownRx = watch::Receiver<Option<ShutdownReason>>;
+
+/// Create a shutdown channel that starts out with no shutdown requested.
+pub fn shutdown_channel() -> (ShutdownTx, ShutdownRx) {
+    watch::channel(None)
+}
+
+/// Resolve once a shutdown has been requested.
+///
+/// If the sender is dropped without a shutdown ever being requested, this
+/// future simply never resolves — there is nobody left who could ask for one.
+pub async fn wait_for_shutdown(rx: &mut ShutdownRx) -> ShutdownReason {
+    loop {
+        let current = *rx.borrow_and_update();
+        if let Some(reason) = current {
+            return reason;
+        }
+        if rx.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+/// What to do with a service's standard output and error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputMode {
+    /// Hand the terminal straight to the child (used by `run`).
+    #[default]
+    Inherit,
+    /// Read the child's output line by line and publish it as events (used by
+    /// `up`, which has to interleave the output of several services).
+    Capture,
+}
+
+/// Options controlling a single service run.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct RunOptions {
     /// Disable automatic restarts regardless of the configured policy
     /// (`--no-restart`).
     pub no_restart: bool,
+    /// How to handle the child's output.
+    pub output: OutputMode,
 }
 
 impl RunOptions {
@@ -45,9 +107,15 @@ impl RunOptions {
             configured
         }
     }
+
+    /// Return a copy with the given output mode.
+    pub fn with_output(mut self, output: OutputMode) -> Self {
+        self.output = output;
+        self
+    }
 }
 
-/// How a foreground run finished.
+/// How a single service run finished.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunOutcome {
     /// The supervised process stopped and the restart policy did not call for
@@ -71,7 +139,10 @@ mod tests {
 
     #[test]
     fn no_restart_overrides_configured_policy() {
-        let opts = RunOptions { no_restart: true };
+        let opts = RunOptions {
+            no_restart: true,
+            ..RunOptions::default()
+        };
         assert_eq!(
             opts.effective_policy(RestartPolicy::Always),
             RestartPolicy::Never
@@ -93,5 +164,33 @@ mod tests {
             opts.effective_policy(RestartPolicy::Never),
             RestartPolicy::Never
         );
+        assert_eq!(opts.output, OutputMode::Inherit);
+    }
+
+    #[test]
+    fn output_mode_can_be_overridden() {
+        let opts = RunOptions::default().with_output(OutputMode::Capture);
+        assert_eq!(opts.output, OutputMode::Capture);
+    }
+
+    #[tokio::test]
+    async fn wait_for_shutdown_resolves_on_request() {
+        let (tx, mut rx) = shutdown_channel();
+        tx.send(Some(ShutdownReason::UserInterrupt))
+            .expect("receiver alive");
+        assert_eq!(
+            wait_for_shutdown(&mut rx).await,
+            ShutdownReason::UserInterrupt
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_shutdown_waits_for_a_later_request() {
+        let (tx, mut rx) = shutdown_channel();
+        let waiter = tokio::spawn(async move { wait_for_shutdown(&mut rx).await });
+        tokio::task::yield_now().await;
+        tx.send(Some(ShutdownReason::Terminated))
+            .expect("receiver alive");
+        assert_eq!(waiter.await.expect("task"), ShutdownReason::Terminated);
     }
 }

--- a/crates/servicrab-core/src/runtime/plan.rs
+++ b/crates/servicrab-core/src/runtime/plan.rs
@@ -1,0 +1,168 @@
+//! Deciding *which* services a stack command should start.
+//!
+//! This is pure graph work: it takes the validated configuration and the
+//! service names the user asked for, and produces a deterministic start order
+//! that always contains every transitive dependency.
+
+use std::collections::BTreeSet;
+
+use crate::config::{Config, ServiceName};
+use crate::error::RuntimeError;
+
+/// Resolve a single service name against the configuration.
+pub fn lookup_service<'a>(
+    config: &'a Config,
+    requested: &str,
+) -> Result<&'a crate::config::Service, RuntimeError> {
+    config
+        .services
+        .iter()
+        .find(|(name, _)| name.as_str() == requested)
+        .map(|(_, service)| service)
+        .ok_or_else(|| RuntimeError::UnknownService {
+            service: requested.to_string(),
+            known: known_services(config),
+        })
+}
+
+/// Comma-separated list of configured service names, for error messages.
+pub fn known_services(config: &Config) -> String {
+    if config.services.is_empty() {
+        return "(none)".to_string();
+    }
+    config
+        .services
+        .keys()
+        .map(|name| name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Build the start plan for a stack command.
+///
+/// * With no requested names, every service with `autostart = true` is
+///   selected.
+/// * With explicit names, only those services are selected.
+///
+/// In both cases every transitive dependency is pulled in — a service can
+/// never be started without the services it declares in `depends_on`.  The
+/// result is ordered according to the configuration's deterministic
+/// topological start order.
+pub fn plan_stack(config: &Config, requested: &[String]) -> Result<Vec<ServiceName>, RuntimeError> {
+    let mut selected: BTreeSet<ServiceName> = BTreeSet::new();
+
+    if requested.is_empty() {
+        for (name, service) in &config.services {
+            if service.autostart {
+                collect_with_dependencies(config, name, &mut selected);
+            }
+        }
+    } else {
+        for name in requested {
+            let service = lookup_service(config, name)?;
+            collect_with_dependencies(config, &service.name, &mut selected);
+        }
+    }
+
+    Ok(config
+        .start_order
+        .iter()
+        .filter(|name| selected.contains(*name))
+        .cloned()
+        .collect())
+}
+
+fn collect_with_dependencies(
+    config: &Config,
+    name: &ServiceName,
+    selected: &mut BTreeSet<ServiceName>,
+) {
+    if !selected.insert(name.clone()) {
+        return;
+    }
+    // The configuration layer already rejected cycles and unknown
+    // dependencies, so this recursion always terminates.
+    if let Some(service) = config.services.get(name) {
+        for dep in &service.depends_on {
+            collect_with_dependencies(config, dep, selected);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn config_with(body: &str) -> (TempDir, Config) {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("servicrab.toml");
+        let mut file = std::fs::File::create(&path).expect("create config");
+        file.write_all(body.as_bytes()).expect("write config");
+        let (config, _warnings) = crate::load::load(&path).expect("valid config");
+        (dir, config)
+    }
+
+    const STACK: &str = r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.db]
+command = ["true"]
+
+[services.cache]
+command = ["true"]
+autostart = false
+
+[services.api]
+command = ["true"]
+depends_on = ["db"]
+
+[services.worker]
+command = ["true"]
+autostart = false
+depends_on = ["cache"]
+"#;
+
+    #[test]
+    fn empty_request_selects_autostart_services_and_their_dependencies() {
+        let (_dir, config) = config_with(STACK);
+        let plan = plan_stack(&config, &[]).expect("plan");
+        let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
+        assert_eq!(names, vec!["db", "api"]);
+    }
+
+    #[test]
+    fn explicit_request_pulls_in_dependencies() {
+        let (_dir, config) = config_with(STACK);
+        let plan = plan_stack(&config, &["worker".to_string()]).expect("plan");
+        let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
+        assert_eq!(names, vec!["cache", "worker"]);
+    }
+
+    #[test]
+    fn plan_follows_the_topological_start_order() {
+        let (_dir, config) = config_with(STACK);
+        let plan = plan_stack(&config, &["api".to_string(), "db".to_string()]).expect("plan");
+        let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
+        assert_eq!(names, vec!["db", "api"]);
+    }
+
+    #[test]
+    fn unknown_service_is_rejected() {
+        let (_dir, config) = config_with(STACK);
+        let err = plan_stack(&config, &["nope".to_string()]).expect_err("unknown service");
+        assert!(matches!(err, RuntimeError::UnknownService { .. }));
+        assert!(err.to_string().contains("api"));
+    }
+
+    #[test]
+    fn duplicate_requests_are_deduplicated() {
+        let (_dir, config) = config_with(STACK);
+        let plan = plan_stack(&config, &["db".to_string(), "db".to_string()]).expect("plan");
+        assert_eq!(plan.len(), 1);
+    }
+}

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -1,0 +1,474 @@
+//! Concurrent supervision of a whole stack of services (`servicrab up`).
+//!
+//! The supervisor starts every planned service in dependency order, keeps them
+//! running according to their individual restart policies, and shuts the stack
+//! down in reverse dependency order so that dependents stop before the services
+//! they rely on.
+//!
+//! A service is considered "available" for its dependents as soon as its
+//! process is running.  Real readiness probes are a later milestone; until then
+//! a dependent may still need to retry its own connection attempts.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+
+use crate::config::{Config, Service, ServiceName};
+use crate::error::RuntimeError;
+use crate::lifecycle::{ServiceState, ShutdownReason};
+use crate::runtime::event::{event_channel, EventKind, EventSender, EventSink, ServiceEvent};
+use crate::runtime::unix::ServiceRunner;
+use crate::runtime::{
+    shutdown_channel, wait_for_shutdown, OutputMode, RunOptions, RunOutcome, ShutdownRx,
+};
+
+/// Extra time granted on top of a service's own shutdown timeout before the
+/// supervisor stops waiting for its task and detaches it.
+const STOP_GRACE: Duration = Duration::from_secs(5);
+
+/// Options for a stack run.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StackOptions {
+    /// Disable automatic restarts for every service (`--no-restart`).
+    pub no_restart: bool,
+    /// Tear the whole stack down as soon as one service fails.
+    pub abort_on_failure: bool,
+}
+
+/// How one service ended during a stack run.
+#[derive(Debug)]
+pub enum ServiceResult {
+    /// The service ran and stopped without a fatal error.
+    Finished(RunOutcome),
+    /// The service failed fatally (spawn failure or restart limit).
+    Failed(RuntimeError),
+    /// The service was never started because a dependency did not come up.
+    Skipped {
+        /// The dependency that never became available.
+        dependency: ServiceName,
+    },
+}
+
+impl ServiceResult {
+    /// Whether this counts as a failure for the exit status.
+    pub fn is_failure(&self) -> bool {
+        matches!(
+            self,
+            ServiceResult::Failed(_) | ServiceResult::Skipped { .. }
+        )
+    }
+}
+
+/// The final report for a single service.
+#[derive(Debug)]
+pub struct ServiceReport {
+    /// Which service this report is about.
+    pub service: ServiceName,
+    /// How it ended.
+    pub result: ServiceResult,
+}
+
+/// The result of supervising a whole stack.
+#[derive(Debug)]
+pub struct StackOutcome {
+    /// One report per planned service, in completion order.
+    pub reports: Vec<ServiceReport>,
+    /// Why the stack was shut down, if it was.
+    pub shutdown: Option<ShutdownReason>,
+}
+
+impl StackOutcome {
+    /// Reports that count as failures.
+    pub fn failures(&self) -> impl Iterator<Item = &ServiceReport> {
+        self.reports.iter().filter(|r| r.result.is_failure())
+    }
+
+    /// Whether every service ended without a fatal error.
+    pub fn is_success(&self) -> bool {
+        self.failures().next().is_none()
+    }
+}
+
+/// Supervises several services concurrently.
+pub struct StackSupervisor<'a> {
+    config: &'a Config,
+    plan: Vec<ServiceName>,
+    options: StackOptions,
+    events: EventSender,
+}
+
+impl<'a> StackSupervisor<'a> {
+    /// Build a supervisor for the given start plan.
+    ///
+    /// The plan must already be topologically ordered and contain every
+    /// transitive dependency; use [`crate::runtime::plan_stack`] to build one.
+    pub fn new(
+        config: &'a Config,
+        plan: Vec<ServiceName>,
+        options: StackOptions,
+        events: EventSender,
+    ) -> Self {
+        Self {
+            config,
+            plan,
+            options,
+            events,
+        }
+    }
+
+    /// The services this supervisor will start, in start order.
+    pub fn plan(&self) -> &[ServiceName] {
+        &self.plan
+    }
+
+    /// Run the stack until every service has stopped or a shutdown is
+    /// requested.
+    pub async fn run(self, shutdown: &mut ShutdownRx) -> StackOutcome {
+        let run_options = RunOptions {
+            no_restart: self.options.no_restart,
+            output: OutputMode::Capture,
+        };
+
+        let (report_tx, mut report_rx) = mpsc::unbounded_channel::<ServiceReport>();
+        let mut states: BTreeMap<ServiceName, watch::Receiver<ServiceState>> = BTreeMap::new();
+        let mut stops: BTreeMap<ServiceName, crate::runtime::ShutdownTx> = BTreeMap::new();
+        let mut handles: BTreeMap<ServiceName, JoinHandle<()>> = BTreeMap::new();
+
+        for name in &self.plan {
+            let Some(service) = self.config.services.get(name) else {
+                continue;
+            };
+            let service = Arc::new(service.clone());
+
+            let (state_tx, state_rx) = watch::channel(ServiceState::Pending);
+            let (stop_tx, stop_rx) = shutdown_channel();
+
+            // Dependencies always appear earlier in the plan, so their state
+            // channels already exist.
+            let deps: Vec<(ServiceName, watch::Receiver<ServiceState>)> = service
+                .depends_on
+                .iter()
+                .filter_map(|dep| states.get(dep).map(|rx| (dep.clone(), rx.clone())))
+                .collect();
+
+            states.insert(name.clone(), state_rx);
+            stops.insert(name.clone(), stop_tx);
+
+            handles.insert(
+                name.clone(),
+                tokio::spawn(supervise_service(
+                    service,
+                    deps,
+                    state_tx,
+                    stop_rx,
+                    self.events.clone(),
+                    run_options,
+                    report_tx.clone(),
+                )),
+            );
+        }
+
+        drop(report_tx);
+
+        let total = handles.len();
+        let mut reports: Vec<ServiceReport> = Vec::with_capacity(total);
+        let mut shutdown_reason: Option<ShutdownReason> = None;
+
+        while reports.len() < total {
+            tokio::select! {
+                reason = wait_for_shutdown(shutdown) => {
+                    shutdown_reason = Some(reason);
+                    break;
+                }
+                report = report_rx.recv() => {
+                    let Some(report) = report else { break };
+                    let failed = report.result.is_failure();
+                    tracing::debug!(service = %report.service, "service finished");
+                    reports.push(report);
+                    if failed && self.options.abort_on_failure {
+                        shutdown_reason = Some(ShutdownReason::StackFailure);
+                        break;
+                    }
+                }
+            }
+        }
+
+        if let Some(reason) = shutdown_reason {
+            self.stop_all(reason, &stops, &mut handles).await;
+        }
+
+        for (name, handle) in handles {
+            if let Err(err) = handle.await {
+                tracing::warn!(service = %name, error = %err, "supervision task did not finish cleanly");
+            }
+        }
+
+        // Every task has finished, so the remaining reports are already
+        // queued.
+        while let Some(report) = report_rx.recv().await {
+            reports.push(report);
+        }
+
+        StackOutcome {
+            reports,
+            shutdown: shutdown_reason,
+        }
+    }
+
+    /// Stop the stack in reverse dependency order, waiting for each service
+    /// before moving on to the ones it depends on.
+    async fn stop_all(
+        &self,
+        reason: ShutdownReason,
+        stops: &BTreeMap<ServiceName, crate::runtime::ShutdownTx>,
+        handles: &mut BTreeMap<ServiceName, JoinHandle<()>>,
+    ) {
+        for name in self.plan.iter().rev() {
+            let Some(stop) = stops.get(name) else {
+                continue;
+            };
+            let _ = stop.send(Some(reason));
+
+            let Some(mut handle) = handles.remove(name) else {
+                continue;
+            };
+            let grace = self
+                .config
+                .services
+                .get(name)
+                .map(|service| service.shutdown_timeout)
+                .unwrap_or_default()
+                + STOP_GRACE;
+
+            if tokio::time::timeout(grace, &mut handle).await.is_err() {
+                tracing::warn!(service = %name, ?grace, "service did not stop in time; detaching");
+                handle.abort();
+            }
+        }
+    }
+}
+
+/// Whether a service may start yet.
+enum DependencyWait {
+    /// Every dependency is available.
+    Ready,
+    /// A dependency will never become available.
+    Blocked(ServiceName),
+    /// A shutdown was requested while waiting.
+    Shutdown(ShutdownReason),
+}
+
+/// Supervise one service: wait for its dependencies, then run it.
+#[allow(clippy::too_many_arguments)]
+async fn supervise_service(
+    service: Arc<Service>,
+    deps: Vec<(ServiceName, watch::Receiver<ServiceState>)>,
+    state: watch::Sender<ServiceState>,
+    mut stop: ShutdownRx,
+    events: EventSender,
+    options: RunOptions,
+    reports: mpsc::UnboundedSender<ServiceReport>,
+) {
+    let name = service.name.clone();
+
+    match wait_for_dependencies(&deps, &mut stop).await {
+        DependencyWait::Ready => {}
+        DependencyWait::Blocked(dependency) => {
+            let _ = events.send(ServiceEvent::new(
+                name.clone(),
+                EventKind::Skipped {
+                    dependency: dependency.clone(),
+                },
+            ));
+            let _ = state.send(ServiceState::Failed);
+            let _ = reports.send(ServiceReport {
+                service: name,
+                result: ServiceResult::Skipped { dependency },
+            });
+            return;
+        }
+        DependencyWait::Shutdown(reason) => {
+            let _ = state.send(ServiceState::Stopped);
+            let _ = reports.send(ServiceReport {
+                service: name,
+                result: ServiceResult::Finished(RunOutcome::Stopped { reason }),
+            });
+            return;
+        }
+    }
+
+    // Relay the runner's events to the stack-wide stream while mirroring state
+    // changes into the watch channel that dependents are waiting on.
+    let (tx, mut rx) = event_channel();
+    let relay = {
+        let global = events.clone();
+        tokio::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                if let EventKind::State(next) = &event.kind {
+                    let _ = state.send(*next);
+                }
+                let _ = global.send(event);
+            }
+        })
+    };
+
+    let result = {
+        let mut runner = ServiceRunner::new(&service, options).with_events(EventSink::new(tx));
+        runner.run(&mut stop).await
+        // `runner` is dropped here, which closes the event channel and ends
+        // the relay task.
+    };
+
+    let _ = relay.await;
+
+    let result = match result {
+        Ok(outcome) => ServiceResult::Finished(outcome),
+        Err(err) => {
+            let _ = events.send(ServiceEvent::new(
+                name.clone(),
+                EventKind::Failed {
+                    message: err.to_string(),
+                },
+            ));
+            ServiceResult::Failed(err)
+        }
+    };
+
+    let _ = reports.send(ServiceReport {
+        service: name,
+        result,
+    });
+}
+
+/// Wait until every dependency is available (or will never be).
+async fn wait_for_dependencies(
+    deps: &[(ServiceName, watch::Receiver<ServiceState>)],
+    stop: &mut ShutdownRx,
+) -> DependencyWait {
+    for (name, receiver) in deps {
+        let mut receiver = receiver.clone();
+        loop {
+            match *receiver.borrow_and_update() {
+                // Running: the process is up.  Exited: a one-shot dependency
+                // (a migration, a build step) already did its job.
+                ServiceState::Running | ServiceState::Exited => break,
+                ServiceState::Failed | ServiceState::Stopped => {
+                    return DependencyWait::Blocked(name.clone())
+                }
+                _ => {}
+            }
+
+            tokio::select! {
+                changed = receiver.changed() => {
+                    if changed.is_err() {
+                        return DependencyWait::Blocked(name.clone());
+                    }
+                }
+                reason = wait_for_shutdown(stop) => return DependencyWait::Shutdown(reason),
+            }
+        }
+    }
+    DependencyWait::Ready
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn name(raw: &str) -> ServiceName {
+        crate::validation::validate_service_name(raw).expect("valid test name")
+    }
+
+    #[test]
+    fn skipped_and_failed_results_count_as_failures() {
+        assert!(ServiceResult::Skipped {
+            dependency: name("db")
+        }
+        .is_failure());
+        assert!(!ServiceResult::Finished(RunOutcome::Exited {
+            reason: crate::lifecycle::ExitReason::Code(0),
+            restarts: 0
+        })
+        .is_failure());
+    }
+
+    #[test]
+    fn outcome_reports_success_only_without_failures() {
+        let ok = StackOutcome {
+            reports: vec![ServiceReport {
+                service: name("api"),
+                result: ServiceResult::Finished(RunOutcome::Stopped {
+                    reason: ShutdownReason::UserInterrupt,
+                }),
+            }],
+            shutdown: Some(ShutdownReason::UserInterrupt),
+        };
+        assert!(ok.is_success());
+
+        let bad = StackOutcome {
+            reports: vec![ServiceReport {
+                service: name("api"),
+                result: ServiceResult::Skipped {
+                    dependency: name("db"),
+                },
+            }],
+            shutdown: None,
+        };
+        assert!(!bad.is_success());
+        assert_eq!(bad.failures().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn dependencies_are_awaited_until_running() {
+        let (tx, rx) = watch::channel(ServiceState::Pending);
+        let (_stop_tx, mut stop_rx) = shutdown_channel();
+        let deps = vec![(name("db"), rx)];
+
+        let waiter = tokio::spawn(async move {
+            let (_stop_tx2, _) = shutdown_channel();
+            matches!(
+                wait_for_dependencies(&deps, &mut stop_rx).await,
+                DependencyWait::Ready
+            )
+        });
+
+        tokio::task::yield_now().await;
+        tx.send(ServiceState::Starting).expect("receiver alive");
+        tx.send(ServiceState::Running).expect("receiver alive");
+
+        assert!(waiter.await.expect("task"));
+    }
+
+    #[tokio::test]
+    async fn a_failed_dependency_blocks_the_dependent() {
+        let (tx, rx) = watch::channel(ServiceState::Pending);
+        let (_stop_tx, mut stop_rx) = shutdown_channel();
+        let deps = vec![(name("db"), rx)];
+
+        tx.send(ServiceState::Failed).expect("receiver alive");
+
+        assert!(matches!(
+            wait_for_dependencies(&deps, &mut stop_rx).await,
+            DependencyWait::Blocked(blocked) if blocked.as_str() == "db"
+        ));
+    }
+
+    #[tokio::test]
+    async fn shutdown_interrupts_the_dependency_wait() {
+        let (_tx, rx) = watch::channel(ServiceState::Pending);
+        let (stop_tx, mut stop_rx) = shutdown_channel();
+        let deps = vec![(name("db"), rx)];
+
+        stop_tx
+            .send(Some(ShutdownReason::UserInterrupt))
+            .expect("receiver alive");
+
+        assert!(matches!(
+            wait_for_dependencies(&deps, &mut stop_rx).await,
+            DependencyWait::Shutdown(ShutdownReason::UserInterrupt)
+        ));
+    }
+}

--- a/crates/servicrab-core/src/runtime/stack_stub.rs
+++ b/crates/servicrab-core/src/runtime/stack_stub.rs
@@ -1,0 +1,122 @@
+//! Stub stack supervisor for platforms other than Linux and macOS.
+//!
+//! It mirrors the public shape of [`crate::runtime::stack`] so that the CLI can
+//! be written without platform conditionals; every service is reported as
+//! failed with [`RuntimeError::UnsupportedPlatform`].
+
+use crate::config::{Config, ServiceName};
+use crate::error::RuntimeError;
+use crate::lifecycle::ShutdownReason;
+use crate::runtime::event::EventSender;
+use crate::runtime::{RunOutcome, ShutdownRx};
+
+/// Options for a stack run.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StackOptions {
+    /// Disable automatic restarts for every service.
+    pub no_restart: bool,
+    /// Tear the whole stack down as soon as one service fails.
+    pub abort_on_failure: bool,
+}
+
+/// How one service ended during a stack run.
+#[derive(Debug)]
+pub enum ServiceResult {
+    /// The service ran and stopped without a fatal error.
+    Finished(RunOutcome),
+    /// The service failed fatally.
+    Failed(RuntimeError),
+    /// The service was never started because a dependency did not come up.
+    Skipped {
+        /// The dependency that never became available.
+        dependency: ServiceName,
+    },
+}
+
+impl ServiceResult {
+    /// Whether this counts as a failure for the exit status.
+    pub fn is_failure(&self) -> bool {
+        matches!(
+            self,
+            ServiceResult::Failed(_) | ServiceResult::Skipped { .. }
+        )
+    }
+}
+
+/// The final report for a single service.
+#[derive(Debug)]
+pub struct ServiceReport {
+    /// Which service this report is about.
+    pub service: ServiceName,
+    /// How it ended.
+    pub result: ServiceResult,
+}
+
+/// The result of supervising a whole stack.
+#[derive(Debug)]
+pub struct StackOutcome {
+    /// One report per planned service.
+    pub reports: Vec<ServiceReport>,
+    /// Why the stack was shut down, if it was.
+    pub shutdown: Option<ShutdownReason>,
+}
+
+impl StackOutcome {
+    /// Reports that count as failures.
+    pub fn failures(&self) -> impl Iterator<Item = &ServiceReport> {
+        self.reports.iter().filter(|r| r.result.is_failure())
+    }
+
+    /// Whether every service ended without a fatal error.
+    pub fn is_success(&self) -> bool {
+        self.failures().next().is_none()
+    }
+}
+
+/// Placeholder stack supervisor.
+pub struct StackSupervisor<'a> {
+    plan: Vec<ServiceName>,
+    _config: &'a Config,
+    _options: StackOptions,
+    _events: EventSender,
+}
+
+impl<'a> StackSupervisor<'a> {
+    /// Build a supervisor for the given start plan.
+    pub fn new(
+        config: &'a Config,
+        plan: Vec<ServiceName>,
+        options: StackOptions,
+        events: EventSender,
+    ) -> Self {
+        Self {
+            plan,
+            _config: config,
+            _options: options,
+            _events: events,
+        }
+    }
+
+    /// The services this supervisor would start.
+    pub fn plan(&self) -> &[ServiceName] {
+        &self.plan
+    }
+
+    /// Always reports every service as unsupported on this platform.
+    pub async fn run(self, _shutdown: &mut ShutdownRx) -> StackOutcome {
+        let reports = self
+            .plan
+            .iter()
+            .map(|service| ServiceReport {
+                service: service.clone(),
+                result: ServiceResult::Failed(RuntimeError::UnsupportedPlatform {
+                    service: service.to_string(),
+                }),
+            })
+            .collect();
+        StackOutcome {
+            reports,
+            shutdown: None,
+        }
+    }
+}

--- a/crates/servicrab-core/src/runtime/stub.rs
+++ b/crates/servicrab-core/src/runtime/stub.rs
@@ -1,19 +1,20 @@
-//! Stub foreground runner for platforms other than Linux and macOS.
+//! Stub runner for platforms other than Linux and macOS.
 //!
 //! Windows support is out of scope for now; the stub exists so that the
 //! workspace still compiles everywhere.
 
 use crate::config::{RestartPolicy, Service};
 use crate::error::RuntimeError;
-use crate::runtime::{RunOptions, RunOutcome};
+use crate::runtime::event::EventSink;
+use crate::runtime::{RunOptions, RunOutcome, ShutdownRx};
 
 /// Placeholder runner that always reports an unsupported platform.
-pub struct ForegroundRunner<'a> {
+pub struct ServiceRunner<'a> {
     service: &'a Service,
     policy: RestartPolicy,
 }
 
-impl<'a> ForegroundRunner<'a> {
+impl<'a> ServiceRunner<'a> {
     /// Build a runner for a validated service.
     pub fn new(service: &'a Service, options: RunOptions) -> Self {
         Self {
@@ -22,15 +23,74 @@ impl<'a> ForegroundRunner<'a> {
         }
     }
 
+    /// Accepted for API parity; the stub never emits events.
+    pub fn with_events(self, _events: EventSink) -> Self {
+        self
+    }
+
     /// The effective restart policy after `--no-restart` is taken into account.
     pub fn policy(&self) -> RestartPolicy {
         self.policy
     }
 
     /// Always fails with [`RuntimeError::UnsupportedPlatform`].
-    pub async fn run(&mut self) -> Result<RunOutcome, RuntimeError> {
+    pub async fn run(&mut self, _shutdown: &mut ShutdownRx) -> Result<RunOutcome, RuntimeError> {
         Err(RuntimeError::UnsupportedPlatform {
             service: self.service.name.to_string(),
         })
+    }
+}
+
+/// Placeholder foreground runner.
+pub struct ForegroundRunner<'a> {
+    runner: ServiceRunner<'a>,
+}
+
+impl<'a> ForegroundRunner<'a> {
+    /// Build a runner for a validated service.
+    pub fn new(service: &'a Service, options: RunOptions) -> Self {
+        Self {
+            runner: ServiceRunner::new(service, options),
+        }
+    }
+
+    /// Accepted for API parity; the stub never emits events.
+    pub fn with_events(self, _events: EventSink) -> Self {
+        self
+    }
+
+    /// The effective restart policy after `--no-restart` is taken into account.
+    pub fn policy(&self) -> RestartPolicy {
+        self.runner.policy()
+    }
+
+    /// Always fails with [`RuntimeError::UnsupportedPlatform`].
+    pub async fn run(&mut self) -> Result<RunOutcome, RuntimeError> {
+        let (_tx, mut rx) = crate::runtime::shutdown_channel();
+        self.runner.run(&mut rx).await
+    }
+}
+
+/// Placeholder signal watcher.
+pub struct SignalWatcher {
+    tx: crate::runtime::ShutdownTx,
+}
+
+impl SignalWatcher {
+    /// Signal handling is unavailable on this platform, but installing the
+    /// watcher still succeeds so that callers can share one code path.
+    pub fn install(_label: &str) -> Result<Self, RuntimeError> {
+        let (tx, _rx) = crate::runtime::shutdown_channel();
+        Ok(Self { tx })
+    }
+
+    /// A fresh receiver for the shutdown channel.
+    pub fn subscribe(&self) -> ShutdownRx {
+        self.tx.subscribe()
+    }
+
+    /// A clone of the shutdown sender.
+    pub fn sender(&self) -> crate::runtime::ShutdownTx {
+        self.tx.clone()
     }
 }

--- a/crates/servicrab-core/src/runtime/unix.rs
+++ b/crates/servicrab-core/src/runtime/unix.rs
@@ -1,4 +1,4 @@
-//! Unix implementation of the foreground process runner.
+//! Unix implementation of the process runner.
 //!
 //! Each supervised service is placed into its own process group so that
 //! shutdown can target the whole tree, not just the direct child:
@@ -12,15 +12,21 @@
 //!
 //! Signalling only the direct child would leave `node` and `esbuild` running,
 //! so every signal is delivered with `killpg(2)`.
+//!
+//! [`ServiceRunner`] supervises exactly one service and is driven entirely by a
+//! shutdown channel, which makes it reusable both for the single-service `run`
+//! command (see [`ForegroundRunner`]) and for the multi-service stack
+//! supervisor in [`crate::runtime::stack`].
 
-use std::os::unix::process::ExitStatusExt;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
 use nix::sys::signal::{killpg, Signal};
 use nix::unistd::Pid;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::signal::unix::{signal, SignalKind};
+use tokio::task::JoinHandle;
 
 use crate::config::{RestartPolicy, Service, ShutdownSignal};
 use crate::error::RuntimeError;
@@ -28,7 +34,13 @@ use crate::lifecycle::{
     ExitReason, ProcessOutcome, RestartDecision, RestartTracker, ServiceState, ShutdownReason,
     StateMachine,
 };
-use crate::runtime::{RunOptions, RunOutcome};
+use crate::runtime::event::{EventKind, EventSink, Stream};
+use crate::runtime::{
+    shutdown_channel, wait_for_shutdown, OutputMode, RunOptions, RunOutcome, ShutdownRx, ShutdownTx,
+};
+
+/// How long to wait for the output readers to drain after the child exited.
+const READER_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Map a validated [`ShutdownSignal`] onto the OS signal.
 fn os_signal(signal: ShutdownSignal) -> Signal {
@@ -64,7 +76,12 @@ impl ProcessHandle {
     ///
     /// The executable and its arguments are passed verbatim — no shell is
     /// involved unless the user configured a shell as the executable.
-    pub fn spawn(service: &Service) -> Result<Self, RuntimeError> {
+    pub fn spawn(service: &Service, output: OutputMode) -> Result<Self, RuntimeError> {
+        let (stdout, stderr) = match output {
+            OutputMode::Inherit => (Stdio::inherit(), Stdio::inherit()),
+            OutputMode::Capture => (Stdio::piped(), Stdio::piped()),
+        };
+
         let mut command = Command::new(&service.executable);
         command
             .args(&service.args)
@@ -72,8 +89,8 @@ impl ProcessHandle {
             .env_clear()
             .envs(&service.env)
             .stdin(Stdio::null())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
+            .stdout(stdout)
+            .stderr(stderr)
             // Put the child into a brand-new process group whose id equals the
             // child's pid.  This is done by the standard library between fork
             // and exec via `setpgid(2)`, so no `unsafe` pre-exec hook of our
@@ -159,6 +176,7 @@ impl ProcessHandle {
 }
 
 fn exit_reason(status: std::process::ExitStatus) -> ExitReason {
+    use std::os::unix::process::ExitStatusExt;
     match (status.code(), status.signal()) {
         (Some(code), _) => ExitReason::Code(code),
         (None, Some(sig)) => ExitReason::Signal(sig),
@@ -172,19 +190,93 @@ fn exit_reason(status: std::process::ExitStatus) -> ExitReason {
 enum Wake {
     /// The child process exited on its own.
     Exited(ExitReason),
-    /// A shutdown signal was received.
+    /// A shutdown was requested.
     Signalled(ShutdownReason),
 }
 
-/// Runs a single configured service in the foreground, applying its restart
-/// policy and handling shutdown signals.
-pub struct ForegroundRunner<'a> {
+/// SIGINT/SIGTERM handling for the current process.
+///
+/// The watcher forwards every signal it sees into a shutdown channel so that
+/// one or many [`ServiceRunner`]s can react to it.  A second signal is
+/// forwarded as well, which the runners interpret as "stop waiting, kill now".
+#[derive(Debug)]
+pub struct SignalWatcher {
+    tx: ShutdownTx,
+    task: JoinHandle<()>,
+}
+
+impl SignalWatcher {
+    /// Install SIGINT and SIGTERM handlers.
+    ///
+    /// `label` only gives signal-registration errors a useful subject: a
+    /// service name for `run`, the project name for `up`.
+    pub fn install(label: &str) -> Result<Self, RuntimeError> {
+        let mut sigint = signal(SignalKind::interrupt()).map_err(|source| {
+            RuntimeError::SignalRegistrationFailed {
+                service: label.to_string(),
+                signal: "SIGINT",
+                source,
+            }
+        })?;
+        let mut sigterm = signal(SignalKind::terminate()).map_err(|source| {
+            RuntimeError::SignalRegistrationFailed {
+                service: label.to_string(),
+                signal: "SIGTERM",
+                source,
+            }
+        })?;
+
+        let (tx, _rx) = shutdown_channel();
+        let sender = tx.clone();
+        let task = tokio::spawn(async move {
+            loop {
+                let reason = tokio::select! {
+                    _ = sigint.recv() => ShutdownReason::UserInterrupt,
+                    _ = sigterm.recv() => ShutdownReason::Terminated,
+                };
+                // `send` fails only when every receiver is gone, in which case
+                // there is nothing left to shut down.
+                if sender.send(Some(reason)).is_err() {
+                    return;
+                }
+            }
+        });
+
+        Ok(Self { tx, task })
+    }
+
+    /// A fresh receiver for the shutdown channel.
+    pub fn subscribe(&self) -> ShutdownRx {
+        self.tx.subscribe()
+    }
+
+    /// A clone of the sender, for code that requests a shutdown itself (for
+    /// example when a service fails and `--abort-on-failure` is in effect).
+    pub fn sender(&self) -> ShutdownTx {
+        self.tx.clone()
+    }
+}
+
+impl Drop for SignalWatcher {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// Supervises a single service process: spawning, restarting, and shutting it
+/// down.
+///
+/// The runner owns no signal handlers of its own; it reacts to a shutdown
+/// channel so that many runners can be driven together.
+pub struct ServiceRunner<'a> {
     service: &'a Service,
     tracker: RestartTracker,
     state: StateMachine,
+    output: OutputMode,
+    events: EventSink,
 }
 
-impl<'a> ForegroundRunner<'a> {
+impl<'a> ServiceRunner<'a> {
     /// Build a runner for a validated service.
     pub fn new(service: &'a Service, options: RunOptions) -> Self {
         let policy = options.effective_policy(service.restart);
@@ -192,12 +284,25 @@ impl<'a> ForegroundRunner<'a> {
             service,
             tracker: RestartTracker::from_service(service).with_policy(policy),
             state: StateMachine::new(),
+            output: options.output,
+            events: EventSink::none(),
         }
     }
 
-    /// The effective restart policy after `--no-restart` is taken into account.
+    /// Publish lifecycle events and captured output to `events`.
+    pub fn with_events(mut self, events: EventSink) -> Self {
+        self.events = events;
+        self
+    }
+
+    /// The effective restart policy after `--no-restart` is taken into
+    /// account.
     pub fn policy(&self) -> RestartPolicy {
         self.tracker.policy()
+    }
+
+    fn emit(&self, kind: EventKind) {
+        self.events.emit(&self.service.name, kind);
     }
 
     fn transition(&mut self, next: ServiceState) -> Result<(), RuntimeError> {
@@ -208,34 +313,73 @@ impl<'a> ForegroundRunner<'a> {
                 source,
             })?;
         tracing::debug!(service = %self.service.name, state = %next, "state transition");
+        self.emit(EventKind::State(next));
         Ok(())
+    }
+
+    /// Attach line readers to the child's piped output, if capturing.
+    fn spawn_readers(&self, handle: &mut ProcessHandle) -> Vec<JoinHandle<()>> {
+        if !matches!(self.output, OutputMode::Capture) {
+            return Vec::new();
+        }
+
+        let mut readers = Vec::new();
+        if let Some(stdout) = handle.child.stdout.take() {
+            readers.push(self.spawn_reader(stdout, Stream::Stdout));
+        }
+        if let Some(stderr) = handle.child.stderr.take() {
+            readers.push(self.spawn_reader(stderr, Stream::Stderr));
+        }
+        readers
+    }
+
+    fn spawn_reader<R>(&self, pipe: R, stream: Stream) -> JoinHandle<()>
+    where
+        R: tokio::io::AsyncRead + Unpin + Send + 'static,
+    {
+        let events = self.events.clone();
+        let name = self.service.name.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(pipe).lines();
+            // Invalid UTF-8 ends the reader rather than the service; the
+            // process keeps running and its exit status is still reported.
+            while let Ok(Some(line)) = lines.next_line().await {
+                events.emit(&name, EventKind::Log { stream, line });
+            }
+        })
+    }
+
+    /// Wait for the output readers to finish, but never block shutdown on a
+    /// descendant that inherited the pipe and refuses to close it.
+    async fn drain_readers(readers: Vec<JoinHandle<()>>) {
+        for reader in readers {
+            if tokio::time::timeout(READER_DRAIN_TIMEOUT, reader)
+                .await
+                .is_err()
+            {
+                // The timeout dropped the JoinHandle, which detaches the task;
+                // it ends as soon as the pipe closes.
+                tracing::debug!("output reader did not finish within the drain timeout");
+            }
+        }
     }
 
     /// Run the service until it stops for good.
     ///
     /// The returned [`RunOutcome`] describes how the run finished; mapping that
     /// to a process exit code is the caller's job.
-    pub async fn run(&mut self) -> Result<RunOutcome, RuntimeError> {
+    pub async fn run(&mut self, shutdown: &mut ShutdownRx) -> Result<RunOutcome, RuntimeError> {
         let name = self.service.name.to_string();
-
-        let mut sigint = signal(SignalKind::interrupt()).map_err(|source| {
-            RuntimeError::SignalRegistrationFailed {
-                service: name.clone(),
-                signal: "SIGINT",
-                source,
-            }
-        })?;
-        let mut sigterm = signal(SignalKind::terminate()).map_err(|source| {
-            RuntimeError::SignalRegistrationFailed {
-                service: name.clone(),
-                signal: "SIGTERM",
-                source,
-            }
-        })?;
-
         let mut restarts = 0u32;
 
         loop {
+            // A shutdown that arrived before (or during) the backoff must not
+            // be overtaken by a new process.
+            if let Some(reason) = *shutdown.borrow_and_update() {
+                self.transition(ServiceState::Stopped)?;
+                return Ok(RunOutcome::Stopped { reason });
+            }
+
             self.transition(ServiceState::Starting)?;
             tracing::info!(
                 service = %name,
@@ -244,7 +388,7 @@ impl<'a> ForegroundRunner<'a> {
                 "starting service"
             );
 
-            let mut handle = match ProcessHandle::spawn(self.service) {
+            let mut handle = match ProcessHandle::spawn(self.service, self.output) {
                 Ok(handle) => handle,
                 Err(err) => {
                     // Feed the spawn failure through the restart policy so that
@@ -261,8 +405,8 @@ impl<'a> ForegroundRunner<'a> {
                         RestartDecision::Restart { delay, attempt } => {
                             tracing::warn!(service = %name, error = %err, "spawn failed");
                             self.transition(ServiceState::Backoff)?;
-                            if let Some(reason) =
-                                wait_backoff(&name, delay, attempt, &mut sigint, &mut sigterm).await
+                            self.emit(EventKind::Backoff { delay, attempt });
+                            if let Some(reason) = self.wait_backoff(delay, attempt, shutdown).await
                             {
                                 self.transition(ServiceState::Stopped)?;
                                 return Ok(RunOutcome::Stopped { reason });
@@ -272,29 +416,35 @@ impl<'a> ForegroundRunner<'a> {
                         }
                         RestartDecision::Stop | RestartDecision::Fail { .. } => {
                             let _ = self.transition(ServiceState::Failed);
+                            self.emit(EventKind::Failed {
+                                message: err.to_string(),
+                            });
                             return Err(err);
                         }
                     }
                 }
             };
 
+            let readers = self.spawn_readers(&mut handle);
+
             self.transition(ServiceState::Running)?;
+            self.emit(EventKind::Started {
+                pgid: handle.pgid(),
+            });
             tracing::info!(service = %name, pid = handle.pgid(), "service running");
 
             // The select! branches cannot borrow `handle` twice, so the wake-up
             // reason is captured first and shutdown is driven afterwards.
             let wake = tokio::select! {
                 result = handle.wait(&name) => Wake::Exited(result?),
-                _ = sigint.recv() => Wake::Signalled(ShutdownReason::UserInterrupt),
-                _ = sigterm.recv() => Wake::Signalled(ShutdownReason::Terminated),
+                reason = wait_for_shutdown(shutdown) => Wake::Signalled(reason),
             };
 
-            let (reason, shutdown) = match wake {
+            let (reason, stopped_by) = match wake {
                 Wake::Exited(reason) => (reason, None),
                 Wake::Signalled(why) => {
-                    let reason = self
-                        .shutdown(&mut handle, why, &mut sigint, &mut sigterm)
-                        .await?;
+                    self.emit(EventKind::Stopping { reason: why });
+                    let reason = self.shutdown(&mut handle, why, shutdown).await?;
                     (reason, Some(why))
                 }
             };
@@ -303,38 +453,52 @@ impl<'a> ForegroundRunner<'a> {
 
             // Sweep the group so no descendant outlives the direct child.
             handle.kill_group(&name, self.service.shutdown_timeout)?;
+            Self::drain_readers(readers).await;
 
-            if let Some(reason) = shutdown {
-                tracing::info!(service = %name, %reason, "service stopped");
+            if let Some(why) = stopped_by {
+                tracing::info!(service = %name, reason = %why, "service stopped");
                 self.transition(ServiceState::Stopped)?;
-                return Ok(RunOutcome::Stopped { reason });
+                self.emit(EventKind::Finished {
+                    summary: format!("stopped ({why}), last status: {reason}"),
+                });
+                return Ok(RunOutcome::Stopped { reason: why });
             }
 
             tracing::info!(service = %name, %reason, ?uptime, "service exited");
+            self.emit(EventKind::Exited { reason, uptime });
 
             let outcome = ProcessOutcome::new(reason, uptime);
             match self.tracker.decide(outcome, None) {
                 RestartDecision::Restart { delay, attempt } => {
                     self.transition(ServiceState::Backoff)?;
-                    if let Some(reason) =
-                        wait_backoff(&name, delay, attempt, &mut sigint, &mut sigterm).await
-                    {
+                    self.emit(EventKind::Backoff { delay, attempt });
+                    if let Some(why) = self.wait_backoff(delay, attempt, shutdown).await {
                         self.transition(ServiceState::Stopped)?;
-                        return Ok(RunOutcome::Stopped { reason });
+                        self.emit(EventKind::Finished {
+                            summary: format!("stopped ({why})"),
+                        });
+                        return Ok(RunOutcome::Stopped { reason: why });
                     }
                     restarts += 1;
                 }
                 RestartDecision::Stop => {
                     self.transition(ServiceState::Exited)?;
+                    self.emit(EventKind::Finished {
+                        summary: reason.to_string(),
+                    });
                     return Ok(RunOutcome::Exited { reason, restarts });
                 }
                 RestartDecision::Fail { reason: why } => {
                     self.transition(ServiceState::Failed)?;
                     tracing::error!(service = %name, %why, restarts, "giving up");
-                    return Err(RuntimeError::RestartLimitExhausted {
+                    let err = RuntimeError::RestartLimitExhausted {
                         service: name,
                         attempts: restarts,
+                    };
+                    self.emit(EventKind::Failed {
+                        message: err.to_string(),
                     });
+                    return Err(err);
                 }
             }
         }
@@ -346,8 +510,7 @@ impl<'a> ForegroundRunner<'a> {
         &mut self,
         handle: &mut ProcessHandle,
         reason: ShutdownReason,
-        sigint: &mut tokio::signal::unix::Signal,
-        sigterm: &mut tokio::signal::unix::Signal,
+        shutdown: &mut ShutdownRx,
     ) -> Result<ExitReason, RuntimeError> {
         let name = self.service.name.to_string();
         self.transition(ServiceState::Stopping)?;
@@ -378,12 +541,10 @@ impl<'a> ForegroundRunner<'a> {
                     }
                 }
             }
-            _ = sigint.recv() => {
-                tracing::warn!(service = %name, "second interrupt; escalating to SIGKILL");
-                true
-            }
-            _ = sigterm.recv() => {
-                tracing::warn!(service = %name, "second termination signal; escalating to SIGKILL");
+            // Any further shutdown request while we are already stopping means
+            // "do not wait any longer".
+            _ = shutdown.changed() => {
+                tracing::warn!(service = %name, "second shutdown request; escalating to SIGKILL");
                 true
             }
         };
@@ -393,22 +554,57 @@ impl<'a> ForegroundRunner<'a> {
         }
         handle.wait(&name).await
     }
+
+    /// Sleep out a restart delay, returning `Some(reason)` if a shutdown was
+    /// requested during the wait.
+    async fn wait_backoff(
+        &self,
+        delay: Duration,
+        attempt: u32,
+        shutdown: &mut ShutdownRx,
+    ) -> Option<ShutdownReason> {
+        tracing::info!(service = %self.service.name, ?delay, attempt, "restarting after backoff");
+        tokio::select! {
+            _ = tokio::time::sleep(delay) => None,
+            reason = wait_for_shutdown(shutdown) => Some(reason),
+        }
+    }
 }
 
-/// Sleep out a restart delay, returning `Some(reason)` if a shutdown signal
-/// interrupted the wait.
-async fn wait_backoff(
-    service: &str,
-    delay: Duration,
-    attempt: u32,
-    sigint: &mut tokio::signal::unix::Signal,
-    sigterm: &mut tokio::signal::unix::Signal,
-) -> Option<ShutdownReason> {
-    tracing::info!(service = %service, ?delay, attempt, "restarting after backoff");
-    tokio::select! {
-        _ = tokio::time::sleep(delay) => None,
-        _ = sigint.recv() => Some(ShutdownReason::UserInterrupt),
-        _ = sigterm.recv() => Some(ShutdownReason::Terminated),
+/// Runs a single configured service in the foreground, installing its own
+/// SIGINT/SIGTERM handlers.
+///
+/// This is the engine behind `servicrab run`.
+pub struct ForegroundRunner<'a> {
+    runner: ServiceRunner<'a>,
+    label: String,
+}
+
+impl<'a> ForegroundRunner<'a> {
+    /// Build a runner for a validated service.
+    pub fn new(service: &'a Service, options: RunOptions) -> Self {
+        Self {
+            label: service.name.to_string(),
+            runner: ServiceRunner::new(service, options),
+        }
+    }
+
+    /// Publish lifecycle events and captured output to `events`.
+    pub fn with_events(mut self, events: EventSink) -> Self {
+        self.runner = self.runner.with_events(events);
+        self
+    }
+
+    /// The effective restart policy after `--no-restart` is taken into account.
+    pub fn policy(&self) -> RestartPolicy {
+        self.runner.policy()
+    }
+
+    /// Run the service until it stops for good.
+    pub async fn run(&mut self) -> Result<RunOutcome, RuntimeError> {
+        let signals = SignalWatcher::install(&self.label)?;
+        let mut shutdown = signals.subscribe();
+        self.runner.run(&mut shutdown).await
     }
 }
 
@@ -436,6 +632,7 @@ mod tests {
 
     #[test]
     fn exit_status_maps_to_exit_reason() {
+        use std::os::unix::process::ExitStatusExt;
         assert_eq!(
             exit_reason(std::process::ExitStatus::from_raw(0)),
             ExitReason::Code(0)


### PR DESCRIPTION
Next milestone after the foreground runner: run the **whole stack** in the foreground, without introducing a daemon.

## What's new

```sh
servicrab up                    # every service with autostart = true
servicrab up api                # `api` plus everything it depends on
servicrab up --no-restart --timestamps --no-prefix --abort-on-failure
```

Output is interleaved and colour-prefixed per service; a service's stdout goes to Servicrab's stdout and its stderr to stderr, so `servicrab up > stack.log` still separates the two. Colour is disabled for non-TTYs, `NO_COLOR`, and `TERM=dumb`.

## Architecture

The single-service runner was generalised rather than duplicated:

- `runtime::event` — `ServiceEvent` / `EventKind` / `EventSink`. The runtime publishes structured events (state changes, captured log lines, exits, backoff, failures) and never formats anything itself. This is also the stream the future daemon will forward over its socket.
- `runtime::plan` — `plan_stack()` resolves requested services (or all autostart ones) plus every transitive dependency, ordered by the config's deterministic topological start order.
- `runtime::unix` — `ServiceRunner` supervises one service, driven by a shutdown `watch` channel instead of owning signal handlers, with `OutputMode::{Inherit, Capture}`. `SignalWatcher` centralises SIGINT/SIGTERM handling and re-broadcasts a second signal as "kill now". `ForegroundRunner` is now a thin wrapper and `run` behaves exactly as before.
- `runtime::stack` — `StackSupervisor` spawns one task per service, gates each service on its dependencies being *running*, supervises them concurrently, and on shutdown stops them **in reverse dependency order**, waiting for each before moving on. Per-service signal/timeout/`SIGKILL` escalation is unchanged.
- CLI `commands::up` + `style` only render events and map the outcome to an exit code.

Dependency gating currently means "the dependency's process is up"; real readiness probes are the next milestone and are documented as such.

## Behaviour details

- A dependency that never comes up (spawn failure, restart budget exhausted) causes its dependents to be **skipped** rather than started against a missing backend, and the run is reported as failed.
- `--abort-on-failure` tears the whole stack down as soon as one service fails.
- Exit codes: `0` clean, `130` Ctrl+C, `143` SIGTERM, `1` any failure/skip.
- Logs now go to **stderr** (they went to stdout before), and `run` shows lifecycle transitions at info level by default — previously they were invisible without `RUST_LOG`.

## Tests

145 tests pass locally (`fmt`, `clippy -D warnings`, `test --workspace --all-features`), including 16 new `up` integration tests: planning/autostart selection, dependency pull-in, unknown service, prefix/no-prefix/timestamps, stdout vs stderr routing, dependency gating, skip-on-failed-dependency, Ctrl+C and SIGTERM shutdown, reverse-order shutdown, restart-limit failure, `--abort-on-failure` teardown, and descendant/orphan cleanup. Plus new unit tests for the planner, event sink, shutdown channel, and dependency waiting.