### PR TITLE
Add health checks: readiness gating and liveness restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "humantime",
  "nix",
  "predicates",
  "serde",

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - `servicrab list` — see all services and their restart policies at a glance
 - `servicrab run <service>` — supervise a single service in the foreground with live stdout/stderr, restart policy, and process-group shutdown (Linux/macOS)
 - `servicrab up` — run your whole stack in the foreground: dependency-ordered start, interleaved and colour-prefixed output, reverse-order shutdown (Linux/macOS)
+- Health checks: `command`, `http` and `tcp` probes with readiness gating and automatic restart of unhealthy services
 - Restart policies: `never`, `on-failure`, `always`, with exponential backoff
 - Per-service environment variables and working directories
 - Dependency declarations and a deterministic start order
@@ -268,10 +269,13 @@ set, or when `TERM=dumb`.
 ### Start and stop ordering
 
 Services start in the configuration's deterministic topological order, and a
-service is only spawned once every service it depends on is **running**. Note
-that "running" currently means "the process was spawned" — real readiness
-probes are a later milestone, so a dependent may still need to retry its first
-connection.
+service is only spawned once every service it depends on is **available**:
+
+- a service without a health check is available as soon as its process is up;
+- a service **with** a health check is available only after its first
+  successful probe;
+- a one-shot dependency (a migration, a build step) that exited cleanly counts
+  as available too.
 
 Shutdown happens in reverse: dependents are stopped (and fully reaped) before
 the services they depend on, each with its own `shutdown_signal` and
@@ -295,10 +299,56 @@ backend, and the run is reported as failed.
 `servicrab up` supports **Linux and macOS**. Current limitations:
 
 - no background daemon: `up` runs in the foreground and stops with your shell;
-- no health or readiness checks — dependency gating is "process is up";
 - no log files or log rotation — redirect the output yourself;
 - no `--json` event stream yet;
 - `servicrab down` does not exist yet (Ctrl+C is the way to stop a stack).
+
+---
+
+## Health checks
+
+Any service may declare a `[services.<name>.health]` block with exactly one
+probe:
+
+```toml
+[services.db.health]
+tcp = "127.0.0.1:5432"        # healthy when the port accepts a connection
+interval = "2s"               # delay between probes          (default 2s)
+timeout = "5s"                # per-probe timeout             (default 5s)
+retries = 3                   # failures before unhealthy     (default 3)
+start_period = "10s"          # failures ignored for this long (default 0s)
+on_unhealthy = "restart"      # restart | ignore              (default restart)
+
+[services.api.health]
+http = "http://127.0.0.1:3000/healthz"   # healthy on any 2xx/3xx response
+
+[services.worker.health]
+command = ["./scripts/queue-ok.sh"]      # healthy when it exits with code 0
+```
+
+- **`command`** runs the given executable with the service's environment and
+  working directory; exit code `0` means healthy.
+- **`http`** speaks plain HTTP/1.1 — no TLS, no redirects. For anything else
+  use a `command` probe such as `["curl", "-fsS", "https://…"]`.
+- **`tcp`** succeeds as soon as a connection can be established. `[::1]:6379`
+  works for IPv6 literals.
+
+### What health checks do
+
+1. **Readiness gating.** Dependents of a health-checked service wait for its
+   first successful probe instead of merely for its process to exist. This is
+   the difference between "postgres has been spawned" and "postgres accepts
+   connections".
+2. **Liveness.** Probing continues for as long as the process runs. After
+   `retries` consecutive failures the service is declared unhealthy.
+   With the default `on_unhealthy = "restart"` the process is stopped with its
+   usual `shutdown_signal`/`shutdown_timeout` and the **restart policy**
+   decides what happens next — so `restart = "never"` means an unhealthy
+   service simply stops, while `on-failure`/`always` bring it back. Set
+   `on_unhealthy = "ignore"` to only report the failure.
+
+Failures during `start_period` never count, which gives slow starters time to
+come up without burning their retry budget.
 
 ---
 
@@ -354,6 +404,11 @@ cargo test -p servicrab-core config::tests
 - [x] `servicrab up` — concurrent supervision of the whole stack
 - [x] Dependency ordering on start, reverse order on shutdown
 - [x] Interleaved, prefixed, colourised output
+
+### Phase 1.7 (current) — Health checks ✅
+- [x] `command`, `http` and `tcp` probes
+- [x] Readiness gating: dependents wait for a healthy dependency
+- [x] Unhealthy services are stopped and restarted by policy
 
 ### Phase 2 — Background daemon
 - [ ] Background daemon process with Unix socket / named-pipe API

--- a/crates/servicrab-cli/Cargo.toml
+++ b/crates/servicrab-cli/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+humantime = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/servicrab-cli/src/commands/init.rs
+++ b/crates/servicrab-cli/src/commands/init.rs
@@ -39,6 +39,19 @@ name = "my-project"
 #   stable_after          Consider stable after running this long (default: 60s)
 #   shutdown_signal       term | int | quit | hup  (default: term)
 #   shutdown_timeout      Wait this long before forcibly killing (default: 10s)
+#
+# Optional [services.<name>.health] block — exactly one probe:
+#   command       Probe command; exit code 0 means healthy
+#   http          Plain-HTTP URL that must answer 2xx/3xx, e.g. "http://127.0.0.1:3000/health"
+#   tcp           "host:port" that must accept a connection
+#   interval      Delay between probes (default: 2s)
+#   timeout       Per-probe timeout (default: 5s)
+#   retries       Consecutive failures before unhealthy (default: 3)
+#   start_period  Grace period after start (default: 0s)
+#   on_unhealthy  restart | ignore (default: restart)
+#
+# Services that depend on a health-checked service wait for its first
+# successful probe instead of just for its process to be up.
 
 [services.api]
 command = ["echo", "Replace me with your API server command"]
@@ -55,6 +68,11 @@ PORT = "3000"
 [services.db]
 command = ["echo", "Replace me with your database command"]
 restart = "always"
+
+# [services.db.health]
+# tcp = "127.0.0.1:5432"
+# interval = "2s"
+# start_period = "5s"
 
 [services.worker]
 command = ["echo", "Replace me with your worker command"]

--- a/crates/servicrab-cli/src/commands/list.rs
+++ b/crates/servicrab-cli/src/commands/list.rs
@@ -38,6 +38,8 @@ struct ServiceJson<'a> {
     depends_on: Vec<&'a str>,
     autostart: bool,
     restart: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    health: Option<String>,
 }
 
 fn print_json(services: &std::collections::BTreeMap<ServiceName, Service>) {
@@ -57,6 +59,7 @@ fn print_json(services: &std::collections::BTreeMap<ServiceName, Service>) {
                     servicrab_core::RestartPolicy::OnFailure => "on-failure",
                     servicrab_core::RestartPolicy::Always => "always",
                 },
+                health: svc.health.as_ref().map(|h| h.probe.to_string()),
             }
         })
         .collect();
@@ -100,6 +103,13 @@ fn print_table(services: &std::collections::BTreeMap<ServiceName, Service>, proj
         if !svc.depends_on.is_empty() {
             let deps: Vec<&str> = svc.depends_on.iter().map(|n| n.as_str()).collect();
             println!("  depends on: {}", deps.join(", "));
+        }
+        if let Some(health) = &svc.health {
+            println!(
+                "  health: {} every {}",
+                health.probe,
+                humantime::format_duration(health.interval)
+            );
         }
     }
 }

--- a/crates/servicrab-cli/src/commands/run.rs
+++ b/crates/servicrab-cli/src/commands/run.rs
@@ -57,12 +57,14 @@ fn exit_code(outcome: RunOutcome) -> i32 {
         RunOutcome::Exited { reason, .. } => match reason {
             ExitReason::Code(code) => code,
             ExitReason::Signal(sig) => 128 + sig,
-            ExitReason::SpawnFailure { .. } => 1,
+            ExitReason::SpawnFailure { .. } | ExitReason::Unhealthy => 1,
         },
         RunOutcome::Stopped { reason } => match reason {
             ShutdownReason::UserInterrupt => EXIT_SIGINT,
             ShutdownReason::Terminated => EXIT_SIGTERM,
-            ShutdownReason::RestartLimit | ShutdownReason::StackFailure => 1,
+            ShutdownReason::RestartLimit
+            | ShutdownReason::StackFailure
+            | ShutdownReason::Unhealthy => 1,
         },
     }
 }

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -189,6 +189,19 @@ impl Printer {
                 &format!("skipped: dependency {dependency} never became available"),
             ),
             EventKind::Failed { message } => self.status(service, "✗", message),
+            EventKind::Healthy => self.status(service, "✔", "healthy"),
+            EventKind::HealthProbeFailed {
+                message,
+                consecutive,
+                retries,
+            } => self.status(
+                service,
+                "!",
+                &format!("health probe failed ({consecutive}/{retries}): {message}"),
+            ),
+            EventKind::Unhealthy { message } => {
+                self.status(service, "✗", &format!("unhealthy: {message}"))
+            }
             // State transitions and the final summary are already conveyed by
             // the events above; showing them too would only add noise.
             EventKind::State(_) | EventKind::Finished { .. } => {}

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -122,11 +122,12 @@ fn main() {
     let cli = Cli::parse();
 
     // `run` has no other progress output, so its lifecycle transitions are
-    // logged by default.  `up` renders its own event stream, and the remaining
-    // commands are one-shot, so those stay quiet unless asked otherwise.
+    // logged by default.  `up` renders the same information from its event
+    // stream, so logging is quiet there to avoid printing everything twice.
     // Either way `RUST_LOG` wins (e.g. `RUST_LOG=debug servicrab up`).
     let default_filter = match cli.command {
         Commands::Run { .. } => "servicrab_core=info",
+        Commands::Up { .. } => "error",
         _ => "warn",
     };
     tracing_subscriber::fmt()

--- a/crates/servicrab-cli/tests/health.rs
+++ b/crates/servicrab-cli/tests/health.rs
@@ -1,0 +1,436 @@
+//! Integration tests for health checks and readiness gating.
+//!
+//! Every fixture is generated into a [`TempDir`] at test time; all waits are
+//! bounded so a hung supervisor fails the test instead of stalling CI.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Upper bound for any wait in this file.
+const CEILING: Duration = Duration::from_secs(15);
+
+fn script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+fn config(dir: &Path, toml: &str) -> PathBuf {
+    let path = dir.join("servicrab.toml");
+    fs::write(&path, toml).unwrap();
+    path
+}
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+/// Run a servicrab subcommand to completion: `(exit code, stdout, stderr)`.
+fn servicrab(command: &str, config_path: &Path, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(binary())
+        .arg(command)
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn up(config_path: &Path, args: &[&str]) -> (i32, String, String) {
+    servicrab("up", config_path, args)
+}
+
+/// Wait until `path` exists and is non-empty.
+fn wait_for_file(path: &Path) {
+    let deadline = Instant::now() + CEILING;
+    while Instant::now() < deadline {
+        if path.exists() && fs::metadata(path).map(|m| m.len() > 0).unwrap_or(false) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
+#[test]
+fn a_dependent_waits_for_its_dependency_to_become_healthy() {
+    let dir = TempDir::new().unwrap();
+    let ready = dir.path().join("db.ready");
+    let log = dir.path().join("order.txt");
+
+    // The dependency only reports itself ready after a delay, so a dependent
+    // that started on "process is up" alone would beat the marker.
+    script(
+        dir.path(),
+        "db.sh",
+        &format!("sleep 0.6\necho ready > {}\nsleep 5", ready.display()),
+    );
+    script(
+        dir.path(),
+        "probe.sh",
+        &format!("test -f {}", ready.display()),
+    );
+    script(
+        dir.path(),
+        "api.sh",
+        &format!(
+            "if [ -f {} ]; then echo after >> {}; else echo before >> {}; fi",
+            ready.display(),
+            log.display(),
+            log.display()
+        ),
+    );
+
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{api}"]
+depends_on = ["db"]
+
+[services.db]
+command = ["{db}"]
+
+[services.db.health]
+command = ["{probe}"]
+interval = "100ms"
+start_period = "5s"
+"#,
+            api = dir.path().join("api.sh").display(),
+            db = dir.path().join("db.sh").display(),
+            probe = dir.path().join("probe.sh").display(),
+        ),
+    );
+
+    let (_code, _stdout, stderr) = up(&cfg, &["--abort-on-failure"]);
+    let order = fs::read_to_string(&log).expect("order log");
+    assert_eq!(order.trim(), "after", "stderr: {stderr}");
+    assert!(stderr.contains("healthy"), "stderr: {stderr}");
+}
+
+#[test]
+fn a_dependent_is_skipped_when_its_dependency_never_becomes_healthy() {
+    let dir = TempDir::new().unwrap();
+    let started = dir.path().join("api.started");
+
+    script(dir.path(), "db.sh", "sleep 30");
+    script(dir.path(), "probe.sh", "exit 1");
+    script(
+        dir.path(),
+        "api.sh",
+        &format!("echo started > {}", started.display()),
+    );
+
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{api}"]
+depends_on = ["db"]
+
+[services.db]
+command = ["{db}"]
+restart = "never"
+
+[services.db.health]
+command = ["{probe}"]
+interval = "100ms"
+retries = 2
+"#,
+            api = dir.path().join("api.sh").display(),
+            db = dir.path().join("db.sh").display(),
+            probe = dir.path().join("probe.sh").display(),
+        ),
+    );
+
+    let (code, _stdout, stderr) = up(&cfg, &[]);
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(stderr.contains("unhealthy"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("skipped") || stderr.contains("never became available"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !started.exists(),
+        "the dependent must not start when its dependency never becomes healthy"
+    );
+}
+
+#[test]
+fn an_unhealthy_service_is_restarted() {
+    let dir = TempDir::new().unwrap();
+    let runs = dir.path().join("runs.txt");
+    let flag = dir.path().join("healthy");
+
+    // The probe fails on the first run and succeeds once the service has been
+    // restarted, so the run must end cleanly after exactly one restart.
+    script(
+        dir.path(),
+        "svc.sh",
+        &format!("echo run >> {}\nsleep 10", runs.display()),
+    );
+    script(
+        dir.path(),
+        "probe.sh",
+        &format!(
+            "if [ -f {flag} ]; then exit 0; fi\necho x > {flag}\nexit 1",
+            flag = flag.display()
+        ),
+    );
+
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.svc]
+command = ["{svc}"]
+restart = "on-failure"
+restart_delay = "100ms"
+max_restarts = 3
+shutdown_timeout = "2s"
+
+[services.svc.health]
+command = ["{probe}"]
+interval = "150ms"
+retries = 1
+"#,
+            svc = dir.path().join("svc.sh").display(),
+            probe = dir.path().join("probe.sh").display(),
+        ),
+    );
+
+    let mut child = Command::new(binary())
+        .arg("up")
+        .arg("--config")
+        .arg(&cfg)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to spawn servicrab up");
+
+    // Wait until the service has been started twice: once initially and once
+    // after the health check stopped it.
+    let deadline = Instant::now() + CEILING;
+    loop {
+        let runs_seen = fs::read_to_string(&runs)
+            .map(|s| s.lines().count())
+            .unwrap_or(0);
+        if runs_seen >= 2 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the unhealthy service was not restarted (runs so far: {runs_seen})"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn on_unhealthy_ignore_keeps_the_process_running() {
+    let dir = TempDir::new().unwrap();
+    let runs = dir.path().join("runs.txt");
+    let done = dir.path().join("done.txt");
+
+    script(
+        dir.path(),
+        "svc.sh",
+        &format!(
+            "echo run >> {}\nsleep 1.5\necho done > {}",
+            runs.display(),
+            done.display()
+        ),
+    );
+    script(dir.path(), "probe.sh", "exit 1");
+
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.svc]
+command = ["{svc}"]
+restart = "never"
+
+[services.svc.health]
+command = ["{probe}"]
+interval = "100ms"
+retries = 1
+on_unhealthy = "ignore"
+"#,
+            svc = dir.path().join("svc.sh").display(),
+            probe = dir.path().join("probe.sh").display(),
+        ),
+    );
+
+    let (code, _stdout, stderr) = up(&cfg, &[]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    wait_for_file(&done);
+    let run_count = fs::read_to_string(&runs).unwrap().lines().count();
+    assert_eq!(run_count, 1, "the service must not have been restarted");
+    assert!(stderr.contains("unhealthy"), "stderr: {stderr}");
+}
+
+#[test]
+fn a_tcp_probe_reports_a_listening_service_as_healthy() {
+    let dir = TempDir::new().unwrap();
+    // Pick a port by binding and releasing it immediately.
+    let port = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.local_addr().unwrap().port()
+    };
+
+    // A tiny listener: `nc` is not guaranteed to exist everywhere, so use the
+    // same Rust binary that is already available — python3 is present on both
+    // CI images and macOS/Linux dev machines.
+    script(
+        dir.path(),
+        "listen.sh",
+        &format!(
+            "exec python3 -c \"import socket,time; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); s.bind(('127.0.0.1', {port})); s.listen(8); time.sleep(10)\""
+        ),
+    );
+
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.listener]
+command = ["{listen}"]
+shutdown_timeout = "2s"
+
+[services.listener.health]
+tcp = "127.0.0.1:{port}"
+interval = "100ms"
+"#,
+            listen = dir.path().join("listen.sh").display(),
+        ),
+    );
+
+    let mut child = Command::new(binary())
+        .arg("up")
+        .arg("--config")
+        .arg(&cfg)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn servicrab up");
+
+    // Give the probe a moment to succeed, then stop the stack and check the
+    // reported status.
+    std::thread::sleep(Duration::from_millis(1500));
+    let _ = child.kill();
+    let output = child.wait_with_output().expect("wait");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("healthy"), "stderr: {stderr}");
+}
+
+#[test]
+fn list_reports_the_configured_probe() {
+    let dir = TempDir::new().unwrap();
+    let cfg = config(
+        dir.path(),
+        r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["echo", "hi"]
+
+[services.api.health]
+http = "http://127.0.0.1:8080/healthz"
+interval = "3s"
+"#,
+    );
+
+    let (code, stdout, stderr) = servicrab("list", &cfg, &[]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(
+        stdout.contains("health: http http://127.0.0.1:8080/healthz every 3s"),
+        "stdout: {stdout}"
+    );
+
+    let (code, stdout, _) = servicrab("list", &cfg, &["--json"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("\"health\": \"http http://127.0.0.1:8080/healthz\""),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn an_invalid_health_block_fails_check() {
+    let dir = TempDir::new().unwrap();
+    let cfg = config(
+        dir.path(),
+        r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["echo", "hi"]
+
+[services.api.health]
+interval = "3s"
+"#,
+    );
+
+    let (code, _stdout, stderr) = servicrab("check", &cfg, &[]);
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("exactly one of `command`, `http` or `tcp`"),
+        "stderr: {stderr}"
+    );
+}

--- a/crates/servicrab-cli/tests/run.rs
+++ b/crates/servicrab-cli/tests/run.rs
@@ -61,6 +61,12 @@ fn run_service(config_path: &Path, service: &str, extra: &[&str]) -> (i32, Strin
 
 /// Spawn `servicrab run <service>` in the background, capturing stdout.
 fn spawn_service(config_path: &Path, service: &str, stdout: Stdio) -> Child {
+    spawn_service_with(config_path, service, stdout, Stdio::null())
+}
+
+/// Like [`spawn_service`] but with an explicit stderr redirection, so a test
+/// can report what the supervisor said when an assertion fails.
+fn spawn_service_with(config_path: &Path, service: &str, stdout: Stdio, stderr: Stdio) -> Child {
     Command::new(binary())
         .arg("run")
         .arg(service)
@@ -68,9 +74,19 @@ fn spawn_service(config_path: &Path, service: &str, stdout: Stdio) -> Child {
         .arg(config_path)
         .env_remove("RUST_LOG")
         .stdout(stdout)
-        .stderr(Stdio::null())
+        .stderr(stderr)
         .spawn()
         .expect("failed to spawn servicrab")
+}
+
+/// Drain a child's captured stderr without blocking forever.
+fn drain_stderr(child: &mut Child) -> String {
+    use std::io::Read;
+    let mut buf = String::new();
+    if let Some(mut err) = child.stderr.take() {
+        let _ = err.read_to_string(&mut buf);
+    }
+    buf
 }
 
 /// Block until `path` exists (or the ceiling elapses).
@@ -406,15 +422,16 @@ fn interrupt_triggers_graceful_shutdown() {
         ),
     );
 
-    let mut child = spawn_service(&cfg, "sleeper", Stdio::null());
+    let mut child = spawn_service_with(&cfg, "sleeper", Stdio::null(), Stdio::piped());
     wait_for_file(&marker);
 
     kill(Pid::from_raw(child.id() as i32), Signal::SIGINT).unwrap();
     let code = wait_bounded(&mut child);
+    let stderr = drain_stderr(&mut child);
 
     // 130 == 128 + SIGINT; `restart = "always"` must not resurrect the service
     // after an explicit user shutdown.
-    assert_eq!(code, 130);
+    assert_eq!(code, 130, "supervisor said: {stderr}");
 }
 
 #[test]
@@ -440,16 +457,17 @@ fn shutdown_timeout_escalates_to_sigkill() {
         ),
     );
 
-    let mut child = spawn_service(&cfg, "stubborn", Stdio::null());
+    let mut child = spawn_service_with(&cfg, "stubborn", Stdio::null(), Stdio::piped());
     wait_for_file(&marker);
 
     let started = Instant::now();
     kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM).unwrap();
     let code = wait_bounded(&mut child);
     let elapsed = started.elapsed();
+    let stderr = drain_stderr(&mut child);
 
     // 143 == 128 + SIGTERM.
-    assert_eq!(code, 143);
+    assert_eq!(code, 143, "supervisor said: {stderr}");
     assert!(
         elapsed >= Duration::from_millis(400),
         "the supervisor should have waited out the shutdown timeout, took {elapsed:?}"

--- a/crates/servicrab-core/src/config.rs
+++ b/crates/servicrab-core/src/config.rs
@@ -117,6 +117,93 @@ pub struct Project {
     pub env: BTreeMap<String, String>,
 }
 
+// ── Health checks ──────────────────────────────────────────────────────────
+
+/// How a service's health is probed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+pub enum HealthProbe {
+    /// Run a command; exit status `0` means healthy.
+    Command {
+        /// Executable to run.
+        executable: String,
+        /// Arguments passed to the executable.
+        args: Vec<String>,
+    },
+    /// Issue a plain `HTTP/1.1` `GET` and require a `2xx`/`3xx` response.
+    Http {
+        /// The original URL, as written in the config.
+        url: String,
+        /// Host part of the URL.
+        host: String,
+        /// Port (defaults to `80` when the URL omits it).
+        port: u16,
+        /// Request target, including any query string.
+        path: String,
+    },
+    /// Open a TCP connection to `host:port`.
+    Tcp {
+        /// Host part of the address.
+        host: String,
+        /// Port part of the address.
+        port: u16,
+    },
+}
+
+impl std::fmt::Display for HealthProbe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HealthProbe::Command { executable, args } => {
+                write!(f, "command {executable}")?;
+                for arg in args {
+                    write!(f, " {arg}")?;
+                }
+                Ok(())
+            }
+            HealthProbe::Http { url, .. } => write!(f, "http {url}"),
+            HealthProbe::Tcp { host, port } => write!(f, "tcp {host}:{port}"),
+        }
+    }
+}
+
+/// What the supervisor does when a service is declared unhealthy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UnhealthyAction {
+    /// Stop the process and let the restart policy decide what happens next
+    /// (default).
+    #[default]
+    Restart,
+    /// Only report the failure and keep the process running.
+    Ignore,
+}
+
+impl std::fmt::Display for UnhealthyAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UnhealthyAction::Restart => write!(f, "restart"),
+            UnhealthyAction::Ignore => write!(f, "ignore"),
+        }
+    }
+}
+
+/// Validated health-check configuration for a service.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HealthCheck {
+    /// How health is probed.
+    pub probe: HealthProbe,
+    /// How long to wait between probes.
+    pub interval: Duration,
+    /// How long a single probe may take before it counts as a failure.
+    pub timeout: Duration,
+    /// Consecutive failures tolerated before the service is unhealthy.
+    pub retries: u32,
+    /// Grace period after start during which failures do not count.
+    pub start_period: Duration,
+    /// What to do once the service is declared unhealthy.
+    pub on_unhealthy: UnhealthyAction,
+}
+
 // ── Service ────────────────────────────────────────────────────────────────
 
 /// Validated configuration for a single managed service.
@@ -151,6 +238,8 @@ pub struct Service {
     pub shutdown_signal: ShutdownSignal,
     /// How long to wait for the process to exit after the shutdown signal.
     pub shutdown_timeout: Duration,
+    /// Optional health check used for readiness gating and liveness.
+    pub health: Option<HealthCheck>,
 }
 
 // ── Config ─────────────────────────────────────────────────────────────────

--- a/crates/servicrab-core/src/error.rs
+++ b/crates/servicrab-core/src/error.rs
@@ -123,6 +123,33 @@ pub enum ConfigError {
     /// An unrecognised shutdown signal string.
     #[error("service {service:?}: unknown shutdown_signal {value:?}; expected one of: term, int, quit, hup")]
     InvalidShutdownSignal { service: String, value: String },
+
+    /// The `[health]` table declared no probe at all.
+    #[error(
+        "service {service:?}: [health] must declare exactly one of `command`, `http` or `tcp`"
+    )]
+    MissingHealthProbe { service: String },
+
+    /// The `[health]` table declared more than one probe.
+    #[error(
+        "service {service:?}: [health] declares multiple probes ({probes}); exactly one of `command`, `http` or `tcp` is allowed"
+    )]
+    ConflictingHealthProbes { service: String, probes: String },
+
+    /// A health probe was declared but is not usable.
+    #[error("service {service:?}: invalid [health] {field} probe {value:?}: {reason}")]
+    InvalidHealthProbe {
+        service: String,
+        field: &'static str,
+        value: String,
+        reason: String,
+    },
+
+    /// An unrecognised `on_unhealthy` action.
+    #[error(
+        "service {service:?}: unknown [health] on_unhealthy {value:?}; expected one of: restart, ignore"
+    )]
+    InvalidUnhealthyAction { service: String, value: String },
 }
 
 /// A non-fatal configuration warning.

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -32,7 +32,8 @@ pub mod validation;
 
 // Convenience re-exports.
 pub use config::{
-    Config, Project, ProjectName, RestartPolicy, Service, ServiceName, ShutdownSignal,
+    Config, HealthCheck, HealthProbe, Project, ProjectName, RestartPolicy, Service, ServiceName,
+    ShutdownSignal, UnhealthyAction,
 };
 pub use error::{ConfigError, ConfigWarning, RuntimeError};
 pub use lifecycle::{

--- a/crates/servicrab-core/src/lifecycle.rs
+++ b/crates/servicrab-core/src/lifecycle.rs
@@ -60,6 +60,7 @@ impl ServiceState {
                 | (Backoff, Starting)
                 | (Backoff, Stopped)
                 | (Backoff, Failed)
+                | (Stopping, Backoff)
                 | (Stopping, Stopped)
                 | (Stopping, Exited)
                 | (Stopping, Failed)
@@ -162,6 +163,8 @@ pub enum ExitReason {
         /// resource shortage rather than a missing executable).
         retryable: bool,
     },
+    /// The process was stopped because its health check failed.
+    Unhealthy,
 }
 
 impl ExitReason {
@@ -179,6 +182,7 @@ impl std::fmt::Display for ExitReason {
             ExitReason::SpawnFailure { retryable } => {
                 write!(f, "spawn failed (retryable: {retryable})")
             }
+            ExitReason::Unhealthy => write!(f, "stopped after failing its health check"),
         }
     }
 }
@@ -195,6 +199,8 @@ pub enum ShutdownReason {
     /// Another service in the stack failed and the whole stack is being torn
     /// down (`up --abort-on-failure`).
     StackFailure,
+    /// The service failed its health check.
+    Unhealthy,
 }
 
 impl ShutdownReason {
@@ -215,6 +221,7 @@ impl std::fmt::Display for ShutdownReason {
             ShutdownReason::Terminated => write!(f, "supervisor terminated"),
             ShutdownReason::RestartLimit => write!(f, "restart limit exhausted"),
             ShutdownReason::StackFailure => write!(f, "another service failed"),
+            ShutdownReason::Unhealthy => write!(f, "failed its health check"),
         }
     }
 }
@@ -377,7 +384,7 @@ impl RestartTracker {
             },
             RestartPolicy::OnFailure => match reason {
                 ExitReason::Code(0) => false,
-                ExitReason::Code(_) | ExitReason::Signal(_) => true,
+                ExitReason::Code(_) | ExitReason::Signal(_) | ExitReason::Unhealthy => true,
                 ExitReason::SpawnFailure { retryable } => retryable,
             },
         }

--- a/crates/servicrab-core/src/raw.rs
+++ b/crates/servicrab-core/src/raw.rs
@@ -93,6 +93,52 @@ pub struct RawService {
     /// signal before forcibly killing it.  Defaults to `"10s"`.
     #[serde(default)]
     pub shutdown_timeout: Option<String>,
+
+    /// Optional health check (`[services.<name>.health]`).
+    #[serde(default)]
+    pub health: Option<RawHealthCheck>,
+}
+
+/// Raw health-check configuration (`[services.<name>.health]`).
+///
+/// Exactly one of `command`, `http` or `tcp` must be set.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawHealthCheck {
+    /// Command probe: first element is the executable, rest are arguments.
+    #[serde(default)]
+    pub command: Option<Vec<String>>,
+
+    /// HTTP probe: an `http://host[:port][/path]` URL.
+    #[serde(default)]
+    pub http: Option<String>,
+
+    /// TCP probe: a `host:port` address.
+    #[serde(default)]
+    pub tcp: Option<String>,
+
+    /// Delay between probes.  Defaults to `"2s"`.
+    #[serde(default)]
+    pub interval: Option<String>,
+
+    /// Per-probe timeout.  Defaults to `"5s"`.
+    #[serde(default)]
+    pub timeout: Option<String>,
+
+    /// Consecutive failures tolerated before the service is unhealthy.
+    /// Defaults to `3`.
+    #[serde(default)]
+    pub retries: Option<u32>,
+
+    /// Grace period after start during which failures do not count.
+    /// Defaults to `"0s"`.
+    #[serde(default)]
+    pub start_period: Option<String>,
+
+    /// What to do when the service becomes unhealthy: `restart` (default) or
+    /// `ignore`.
+    #[serde(default)]
+    pub on_unhealthy: Option<String>,
 }
 
 /// Raw restart-policy string token.

--- a/crates/servicrab-core/src/runtime/event.rs
+++ b/crates/servicrab-core/src/runtime/event.rs
@@ -77,6 +77,22 @@ pub enum EventKind {
         /// A human-readable description of the final outcome.
         summary: String,
     },
+    /// The service passed its health check and is considered ready.
+    Healthy,
+    /// A health probe failed.
+    HealthProbeFailed {
+        /// Why the probe failed.
+        message: String,
+        /// How many consecutive failures have been seen so far.
+        consecutive: u32,
+        /// How many consecutive failures are tolerated.
+        retries: u32,
+    },
+    /// The service exhausted its health-check retry budget.
+    Unhealthy {
+        /// Why the last probe failed.
+        message: String,
+    },
     /// The service failed fatally.
     Failed {
         /// A human-readable description of the failure.

--- a/crates/servicrab-core/src/runtime/health.rs
+++ b/crates/servicrab-core/src/runtime/health.rs
@@ -368,13 +368,11 @@ mod tests {
 
     #[tokio::test]
     async fn a_tcp_probe_fails_when_nothing_listens() {
-        // Bind and immediately drop to get a port that is very likely free.
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
+        // Port 1 is privileged, so nothing can be listening on it — unlike a
+        // just-released ephemeral port, which another test may grab.
         let probe = HealthProbe::Tcp {
             host: "127.0.0.1".to_string(),
-            port,
+            port: 1,
         };
         let err = probe_once(&probe, &ctx(), Duration::from_secs(5))
             .await

--- a/crates/servicrab-core/src/runtime/health.rs
+++ b/crates/servicrab-core/src/runtime/health.rs
@@ -1,0 +1,428 @@
+//! Health and readiness probing.
+//!
+//! A service may declare a `[health]` table; when it does, the runtime runs
+//! the configured probe on an interval for as long as the process is alive.
+//! The first successful probe makes the service *ready* — which is what the
+//! stack supervisor gates dependents on — and a run of consecutive failures
+//! makes it *unhealthy*, which optionally stops the process so that the normal
+//! restart policy applies.
+//!
+//! Probes are deliberately dependency-free: the HTTP probe speaks just enough
+//! HTTP/1.1 to issue a `GET` and read the status line.  Anything more involved
+//! (TLS, redirects, authentication) belongs in a `command` probe.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::time::{Instant, MissedTickBehavior};
+use tracing::{debug, info, warn};
+
+use crate::config::{HealthCheck, HealthProbe, Service, ServiceName, UnhealthyAction};
+use crate::runtime::event::{EventKind, EventSink};
+
+/// What a health monitor reports back to the service runner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HealthSignal {
+    /// The service passed a probe and is ready.
+    Ready,
+    /// The service exhausted its retry budget.
+    Unhealthy {
+        /// Why the last probe failed.
+        message: String,
+    },
+}
+
+impl HealthSignal {
+    /// Whether this signal reports an unhealthy service.
+    pub fn is_unhealthy(&self) -> bool {
+        matches!(self, HealthSignal::Unhealthy { .. })
+    }
+}
+
+/// Environment needed to run a probe, cloned so the monitor can outlive the
+/// borrow of the [`Service`].
+#[derive(Debug, Clone)]
+struct ProbeContext {
+    cwd: PathBuf,
+    env: BTreeMap<String, String>,
+}
+
+/// Run a single probe, returning `Err(message)` when it fails.
+async fn probe_once(
+    probe: &HealthProbe,
+    ctx: &ProbeContext,
+    timeout: Duration,
+) -> Result<(), String> {
+    let attempt = async {
+        match probe {
+            HealthProbe::Command { executable, args } => run_command_probe(executable, args, ctx)
+                .await
+                .map_err(|e| e.to_string()),
+            HealthProbe::Http {
+                host, port, path, ..
+            } => run_http_probe(host, *port, path).await,
+            HealthProbe::Tcp { host, port } => run_tcp_probe(host, *port).await,
+        }
+    };
+
+    match tokio::time::timeout(timeout, attempt).await {
+        Ok(result) => result,
+        Err(_) => Err(format!(
+            "probe timed out after {}",
+            format_duration(timeout)
+        )),
+    }
+}
+
+/// Run a command probe: exit status `0` means healthy.
+async fn run_command_probe(
+    executable: &str,
+    args: &[String],
+    ctx: &ProbeContext,
+) -> Result<(), String> {
+    let mut command = tokio::process::Command::new(executable);
+    command
+        .args(args)
+        .current_dir(&ctx.cwd)
+        .env_clear()
+        .envs(&ctx.env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    #[cfg(unix)]
+    command.process_group(0);
+
+    let output = command
+        .output()
+        .await
+        .map_err(|e| format!("failed to run {executable:?}: {e}"))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let detail = stderr.lines().next_back().unwrap_or("").trim();
+    let status = match output.status.code() {
+        Some(code) => format!("exited with code {code}"),
+        None => "terminated by a signal".to_string(),
+    };
+    Err(if detail.is_empty() {
+        format!("probe command {status}")
+    } else {
+        format!("probe command {status}: {detail}")
+    })
+}
+
+/// Issue a bare `HTTP/1.1` `GET` and accept any `2xx`/`3xx` status.
+async fn run_http_probe(host: &str, port: u16, path: &str) -> Result<(), String> {
+    let mut stream = connect(host, port).await?;
+    let request = format!(
+        "GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\nUser-Agent: servicrab\r\nAccept: */*\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .map_err(|e| format!("failed to send the request: {e}"))?;
+
+    let mut status_line = String::new();
+    BufReader::new(stream)
+        .read_line(&mut status_line)
+        .await
+        .map_err(|e| format!("failed to read the response: {e}"))?;
+
+    let status_line = status_line.trim_end();
+    let code: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .ok_or_else(|| format!("malformed status line {status_line:?}"))?;
+
+    if (200..400).contains(&code) {
+        Ok(())
+    } else {
+        Err(format!("unhealthy HTTP status {code}"))
+    }
+}
+
+/// Succeed as soon as a TCP connection can be established.
+async fn run_tcp_probe(host: &str, port: u16) -> Result<(), String> {
+    connect(host, port).await.map(|_| ())
+}
+
+async fn connect(host: &str, port: u16) -> Result<TcpStream, String> {
+    // A bare IPv6 literal has to be bracketed before it can be resolved.
+    let target = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    };
+    TcpStream::connect(&target)
+        .await
+        .map_err(|e| format!("failed to connect to {target}: {e}"))
+}
+
+/// Supervise the health of one running process.
+///
+/// The loop ends when the returned sender is dropped (the process stopped) or
+/// once it has reported [`HealthSignal::Unhealthy`].
+pub struct HealthMonitor {
+    check: HealthCheck,
+    ctx: ProbeContext,
+    name: ServiceName,
+    events: EventSink,
+}
+
+impl HealthMonitor {
+    /// Build a monitor for `service`, or `None` when it declares no health
+    /// check.
+    pub fn for_service(service: &Service, events: EventSink) -> Option<Self> {
+        let check = service.health.clone()?;
+        Some(Self {
+            check,
+            ctx: ProbeContext {
+                cwd: service.cwd.clone(),
+                env: service.env.clone(),
+            },
+            name: service.name.clone(),
+            events,
+        })
+    }
+
+    /// Probe until the monitor is dropped, reporting transitions on the
+    /// returned channel.
+    pub fn spawn(self) -> mpsc::UnboundedReceiver<HealthSignal> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move { self.run(tx).await });
+        rx
+    }
+
+    async fn run(self, tx: mpsc::UnboundedSender<HealthSignal>) {
+        let name = self.name.clone();
+        let started = Instant::now();
+        let mut ticker = tokio::time::interval(self.check.interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        // The first tick completes immediately, which is what we want: probe
+        // as soon as the process is up so readiness is not delayed.
+        let mut consecutive = 0u32;
+        let mut ready = false;
+
+        loop {
+            ticker.tick().await;
+            if tx.is_closed() {
+                return;
+            }
+
+            match probe_once(&self.check.probe, &self.ctx, self.check.timeout).await {
+                Ok(()) => {
+                    consecutive = 0;
+                    if !ready {
+                        ready = true;
+                        info!(service = %name, probe = %self.check.probe, "service is healthy");
+                        self.events.emit(&name, EventKind::Healthy);
+                        if tx.send(HealthSignal::Ready).is_err() {
+                            return;
+                        }
+                    } else {
+                        debug!(service = %name, "health probe passed");
+                    }
+                }
+                Err(message) => {
+                    // Failures during the start period never count: the
+                    // service is still allowed to be starting up.
+                    if started.elapsed() < self.check.start_period {
+                        debug!(
+                            service = %name,
+                            %message,
+                            "health probe failed during the start period"
+                        );
+                        continue;
+                    }
+
+                    consecutive += 1;
+                    warn!(
+                        service = %name,
+                        %message,
+                        consecutive,
+                        retries = self.check.retries,
+                        "health probe failed"
+                    );
+                    self.events.emit(
+                        &name,
+                        EventKind::HealthProbeFailed {
+                            message: message.clone(),
+                            consecutive,
+                            retries: self.check.retries,
+                        },
+                    );
+
+                    // Report the transition once, when the budget is first
+                    // exhausted.  Monitoring continues so that a service left
+                    // running by `on_unhealthy = "ignore"` can recover.
+                    if consecutive == self.check.retries {
+                        warn!(service = %name, %message, "service is unhealthy");
+                        ready = false;
+                        self.events.emit(
+                            &name,
+                            EventKind::Unhealthy {
+                                message: message.clone(),
+                            },
+                        );
+                        if tx.send(HealthSignal::Unhealthy { message }).is_err() {
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Whether a failing health check should stop the process.
+pub fn stops_process(check: &HealthCheck) -> bool {
+    check.on_unhealthy == UnhealthyAction::Restart
+}
+
+fn format_duration(d: Duration) -> String {
+    humantime::format_duration(d).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
+
+    fn ctx() -> ProbeContext {
+        ProbeContext {
+            cwd: std::env::temp_dir(),
+            env: std::env::vars().collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_command_probe_succeeds_on_exit_code_zero() {
+        let probe = HealthProbe::Command {
+            executable: "true".to_string(),
+            args: vec![],
+        };
+        assert!(probe_once(&probe, &ctx(), Duration::from_secs(5))
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_command_probe_fails_on_a_non_zero_exit_code() {
+        let probe = HealthProbe::Command {
+            executable: "false".to_string(),
+            args: vec![],
+        };
+        let err = probe_once(&probe, &ctx(), Duration::from_secs(5))
+            .await
+            .unwrap_err();
+        assert!(err.contains("exited with code 1"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_command_probe_reports_a_missing_executable() {
+        let probe = HealthProbe::Command {
+            executable: "servicrab-does-not-exist".to_string(),
+            args: vec![],
+        };
+        let err = probe_once(&probe, &ctx(), Duration::from_secs(5))
+            .await
+            .unwrap_err();
+        assert!(err.contains("failed to run"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_command_probe_times_out() {
+        let probe = HealthProbe::Command {
+            executable: "sleep".to_string(),
+            args: vec!["30".to_string()],
+        };
+        let err = probe_once(&probe, &ctx(), Duration::from_millis(150))
+            .await
+            .unwrap_err();
+        assert!(err.contains("timed out"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_tcp_probe_succeeds_against_a_listener() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let probe = HealthProbe::Tcp {
+            host: "127.0.0.1".to_string(),
+            port,
+        };
+        assert!(probe_once(&probe, &ctx(), Duration::from_secs(5))
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_tcp_probe_fails_when_nothing_listens() {
+        // Bind and immediately drop to get a port that is very likely free.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let probe = HealthProbe::Tcp {
+            host: "127.0.0.1".to_string(),
+            port,
+        };
+        let err = probe_once(&probe, &ctx(), Duration::from_secs(5))
+            .await
+            .unwrap_err();
+        assert!(err.contains("failed to connect"), "{err}");
+    }
+
+    /// Serve a single request with the given status line.
+    async fn serve_once(status: &'static str) -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 1024];
+            let _ = socket.read(&mut buf).await;
+            let _ = socket
+                .write_all(format!("{status}\r\nContent-Length: 0\r\n\r\n").as_bytes())
+                .await;
+        });
+        port
+    }
+
+    #[tokio::test]
+    async fn an_http_probe_accepts_a_2xx_response() {
+        let port = serve_once("HTTP/1.1 204 No Content").await;
+        let probe = HealthProbe::Http {
+            url: format!("http://127.0.0.1:{port}/health"),
+            host: "127.0.0.1".to_string(),
+            port,
+            path: "/health".to_string(),
+        };
+        assert!(probe_once(&probe, &ctx(), Duration::from_secs(5))
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn an_http_probe_rejects_a_5xx_response() {
+        let port = serve_once("HTTP/1.1 503 Service Unavailable").await;
+        let probe = HealthProbe::Http {
+            url: format!("http://127.0.0.1:{port}/"),
+            host: "127.0.0.1".to_string(),
+            port,
+            path: "/".to_string(),
+        };
+        let err = probe_once(&probe, &ctx(), Duration::from_secs(5))
+            .await
+            .unwrap_err();
+        assert!(err.contains("unhealthy HTTP status 503"), "{err}");
+    }
+}

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -23,6 +23,8 @@ use crate::config::RestartPolicy;
 use crate::lifecycle::{ExitReason, ShutdownReason};
 
 pub mod event;
+#[cfg(unix)]
+pub mod health;
 pub mod plan;
 
 #[cfg(unix)]
@@ -44,8 +46,12 @@ pub use stub::{ForegroundRunner, ServiceRunner, SignalWatcher};
 pub use event::{
     event_channel, EventKind, EventReceiver, EventSender, EventSink, ServiceEvent, Stream,
 };
+#[cfg(unix)]
+pub use health::{HealthMonitor, HealthSignal};
 pub use plan::{known_services, lookup_service, plan_stack};
-pub use stack::{ServiceReport, ServiceResult, StackOptions, StackOutcome, StackSupervisor};
+pub use stack::{
+    Readiness, ServiceReport, ServiceResult, StackOptions, StackOutcome, StackSupervisor,
+};
 
 /// Sending half of a shutdown channel.
 ///

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -18,7 +18,7 @@ use tokio::task::JoinHandle;
 
 use crate::config::{Config, Service, ServiceName};
 use crate::error::RuntimeError;
-use crate::lifecycle::{ServiceState, ShutdownReason};
+use crate::lifecycle::{ExitReason, ServiceState, ShutdownReason};
 use crate::runtime::event::{event_channel, EventKind, EventSender, EventSink, ServiceEvent};
 use crate::runtime::unix::ServiceRunner;
 use crate::runtime::{
@@ -133,7 +133,7 @@ impl<'a> StackSupervisor<'a> {
         };
 
         let (report_tx, mut report_rx) = mpsc::unbounded_channel::<ServiceReport>();
-        let mut states: BTreeMap<ServiceName, watch::Receiver<ServiceState>> = BTreeMap::new();
+        let mut states: BTreeMap<ServiceName, watch::Receiver<Readiness>> = BTreeMap::new();
         let mut stops: BTreeMap<ServiceName, crate::runtime::ShutdownTx> = BTreeMap::new();
         let mut handles: BTreeMap<ServiceName, JoinHandle<()>> = BTreeMap::new();
 
@@ -143,12 +143,12 @@ impl<'a> StackSupervisor<'a> {
             };
             let service = Arc::new(service.clone());
 
-            let (state_tx, state_rx) = watch::channel(ServiceState::Pending);
+            let (state_tx, state_rx) = watch::channel(Readiness::Pending);
             let (stop_tx, stop_rx) = shutdown_channel();
 
             // Dependencies always appear earlier in the plan, so their state
             // channels already exist.
-            let deps: Vec<(ServiceName, watch::Receiver<ServiceState>)> = service
+            let deps: Vec<(ServiceName, watch::Receiver<Readiness>)> = service
                 .depends_on
                 .iter()
                 .filter_map(|dep| states.get(dep).map(|rx| (dep.clone(), rx.clone())))
@@ -261,12 +261,27 @@ enum DependencyWait {
     Shutdown(ShutdownReason),
 }
 
+/// Whether a service can be depended on yet.
+///
+/// This is a coarser signal than [`ServiceState`]: dependents do not care
+/// about backoff or restarts, only about "can I start now", "keep waiting" and
+/// "this will never happen".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Readiness {
+    /// Not available yet; keep waiting.
+    Pending,
+    /// Available: dependents may start.
+    Ready,
+    /// It will never become available.
+    Gone,
+}
+
 /// Supervise one service: wait for its dependencies, then run it.
 #[allow(clippy::too_many_arguments)]
 async fn supervise_service(
     service: Arc<Service>,
-    deps: Vec<(ServiceName, watch::Receiver<ServiceState>)>,
-    state: watch::Sender<ServiceState>,
+    deps: Vec<(ServiceName, watch::Receiver<Readiness>)>,
+    readiness: watch::Sender<Readiness>,
     mut stop: ShutdownRx,
     events: EventSender,
     options: RunOptions,
@@ -283,7 +298,7 @@ async fn supervise_service(
                     dependency: dependency.clone(),
                 },
             ));
-            let _ = state.send(ServiceState::Failed);
+            let _ = readiness.send(Readiness::Gone);
             let _ = reports.send(ServiceReport {
                 service: name,
                 result: ServiceResult::Skipped { dependency },
@@ -291,7 +306,7 @@ async fn supervise_service(
             return;
         }
         DependencyWait::Shutdown(reason) => {
-            let _ = state.send(ServiceState::Stopped);
+            let _ = readiness.send(Readiness::Gone);
             let _ = reports.send(ServiceReport {
                 service: name,
                 result: ServiceResult::Finished(RunOutcome::Stopped { reason }),
@@ -300,15 +315,18 @@ async fn supervise_service(
         }
     }
 
-    // Relay the runner's events to the stack-wide stream while mirroring state
-    // changes into the watch channel that dependents are waiting on.
+    // Relay the runner's events to the stack-wide stream while deriving the
+    // readiness signal that dependents are waiting on.
     let (tx, mut rx) = event_channel();
     let relay = {
         let global = events.clone();
+        // A service with a health check is only ready once a probe passes;
+        // without one, "the process is up" is the best signal available.
+        let mut tracker = ReadinessTracker::new(service.health.is_some());
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
-                if let EventKind::State(next) = &event.kind {
-                    let _ = state.send(*next);
+                if let Some(next) = tracker.observe(&event.kind) {
+                    let _ = readiness.send(next);
                 }
                 let _ = global.send(event);
             }
@@ -343,22 +361,80 @@ async fn supervise_service(
     });
 }
 
+/// Derives the readiness signal dependents wait on from a service's events.
+struct ReadinessTracker {
+    /// Whether the service promised a health check, in which case being up is
+    /// not enough to be ready.
+    gate_on_health: bool,
+    /// Whether the current process run is known to be unhealthy.
+    unhealthy: bool,
+}
+
+impl ReadinessTracker {
+    fn new(gate_on_health: bool) -> Self {
+        Self {
+            gate_on_health,
+            unhealthy: false,
+        }
+    }
+
+    /// Map one runtime event to the readiness it implies, if any.
+    fn observe(&mut self, kind: &EventKind) -> Option<Readiness> {
+        match kind {
+            // A passing health probe always means ready.
+            EventKind::Healthy => {
+                self.unhealthy = false;
+                Some(Readiness::Ready)
+            }
+            // A failing one takes readiness away again, so a dependent that
+            // has not started yet keeps waiting for the service to recover.
+            EventKind::Unhealthy { .. } => {
+                self.unhealthy = true;
+                Some(Readiness::Pending)
+            }
+            EventKind::Exited {
+                reason: ExitReason::Unhealthy,
+                ..
+            } => {
+                self.unhealthy = true;
+                None
+            }
+            EventKind::State(state) => match state {
+                // A restart gets a clean slate: the new process has to prove
+                // itself healthy again.
+                ServiceState::Starting => {
+                    self.unhealthy = false;
+                    None
+                }
+                // The process is up: enough on its own, unless the service
+                // promised a health check that has not passed yet.
+                ServiceState::Running if !self.gate_on_health => Some(Readiness::Ready),
+                // A one-shot dependency (a migration, a build step) that
+                // already did its job counts as available — unless it was
+                // stopped precisely because it was unhealthy.
+                ServiceState::Exited if !self.unhealthy => Some(Readiness::Ready),
+                ServiceState::Exited | ServiceState::Failed | ServiceState::Stopped => {
+                    Some(Readiness::Gone)
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
 /// Wait until every dependency is available (or will never be).
 async fn wait_for_dependencies(
-    deps: &[(ServiceName, watch::Receiver<ServiceState>)],
+    deps: &[(ServiceName, watch::Receiver<Readiness>)],
     stop: &mut ShutdownRx,
 ) -> DependencyWait {
     for (name, receiver) in deps {
         let mut receiver = receiver.clone();
         loop {
             match *receiver.borrow_and_update() {
-                // Running: the process is up.  Exited: a one-shot dependency
-                // (a migration, a build step) already did its job.
-                ServiceState::Running | ServiceState::Exited => break,
-                ServiceState::Failed | ServiceState::Stopped => {
-                    return DependencyWait::Blocked(name.clone())
-                }
-                _ => {}
+                Readiness::Ready => break,
+                Readiness::Gone => return DependencyWait::Blocked(name.clone()),
+                Readiness::Pending => {}
             }
 
             tokio::select! {
@@ -422,8 +498,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dependencies_are_awaited_until_running() {
-        let (tx, rx) = watch::channel(ServiceState::Pending);
+    async fn dependencies_are_awaited_until_ready() {
+        let (tx, rx) = watch::channel(Readiness::Pending);
         let (_stop_tx, mut stop_rx) = shutdown_channel();
         let deps = vec![(name("db"), rx)];
 
@@ -436,19 +512,18 @@ mod tests {
         });
 
         tokio::task::yield_now().await;
-        tx.send(ServiceState::Starting).expect("receiver alive");
-        tx.send(ServiceState::Running).expect("receiver alive");
+        tx.send(Readiness::Ready).expect("receiver alive");
 
         assert!(waiter.await.expect("task"));
     }
 
     #[tokio::test]
     async fn a_failed_dependency_blocks_the_dependent() {
-        let (tx, rx) = watch::channel(ServiceState::Pending);
+        let (tx, rx) = watch::channel(Readiness::Pending);
         let (_stop_tx, mut stop_rx) = shutdown_channel();
         let deps = vec![(name("db"), rx)];
 
-        tx.send(ServiceState::Failed).expect("receiver alive");
+        tx.send(Readiness::Gone).expect("receiver alive");
 
         assert!(matches!(
             wait_for_dependencies(&deps, &mut stop_rx).await,
@@ -456,9 +531,88 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn readiness_follows_the_process_when_there_is_no_health_check() {
+        let mut tracker = ReadinessTracker::new(false);
+        assert_eq!(
+            tracker.observe(&EventKind::State(ServiceState::Running)),
+            Some(Readiness::Ready)
+        );
+        assert_eq!(
+            tracker.observe(&EventKind::State(ServiceState::Backoff)),
+            None
+        );
+        assert_eq!(
+            tracker.observe(&EventKind::State(ServiceState::Failed)),
+            Some(Readiness::Gone)
+        );
+    }
+
+    #[test]
+    fn a_health_checked_service_is_only_ready_once_a_probe_passes() {
+        let mut tracker = ReadinessTracker::new(true);
+        assert_eq!(
+            tracker.observe(&EventKind::State(ServiceState::Running)),
+            None
+        );
+        assert_eq!(tracker.observe(&EventKind::Healthy), Some(Readiness::Ready));
+        assert_eq!(
+            tracker.observe(&EventKind::Unhealthy {
+                message: "boom".to_string()
+            }),
+            Some(Readiness::Pending)
+        );
+    }
+
+    #[test]
+    fn a_one_shot_dependency_counts_as_ready_once_it_exits() {
+        for gate in [false, true] {
+            let mut tracker = ReadinessTracker::new(gate);
+            assert_eq!(
+                tracker.observe(&EventKind::State(ServiceState::Exited)),
+                Some(Readiness::Ready)
+            );
+        }
+    }
+
+    #[test]
+    fn a_service_stopped_for_being_unhealthy_never_becomes_available() {
+        let mut tracker = ReadinessTracker::new(true);
+        assert_eq!(
+            tracker.observe(&EventKind::Unhealthy {
+                message: "boom".to_string()
+            }),
+            Some(Readiness::Pending)
+        );
+        assert_eq!(
+            tracker.observe(&EventKind::Exited {
+                reason: ExitReason::Unhealthy,
+                uptime: Duration::from_secs(1),
+            }),
+            None
+        );
+        assert_eq!(
+            tracker.observe(&EventKind::State(ServiceState::Exited)),
+            Some(Readiness::Gone)
+        );
+    }
+
+    #[test]
+    fn a_restart_resets_the_unhealthy_verdict() {
+        let mut tracker = ReadinessTracker::new(true);
+        tracker.observe(&EventKind::Unhealthy {
+            message: "boom".to_string(),
+        });
+        assert_eq!(
+            tracker.observe(&EventKind::State(ServiceState::Starting)),
+            None
+        );
+        assert_eq!(tracker.observe(&EventKind::Healthy), Some(Readiness::Ready));
+    }
+
     #[tokio::test]
     async fn shutdown_interrupts_the_dependency_wait() {
-        let (_tx, rx) = watch::channel(ServiceState::Pending);
+        let (_tx, rx) = watch::channel(Readiness::Pending);
         let (stop_tx, mut stop_rx) = shutdown_channel();
         let deps = vec![(name("db"), rx)];
 

--- a/crates/servicrab-core/src/runtime/stack_stub.rs
+++ b/crates/servicrab-core/src/runtime/stack_stub.rs
@@ -10,6 +10,17 @@ use crate::lifecycle::ShutdownReason;
 use crate::runtime::event::EventSender;
 use crate::runtime::{RunOutcome, ShutdownRx};
 
+/// Whether a service can be depended on yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Readiness {
+    /// Not available yet; keep waiting.
+    Pending,
+    /// Available: dependents may start.
+    Ready,
+    /// It will never become available.
+    Gone,
+}
+
 /// Options for a stack run.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StackOptions {

--- a/crates/servicrab-core/src/runtime/unix.rs
+++ b/crates/servicrab-core/src/runtime/unix.rs
@@ -26,6 +26,7 @@ use nix::unistd::Pid;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::signal::unix::{signal, SignalKind};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::config::{RestartPolicy, Service, ShutdownSignal};
@@ -35,6 +36,7 @@ use crate::lifecycle::{
     StateMachine,
 };
 use crate::runtime::event::{EventKind, EventSink, Stream};
+use crate::runtime::health::{HealthMonitor, HealthSignal};
 use crate::runtime::{
     shutdown_channel, wait_for_shutdown, OutputMode, RunOptions, RunOutcome, ShutdownRx, ShutdownTx,
 };
@@ -192,6 +194,26 @@ enum Wake {
     Exited(ExitReason),
     /// A shutdown was requested.
     Signalled(ShutdownReason),
+    /// The service's health check gave up on it.
+    Unhealthy,
+}
+
+/// Wait for the health monitor to declare the service unhealthy.
+///
+/// Pends forever when the service has no health check, when failures are only
+/// reported (`on_unhealthy = "ignore"`), or once the monitor is gone: in those
+/// cases the process is only ever stopped by an exit or a shutdown request.
+async fn next_unhealthy(health: &mut Option<mpsc::UnboundedReceiver<HealthSignal>>, act: bool) {
+    match health {
+        Some(rx) if act => loop {
+            match rx.recv().await {
+                Some(signal) if signal.is_unhealthy() => return,
+                Some(_) => continue,
+                None => std::future::pending().await,
+            }
+        },
+        _ => std::future::pending().await,
+    }
 }
 
 /// SIGINT/SIGTERM handling for the current process.
@@ -427,6 +449,16 @@ impl<'a> ServiceRunner<'a> {
 
             let readers = self.spawn_readers(&mut handle);
 
+            // The monitor lives exactly as long as this process run: dropping
+            // the receiver at the end of the iteration stops the probing task.
+            let mut health = HealthMonitor::for_service(self.service, self.events.clone())
+                .map(HealthMonitor::spawn);
+            let act_on_unhealthy = self
+                .service
+                .health
+                .as_ref()
+                .is_some_and(crate::runtime::health::stops_process);
+
             self.transition(ServiceState::Running)?;
             self.emit(EventKind::Started {
                 pgid: handle.pgid(),
@@ -438,6 +470,7 @@ impl<'a> ServiceRunner<'a> {
             let wake = tokio::select! {
                 result = handle.wait(&name) => Wake::Exited(result?),
                 reason = wait_for_shutdown(shutdown) => Wake::Signalled(reason),
+                () = next_unhealthy(&mut health, act_on_unhealthy) => Wake::Unhealthy,
             };
 
             let (reason, stopped_by) = match wake {
@@ -446,6 +479,15 @@ impl<'a> ServiceRunner<'a> {
                     self.emit(EventKind::Stopping { reason: why });
                     let reason = self.shutdown(&mut handle, why, shutdown).await?;
                     (reason, Some(why))
+                }
+                // An unhealthy service is stopped like any other, but the
+                // outcome is fed to the restart policy instead of ending the
+                // supervision loop.
+                Wake::Unhealthy => {
+                    let why = ShutdownReason::Unhealthy;
+                    self.emit(EventKind::Stopping { reason: why });
+                    self.shutdown(&mut handle, why, shutdown).await?;
+                    (ExitReason::Unhealthy, None)
                 }
             };
 

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -8,11 +8,12 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::config::{
-    Config, Project, ProjectName, RestartPolicy, Service, ServiceName, ShutdownSignal,
+    Config, HealthCheck, HealthProbe, Project, ProjectName, RestartPolicy, Service, ServiceName,
+    ShutdownSignal, UnhealthyAction,
 };
 use crate::error::{ConfigError, ConfigWarning};
 use crate::graph::topological_sort;
-use crate::raw::{RawConfig, RawRestartPolicy};
+use crate::raw::{RawConfig, RawHealthCheck, RawRestartPolicy};
 
 /// The only supported schema version.
 const SUPPORTED_VERSION: u32 = 1;
@@ -165,6 +166,11 @@ pub fn validate_raw(
             &mut errors,
         );
 
+        let health = raw_svc
+            .health
+            .as_ref()
+            .and_then(|raw_health| validate_health(raw_health, raw_name, &mut errors));
+
         // restart_max_delay >= restart_delay
         if restart_max_delay < restart_delay {
             errors.push(ConfigError::RestartMaxDelayTooSmall {
@@ -225,6 +231,7 @@ pub fn validate_raw(
                 stable_after,
                 shutdown_signal,
                 shutdown_timeout,
+                health,
             },
         );
     }
@@ -488,6 +495,221 @@ fn parse_duration_field(
     dur
 }
 
+// ── Health-check validation ────────────────────────────────────────────────
+
+/// Validate a `[services.<name>.health]` table.
+///
+/// Returns `None` (after pushing errors) when the table is unusable.
+fn validate_health(
+    raw: &RawHealthCheck,
+    service: &str,
+    errors: &mut Vec<ConfigError>,
+) -> Option<HealthCheck> {
+    let declared: Vec<&'static str> = [
+        raw.command.is_some().then_some("command"),
+        raw.http.is_some().then_some("http"),
+        raw.tcp.is_some().then_some("tcp"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    let probe = match declared.as_slice() {
+        [] => {
+            errors.push(ConfigError::MissingHealthProbe {
+                service: service.to_string(),
+            });
+            None
+        }
+        [_] => build_probe(raw, service, errors),
+        _ => {
+            errors.push(ConfigError::ConflictingHealthProbes {
+                service: service.to_string(),
+                probes: declared.join(", "),
+            });
+            None
+        }
+    };
+
+    let interval = parse_duration_field(
+        raw.interval.as_deref(),
+        "health.interval",
+        Duration::from_secs(2),
+        service,
+        DUR_100MS,
+        DUR_1H,
+        errors,
+    );
+    let timeout = parse_duration_field(
+        raw.timeout.as_deref(),
+        "health.timeout",
+        Duration::from_secs(5),
+        service,
+        DUR_100MS,
+        DUR_1H,
+        errors,
+    );
+    let start_period = parse_duration_field(
+        raw.start_period.as_deref(),
+        "health.start_period",
+        Duration::ZERO,
+        service,
+        Duration::ZERO,
+        DUR_24H,
+        errors,
+    );
+
+    let on_unhealthy = match raw.on_unhealthy.as_deref() {
+        None | Some("restart") => UnhealthyAction::Restart,
+        Some("ignore") => UnhealthyAction::Ignore,
+        Some(other) => {
+            errors.push(ConfigError::InvalidUnhealthyAction {
+                service: service.to_string(),
+                value: other.to_string(),
+            });
+            UnhealthyAction::Restart
+        }
+    };
+
+    // `retries` is the number of consecutive failures needed to declare the
+    // service unhealthy, so it is always at least one probe.
+    let retries = raw.retries.unwrap_or(3).max(1);
+
+    Some(HealthCheck {
+        probe: probe?,
+        interval,
+        timeout,
+        retries,
+        start_period,
+        on_unhealthy,
+    })
+}
+
+/// Build the probe described by the (single) probe field that was set.
+fn build_probe(
+    raw: &RawHealthCheck,
+    service: &str,
+    errors: &mut Vec<ConfigError>,
+) -> Option<HealthProbe> {
+    let invalid =
+        |field: &'static str, value: &str, reason: &str| ConfigError::InvalidHealthProbe {
+            service: service.to_string(),
+            field,
+            value: value.to_string(),
+            reason: reason.to_string(),
+        };
+
+    if let Some(command) = &raw.command {
+        let Some(executable) = command.first() else {
+            errors.push(invalid("command", "", "the command must not be empty"));
+            return None;
+        };
+        if executable.is_empty() || command.iter().any(|part| part.contains('\0')) {
+            errors.push(invalid(
+                "command",
+                executable,
+                "the executable must not be empty and no argument may contain a NUL byte",
+            ));
+            return None;
+        }
+        return Some(HealthProbe::Command {
+            executable: executable.clone(),
+            args: command[1..].to_vec(),
+        });
+    }
+
+    if let Some(url) = &raw.http {
+        return match parse_http_url(url) {
+            Ok(probe) => Some(probe),
+            Err(reason) => {
+                errors.push(invalid("http", url, &reason));
+                None
+            }
+        };
+    }
+
+    if let Some(addr) = &raw.tcp {
+        return match parse_host_port(addr) {
+            Ok((host, port)) => Some(HealthProbe::Tcp { host, port }),
+            Err(reason) => {
+                errors.push(invalid("tcp", addr, &reason));
+                None
+            }
+        };
+    }
+
+    None
+}
+
+/// Parse an `http://host[:port][/path]` URL into an [`HealthProbe::Http`].
+///
+/// Only plaintext HTTP is supported; use a `command` probe (e.g. `curl`) for
+/// anything that needs TLS, redirects or authentication.
+fn parse_http_url(url: &str) -> Result<HealthProbe, String> {
+    let rest = url
+        .strip_prefix("http://")
+        .ok_or_else(|| match url.split_once("://") {
+            Some(("https", _)) => {
+                "https is not supported; use a `command` probe such as `curl -fsS <url>`"
+                    .to_string()
+            }
+            _ => "the URL must start with `http://`".to_string(),
+        })?;
+
+    let (authority, path) = match rest.find('/') {
+        Some(idx) => (&rest[..idx], &rest[idx..]),
+        None => (rest, "/"),
+    };
+    if authority.contains('@') {
+        return Err("credentials in the URL are not supported".to_string());
+    }
+
+    let (host, port) = match parse_host_port(authority) {
+        Ok(hp) => hp,
+        Err(_) if !authority.contains(':') => {
+            if authority.is_empty() {
+                return Err("the URL has no host".to_string());
+            }
+            (authority.to_string(), 80)
+        }
+        Err(reason) => return Err(reason),
+    };
+
+    Ok(HealthProbe::Http {
+        url: url.to_string(),
+        host,
+        port,
+        path: path.to_string(),
+    })
+}
+
+/// Parse a `host:port` pair, accepting `[::1]:port` for IPv6 literals.
+fn parse_host_port(addr: &str) -> Result<(String, u16), String> {
+    let (host, port) = if let Some(rest) = addr.strip_prefix('[') {
+        let (host, rest) = rest
+            .split_once(']')
+            .ok_or_else(|| "unterminated IPv6 literal".to_string())?;
+        let port = rest
+            .strip_prefix(':')
+            .ok_or_else(|| "expected `[host]:port`".to_string())?;
+        (host, port)
+    } else {
+        addr.rsplit_once(':')
+            .ok_or_else(|| "expected `host:port`".to_string())?
+    };
+
+    if host.is_empty() {
+        return Err("the host must not be empty".to_string());
+    }
+    let port: u16 = port
+        .parse()
+        .map_err(|_| format!("{port:?} is not a valid port number"))?;
+    if port == 0 {
+        return Err("the port must not be zero".to_string());
+    }
+    Ok((host.to_string(), port))
+}
+
 // ── Shutdown signal parsing ────────────────────────────────────────────────
 
 fn parse_shutdown_signal(
@@ -558,11 +780,251 @@ mod tests {
     }
 
     /// Like `load_from_str` but expects exactly one error.
-    #[allow(dead_code)]
     fn expect_one_error(toml: &str) -> ConfigError {
         let errs = load_from_str(toml).unwrap_err();
         assert_eq!(errs.len(), 1, "expected 1 error, got: {errs:?}");
         errs.into_iter().next().unwrap()
+    }
+
+    // ── Health checks ──────────────────────────────────────────────────────
+
+    /// A config with a single service carrying the given `[health]` body.
+    fn with_health(body: &str) -> String {
+        format!(
+            r#"
+version = 1
+[project]
+name = "p"
+[services.api]
+command = ["echo", "hi"]
+[services.api.health]
+{body}
+"#
+        )
+    }
+
+    #[test]
+    fn a_health_check_defaults_are_applied() {
+        let (cfg, _) = load_from_str(&with_health(r#"tcp = "127.0.0.1:5432""#)).unwrap();
+        let health = cfg
+            .services
+            .values()
+            .next()
+            .unwrap()
+            .health
+            .clone()
+            .unwrap();
+        assert_eq!(
+            health.probe,
+            HealthProbe::Tcp {
+                host: "127.0.0.1".to_string(),
+                port: 5432
+            }
+        );
+        assert_eq!(health.interval, Duration::from_secs(2));
+        assert_eq!(health.timeout, Duration::from_secs(5));
+        assert_eq!(health.retries, 3);
+        assert_eq!(health.start_period, Duration::ZERO);
+        assert_eq!(health.on_unhealthy, UnhealthyAction::Restart);
+    }
+
+    #[test]
+    fn a_health_check_can_override_every_field() {
+        let toml = with_health(
+            r#"command = ["curl", "-fsS", "http://localhost/health"]
+interval = "500ms"
+timeout = "1s"
+retries = 7
+start_period = "10s"
+on_unhealthy = "ignore""#,
+        );
+        let (cfg, _) = load_from_str(&toml).unwrap();
+        let health = cfg
+            .services
+            .values()
+            .next()
+            .unwrap()
+            .health
+            .clone()
+            .unwrap();
+        assert_eq!(
+            health.probe,
+            HealthProbe::Command {
+                executable: "curl".to_string(),
+                args: vec!["-fsS".to_string(), "http://localhost/health".to_string()],
+            }
+        );
+        assert_eq!(health.interval, Duration::from_millis(500));
+        assert_eq!(health.timeout, Duration::from_secs(1));
+        assert_eq!(health.retries, 7);
+        assert_eq!(health.start_period, Duration::from_secs(10));
+        assert_eq!(health.on_unhealthy, UnhealthyAction::Ignore);
+    }
+
+    #[test]
+    fn an_http_probe_is_split_into_host_port_and_path() {
+        let (cfg, _) = load_from_str(&with_health(
+            r#"http = "http://127.0.0.1:8080/healthz?full=1""#,
+        ))
+        .unwrap();
+        let health = cfg
+            .services
+            .values()
+            .next()
+            .unwrap()
+            .health
+            .clone()
+            .unwrap();
+        assert_eq!(
+            health.probe,
+            HealthProbe::Http {
+                url: "http://127.0.0.1:8080/healthz?full=1".to_string(),
+                host: "127.0.0.1".to_string(),
+                port: 8080,
+                path: "/healthz?full=1".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn an_http_probe_defaults_to_port_80_and_root() {
+        let (cfg, _) = load_from_str(&with_health(r#"http = "http://example.test""#)).unwrap();
+        let health = cfg
+            .services
+            .values()
+            .next()
+            .unwrap()
+            .health
+            .clone()
+            .unwrap();
+        assert_eq!(
+            health.probe,
+            HealthProbe::Http {
+                url: "http://example.test".to_string(),
+                host: "example.test".to_string(),
+                port: 80,
+                path: "/".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn https_health_urls_are_rejected_with_a_hint() {
+        let err = expect_one_error(&with_health(r#"http = "https://example.test/health""#));
+        let msg = err.to_string();
+        assert!(msg.contains("https is not supported"), "{msg}");
+    }
+
+    #[test]
+    fn a_health_table_without_a_probe_is_rejected() {
+        let err = expect_one_error(&with_health(r#"interval = "1s""#));
+        assert!(
+            matches!(err, ConfigError::MissingHealthProbe { .. }),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_health_table_with_two_probes_is_rejected() {
+        let err = expect_one_error(&with_health(
+            r#"tcp = "127.0.0.1:5432"
+http = "http://127.0.0.1:8080/""#,
+        ));
+        let msg = err.to_string();
+        assert!(msg.contains("http, tcp"), "{msg}");
+    }
+
+    #[test]
+    fn a_malformed_tcp_probe_is_rejected() {
+        for (addr, needle) in [
+            (r#"tcp = "127.0.0.1""#, "expected `host:port`"),
+            (r#"tcp = "127.0.0.1:0""#, "must not be zero"),
+            (r#"tcp = "127.0.0.1:https""#, "not a valid port"),
+            (r#"tcp = ":5432""#, "host must not be empty"),
+        ] {
+            let err = expect_one_error(&with_health(addr));
+            let msg = err.to_string();
+            assert!(msg.contains(needle), "{addr}: {msg}");
+        }
+    }
+
+    #[test]
+    fn an_ipv6_tcp_probe_is_accepted() {
+        let (cfg, _) = load_from_str(&with_health(r#"tcp = "[::1]:6379""#)).unwrap();
+        let health = cfg
+            .services
+            .values()
+            .next()
+            .unwrap()
+            .health
+            .clone()
+            .unwrap();
+        assert_eq!(
+            health.probe,
+            HealthProbe::Tcp {
+                host: "::1".to_string(),
+                port: 6379
+            }
+        );
+    }
+
+    #[test]
+    fn an_empty_probe_command_is_rejected() {
+        let err = expect_one_error(&with_health("command = []"));
+        assert!(
+            matches!(err, ConfigError::InvalidHealthProbe { .. }),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_on_unhealthy_action_is_rejected() {
+        let err = expect_one_error(&with_health(
+            r#"tcp = "127.0.0.1:5432"
+on_unhealthy = "explode""#,
+        ));
+        assert!(
+            matches!(err, ConfigError::InvalidUnhealthyAction { .. }),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn an_out_of_range_health_interval_is_rejected() {
+        let err = expect_one_error(&with_health(
+            r#"tcp = "127.0.0.1:5432"
+interval = "10ms""#,
+        ));
+        let msg = err.to_string();
+        assert!(msg.contains("health.interval"), "{msg}");
+    }
+
+    #[test]
+    fn zero_retries_are_normalised_to_one() {
+        let (cfg, _) = load_from_str(&with_health(
+            r#"tcp = "127.0.0.1:5432"
+retries = 0"#,
+        ))
+        .unwrap();
+        let health = cfg
+            .services
+            .values()
+            .next()
+            .unwrap()
+            .health
+            .clone()
+            .unwrap();
+        assert_eq!(health.retries, 1);
+    }
+
+    #[test]
+    fn an_unknown_health_field_is_rejected() {
+        let toml = with_health(
+            r#"tcp = "127.0.0.1:5432"
+retires = 3"#,
+        );
+        let raw: Result<RawConfig, _> = toml::from_str(&toml);
+        assert!(raw.is_err(), "unknown health fields must not be accepted");
     }
 
     // ── Minimal valid config ───────────────────────────────────────────────
@@ -764,6 +1226,7 @@ command = ["echo"]
                         stable_after: None,
                         shutdown_signal: None,
                         shutdown_timeout: None,
+                        health: None,
                     },
                 );
                 m
@@ -1118,6 +1581,7 @@ restart_delay = "2s"
                 stable_after: None,
                 shutdown_signal: None,
                 shutdown_timeout: None,
+                health: None,
             },
         );
         RawConfig {


### PR DESCRIPTION
Third milestone: services can describe what "up" actually means, and the stack supervisor uses that instead of "the process exists".

## Config

```toml
[services.db.health]
tcp = "127.0.0.1:5432"        # or: http = "http://…", command = ["…"]
interval = "2s"               # default 2s
timeout = "5s"                # default 5s
retries = 3                   # consecutive failures before unhealthy
start_period = "10s"          # failures ignored while starting up
on_unhealthy = "restart"      # restart (default) | ignore
```

Exactly one probe per block; everything is validated up front (`check` reports missing/conflicting probes, malformed `host:port`, out-of-range durations, unknown actions). `https://` URLs are rejected with a hint to use a `command` probe, since the HTTP probe is deliberately dependency-free plain HTTP/1.1.

## Behaviour

**Readiness gating.** Dependents now wait on a `Readiness` signal derived from the event stream rather than the raw process state:

| Dependency | Available when |
|---|---|
| no health check | its process is up (as before) |
| health check | its first probe passes |
| one-shot job | it exited cleanly |
| stopped as unhealthy | never — dependents are skipped |

That last row was a real bug found by the new tests: an unhealthy service that stopped went through `ServiceState::Exited`, which the old mapping read as "one-shot finished, dependents may start".

**Liveness.** Probing continues for the life of the process. After `retries` consecutive failures the service is declared unhealthy; with the default `on_unhealthy = "restart"` it is stopped with its usual `shutdown_signal`/`shutdown_timeout` and the outcome (`ExitReason::Unhealthy`) is fed to the restart policy — so `restart = "never"` stops it for good and `on-failure`/`always` bring it back. `ignore` keeps probing and lets the service recover.

## Also in this PR

- `servicrab list` shows the configured probe in both the table and `--json`; `servicrab init` documents the whole block.
- `up` renders `✔ healthy`, `! health probe failed (n/m)` and `✗ unhealthy`.
- Logging defaults are now per command: `run` logs lifecycle transitions at info (they were invisible before), `up` stays quiet because its printer already shows the same events, and everything goes to **stderr** so stdout stays clean. `RUST_LOG` still wins.

## Tests

179 tests pass (`fmt`, `clippy -D warnings`, `test --workspace --all-features`): 18 new validation tests, 8 probe tests against real TCP/HTTP listeners and real commands, 5 readiness-mapping unit tests, and 7 integration tests covering gating on a slow dependency, skipping when a dependency never becomes healthy, restart-on-unhealthy, `ignore`, a TCP probe against a live listener, and the `list`/`check` output.