### PR TITLE
Log files + `servicrab logs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - `servicrab run <service>` — supervise a single service in the foreground with live stdout/stderr, restart policy, and process-group shutdown (Linux/macOS)
 - `servicrab up` — run your whole stack in the foreground: dependency-ordered start, interleaved and colour-prefixed output, reverse-order shutdown (Linux/macOS)
 - Health checks: `command`, `http` and `tcp` probes with readiness gating and automatic restart of unhealthy services
+- Log files: opt-in per-service capture with size-based rotation, plus `servicrab logs [-f]` to read and follow them
 - Restart policies: `never`, `on-failure`, `always`, with exponential backoff
 - Per-service environment variables and working directories
 - Dependency declarations and a deterministic start order
@@ -121,6 +122,7 @@ if you want shell semantics.
 | `servicrab list [--config PATH] [--json]` | List all services with their restart policies |
 | `servicrab run <SERVICE> [--config PATH] [--no-restart]` | Supervise one service in the foreground |
 | `servicrab up [SERVICE...] [--config PATH] [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure]` | Supervise a whole stack in the foreground |
+| `servicrab logs [SERVICE...] [--config PATH] [-f] [-n N] [--no-prefix]` | Show (and follow) the captured log files |
 
 If `--config` is omitted, Servicrab discovers `servicrab.toml` by walking up
 from the current directory.
@@ -299,7 +301,6 @@ backend, and the run is reported as failed.
 `servicrab up` supports **Linux and macOS**. Current limitations:
 
 - no background daemon: `up` runs in the foreground and stops with your shell;
-- no log files or log rotation — redirect the output yourself;
 - no `--json` event stream yet;
 - `servicrab down` does not exist yet (Ctrl+C is the way to stop a stack).
 
@@ -349,6 +350,46 @@ command = ["./scripts/queue-ok.sh"]      # healthy when it exits with code 0
 
 Failures during `start_period` never count, which gives slow starters time to
 come up without burning their retry budget.
+
+---
+
+## Log files
+
+Add a `[project.logs]` table and servicrab keeps a copy of everything its
+services write:
+
+```toml
+[project.logs]
+dir = ".servicrab/logs"   # relative paths resolve next to servicrab.toml
+max_size = "10MB"         # rotate once a file grows past this (default 10MB)
+max_files = 3             # how many rotated generations to keep (default 3)
+
+[services.noisy.logs]
+enabled = false           # this one service is not written to disk
+```
+
+Every service gets its own `<dir>/<service>.log`. When a file crosses
+`max_size` it is rotated to `<service>.log.1`, the previous `.1` becomes `.2`,
+and so on up to `max_files`; anything older is deleted. `max_files = 0` simply
+truncates the file instead of keeping history.
+
+Both `servicrab up` and `servicrab run` write these files, and neither changes
+what you see in the terminal — the files are a copy, not a redirect.
+
+Read them back with `logs`:
+
+```bash
+servicrab logs                 # last 50 lines of every service, prefixed
+servicrab logs api -n 200      # last 200 lines of one service, unprefixed
+servicrab logs -f              # follow new output (Ctrl+C to stop)
+```
+
+`logs -f` notices rotation and keeps following the fresh file. Without a
+`[project.logs]` table the command tells you how to enable capture rather than
+printing nothing.
+
+Sizes accept `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB` and `TB`/`TiB` suffixes;
+all of them are powers of 1024.
 
 ---
 
@@ -410,16 +451,20 @@ cargo test -p servicrab-core config::tests
 - [x] Readiness gating: dependents wait for a healthy dependency
 - [x] Unhealthy services are stopped and restarted by policy
 
+### Phase 1.8 (current) — Log files ✅
+- [x] Opt-in capture to `<dir>/<service>.log` with size-based rotation
+- [x] `servicrab logs [SERVICE...] [-f] [-n N]`
+- [x] Per-service opt-out via `[services.<name>.logs] enabled = false`
+
 ### Phase 2 — Background daemon
 - [ ] Background daemon process with Unix socket / named-pipe API
 - [ ] `servicrab start` / `stop` / `restart` / `status` commands
-- [ ] `servicrab logs <service>` — stream live logs
+- [ ] Live log streaming from the daemon
 
 ### Phase 3 — Stack management
 - [ ] `servicrab down` — stop a detached stack
 - [ ] `servicrab watch` — restart on file changes (à la `watchexec`)
 - [ ] `.env` file support per service
-- [ ] Health-check probes (HTTP + command)
 - [ ] Config hot-reload
 
 ### Phase 4 — Platform integration (optional)

--- a/crates/servicrab-cli/src/commands/init.rs
+++ b/crates/servicrab-cli/src/commands/init.rs
@@ -21,6 +21,15 @@ name = "my-project"
 # [project.env]
 # RUST_LOG = "info"
 
+# ── Log files ─────────────────────────────────────────────────────────────────
+# Uncomment to keep a copy of every service's output on disk.  Files are
+# rotated once they cross max_size:  api.log -> api.log.1 -> api.log.2 ...
+# Read them back with `servicrab logs [SERVICE] [-f] [-n N]`.
+# [project.logs]
+# dir = ".servicrab/logs"   # relative to this file (default)
+# max_size = "10MB"         # rotate above this size (default)
+# max_files = 3             # rotated generations to keep (default)
+
 # ── Services ──────────────────────────────────────────────────────────────────
 # Each [services.<name>] block defines one managed process.
 #
@@ -39,6 +48,10 @@ name = "my-project"
 #   stable_after          Consider stable after running this long (default: 60s)
 #   shutdown_signal       term | int | quit | hup  (default: term)
 #   shutdown_timeout      Wait this long before forcibly killing (default: 10s)
+#
+# Optional [services.<name>.logs] block:
+#   enabled       Write this service's output to a log file (default: true,
+#                 only has an effect when [project.logs] exists)
 #
 # Optional [services.<name>.health] block — exactly one probe:
 #   command       Probe command; exit code 0 means healthy

--- a/crates/servicrab-cli/src/commands/logs.rs
+++ b/crates/servicrab-cli/src/commands/logs.rs
@@ -1,0 +1,281 @@
+//! `servicrab logs [SERVICE...]` — read the captured service log files.
+//!
+//! Log files only exist when the config declares a `[project.logs]` table;
+//! without it this command explains how to turn file logging on rather than
+//! silently printing nothing.
+
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::time::Duration;
+
+use servicrab_core::{load, resolve_config_path, Config, LogRouter, ServiceName};
+
+use crate::style::{self, SERVICE_COLORS};
+
+/// How long to sleep between polls while following.
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Command-line options for `logs`.
+#[derive(Debug, Clone, Copy)]
+pub struct LogsOptions {
+    /// Keep printing new lines as they are written.
+    pub follow: bool,
+    /// How many trailing lines to show per service.
+    pub lines: usize,
+    /// Do not prefix output lines with the service name.
+    pub no_prefix: bool,
+}
+
+/// Build a [`LogRouter`] for a config, when file logging is enabled.
+///
+/// Services that set `[services.<name>.logs] enabled = false` are excluded.
+pub fn router_for(cfg: &Config) -> Option<LogRouter> {
+    let settings = cfg.project.logs.clone()?;
+    let excluded: Vec<ServiceName> = cfg
+        .services
+        .values()
+        .filter(|svc| !svc.log_to_file)
+        .map(|svc| svc.name.clone())
+        .collect();
+    Some(LogRouter::new(settings, excluded))
+}
+
+/// Run the `logs` subcommand.
+pub fn run(services: &[String], config: Option<&Path>, options: LogsOptions) -> Result<(), String> {
+    let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
+
+    let (cfg, _) = load(&path).map_err(|errors| {
+        let msgs: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
+        format!(
+            "✗ {} has {} error(s):\n{}",
+            path.display(),
+            errors.len(),
+            msgs.join("\n")
+        )
+    })?;
+
+    let Some(settings) = cfg.project.logs.clone() else {
+        return Err(format!(
+            "file logging is disabled: add a [project.logs] section to {} to capture service output",
+            path.display()
+        ));
+    };
+
+    let selected = select_services(&cfg, services)?;
+    let mut sources: Vec<Source> = Vec::new();
+    for name in &selected {
+        let file = settings.file_for(name);
+        let tail = read_tail(&file, options.lines)?;
+        sources.push(Source {
+            service: name.clone(),
+            path: file,
+            offset: 0,
+            tail,
+        });
+    }
+
+    if sources.iter().all(|s| s.tail.is_empty()) && !options.follow {
+        return Err(format!(
+            "no log output yet in {} — start the stack with `servicrab up` first",
+            settings.dir.display()
+        ));
+    }
+
+    let printer = Printer::new(&selected, options.no_prefix);
+    // Interleaving files by line count is meaningless, so each service's tail
+    // is printed as a block; following then merges new lines as they arrive.
+    for source in &mut sources {
+        for line in std::mem::take(&mut source.tail) {
+            printer.line(&source.service, &line);
+        }
+        source.offset = file_len(&source.path);
+    }
+
+    if options.follow {
+        follow(&mut sources, &printer)?;
+    }
+    Ok(())
+}
+
+/// Resolve the requested service names, defaulting to every service that logs.
+fn select_services(cfg: &Config, requested: &[String]) -> Result<Vec<ServiceName>, String> {
+    if requested.is_empty() {
+        let all: Vec<ServiceName> = cfg
+            .services
+            .values()
+            .filter(|svc| svc.log_to_file)
+            .map(|svc| svc.name.clone())
+            .collect();
+        if all.is_empty() {
+            return Err("every service has [logs] enabled = false".to_string());
+        }
+        return Ok(all);
+    }
+
+    let known: Vec<&str> = cfg.services.keys().map(|n| n.as_str()).collect();
+    let mut selected = Vec::new();
+    for name in requested {
+        let Some(svc) = cfg.services.values().find(|s| s.name.as_str() == name) else {
+            return Err(format!(
+                "unknown service {name:?}; known services: {}",
+                known.join(", ")
+            ));
+        };
+        if !svc.log_to_file {
+            return Err(format!(
+                "service {name:?} has [logs] enabled = false, so it has no log file"
+            ));
+        }
+        selected.push(svc.name.clone());
+    }
+    Ok(selected)
+}
+
+/// One followed log file.
+struct Source {
+    service: ServiceName,
+    path: std::path::PathBuf,
+    offset: u64,
+    tail: Vec<String>,
+}
+
+fn file_len(path: &Path) -> u64 {
+    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+}
+
+/// Read the last `count` lines of a file, tolerating a missing file.
+fn read_tail(path: &Path, count: usize) -> Result<Vec<String>, String> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(format!("could not read {}: {err}", path.display())),
+    };
+
+    let mut lines: std::collections::VecDeque<String> = std::collections::VecDeque::new();
+    for line in BufReader::new(file).lines() {
+        let line = line.map_err(|e| format!("could not read {}: {e}", path.display()))?;
+        if count > 0 && lines.len() == count {
+            lines.pop_front();
+        }
+        if count > 0 {
+            lines.push_back(line);
+        }
+    }
+    Ok(lines.into())
+}
+
+/// Print new lines as they are appended, until interrupted.
+fn follow(sources: &mut [Source], printer: &Printer) -> Result<(), String> {
+    loop {
+        let mut printed = false;
+        for source in sources.iter_mut() {
+            let len = file_len(&source.path);
+            // A shrinking file means the log was rotated; start over from the
+            // beginning of the fresh file so nothing is skipped.
+            if len < source.offset {
+                source.offset = 0;
+            }
+            if len == source.offset {
+                continue;
+            }
+
+            let mut file = match std::fs::File::open(&source.path) {
+                Ok(file) => file,
+                Err(_) => continue,
+            };
+            if file.seek(SeekFrom::Start(source.offset)).is_err() {
+                continue;
+            }
+            for line in BufReader::new(&mut file).lines() {
+                let Ok(line) = line else { break };
+                printer.line(&source.service, &line);
+                printed = true;
+            }
+            source.offset = len;
+        }
+
+        if !printed {
+            std::thread::sleep(POLL_INTERVAL);
+        }
+    }
+}
+
+/// Renders log lines with optional per-service prefixes.
+struct Printer {
+    colors: BTreeMap<ServiceName, &'static str>,
+    width: usize,
+    color: bool,
+    no_prefix: bool,
+}
+
+impl Printer {
+    fn new(services: &[ServiceName], no_prefix: bool) -> Self {
+        let colors = services
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), SERVICE_COLORS[i % SERVICE_COLORS.len()]))
+            .collect();
+        let width = services
+            .iter()
+            .map(|n| n.as_str().len())
+            .max()
+            .unwrap_or(0)
+            .min(20);
+        Self {
+            colors,
+            width,
+            color: style::color_enabled(),
+            // A single service needs no prefix to tell its lines apart.
+            no_prefix: no_prefix || services.len() < 2,
+        }
+    }
+
+    fn line(&self, service: &ServiceName, line: &str) {
+        let mut out = std::io::stdout().lock();
+        let _ = if self.no_prefix {
+            writeln!(out, "{line}")
+        } else {
+            let color = self.colors.get(service).copied().unwrap_or(style::RESET);
+            let label = format!("{:width$}", service.as_str(), width = self.width);
+            writeln!(out, "{} | {line}", style::paint(self.color, color, &label))
+        };
+        let _ = out.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn the_tail_of_a_missing_file_is_empty() {
+        let dir = TempDir::new().unwrap();
+        assert!(read_tail(&dir.path().join("nope.log"), 10)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn only_the_last_lines_are_returned() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.log");
+        std::fs::write(&path, "one\ntwo\nthree\nfour\n").unwrap();
+
+        assert_eq!(read_tail(&path, 2).unwrap(), vec!["three", "four"]);
+        assert_eq!(
+            read_tail(&path, 10).unwrap(),
+            vec!["one", "two", "three", "four"]
+        );
+    }
+
+    #[test]
+    fn zero_lines_returns_nothing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.log");
+        std::fs::write(&path, "one\ntwo\n").unwrap();
+
+        assert!(read_tail(&path, 0).unwrap().is_empty());
+    }
+}

--- a/crates/servicrab-cli/src/commands/mod.rs
+++ b/crates/servicrab-cli/src/commands/mod.rs
@@ -3,5 +3,6 @@
 pub mod check;
 pub mod init;
 pub mod list;
+pub mod logs;
 pub mod run;
 pub mod up;

--- a/crates/servicrab-cli/src/commands/run.rs
+++ b/crates/servicrab-cli/src/commands/run.rs
@@ -4,10 +4,14 @@
 //! This module only deals with user-facing output and exit-code mapping; all
 //! process handling lives in [`servicrab_core::runtime`].
 
+use std::io::Write;
 use std::path::Path;
 
 use servicrab_core::runtime::{lookup_service, OutputMode, RunOptions, RunOutcome};
-use servicrab_core::{load, resolve_config_path, ExitReason, ForegroundRunner, ShutdownReason};
+use servicrab_core::{
+    event_channel, load, resolve_config_path, EventKind, EventReceiver, ExitReason,
+    ForegroundRunner, LogRouter, ShutdownReason, Stream,
+};
 
 /// Exit code used when a run is cut short by Ctrl+C (`128 + SIGINT`).
 const EXIT_SIGINT: i32 = 130;
@@ -33,10 +37,35 @@ pub fn run(service: &str, config: Option<&Path>, no_restart: bool) -> Result<i32
     }
 
     let service = lookup_service(&cfg, service).map_err(|e| e.to_string())?;
+    let mut router = crate::commands::logs::router_for(&cfg);
+    if let Some(router) = router.as_ref() {
+        if !router.handles(&service.name) {
+            // The service opted out, so there is nothing to capture.
+            return foreground(service, no_restart, None);
+        }
+    } else {
+        return foreground(service, no_restart, None);
+    }
 
+    foreground(service, no_restart, router.take())
+}
+
+/// Run one service in the foreground, optionally teeing its output to a file.
+fn foreground(
+    service: &servicrab_core::Service,
+    no_restart: bool,
+    router: Option<LogRouter>,
+) -> Result<i32, String> {
+    // Without file logging the child inherits our stdio, which keeps colours,
+    // TTY detection, and back-pressure exactly as they would be without
+    // servicrab in the middle.
     let options = RunOptions {
         no_restart,
-        output: OutputMode::Inherit,
+        output: if router.is_some() {
+            OutputMode::Capture
+        } else {
+            OutputMode::Inherit
+        },
     };
     let mut runner = ForegroundRunner::new(service, options);
 
@@ -45,9 +74,49 @@ pub fn run(service: &str, config: Option<&Path>, no_restart: bool) -> Result<i32
         .build()
         .map_err(|e| format!("failed to start the async runtime: {e}"))?;
 
-    match runtime.block_on(runner.run()) {
+    let outcome = runtime.block_on(async move {
+        let Some(router) = router else {
+            return runner.run().await;
+        };
+
+        let (events_tx, events_rx) = event_channel();
+        let tee = tokio::spawn(tee_output(events_rx, router));
+        let outcome = runner
+            .with_events(servicrab_core::EventSink::new(events_tx))
+            .run()
+            .await;
+        // The runner held the last sender, so the tee finishes on its own.
+        let _ = tee.await;
+        outcome
+    });
+
+    match outcome {
         Ok(outcome) => Ok(exit_code(outcome)),
         Err(err) => Err(err.to_string()),
+    }
+}
+
+/// Echo captured output verbatim while copying it into the log file.
+async fn tee_output(mut events: EventReceiver, mut router: LogRouter) {
+    while let Some(event) = events.recv().await {
+        let EventKind::Log { stream, line } = &event.kind else {
+            continue;
+        };
+        if let Some(problem) = router.record(&event.service, line) {
+            eprintln!("⚠  {problem}");
+        }
+        match stream {
+            Stream::Stdout => {
+                let mut out = std::io::stdout().lock();
+                let _ = writeln!(out, "{line}");
+                let _ = out.flush();
+            }
+            Stream::Stderr => {
+                let mut err = std::io::stderr().lock();
+                let _ = writeln!(err, "{line}");
+                let _ = err.flush();
+            }
+        }
     }
 }
 

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use servicrab_core::runtime::stack::{ServiceResult, StackOptions, StackSupervisor};
 use servicrab_core::{
     event_channel, load, plan_stack, resolve_config_path, Config, EventKind, EventReceiver,
-    ServiceName, ShutdownReason, SignalWatcher, Stream,
+    LogRouter, ServiceName, ShutdownReason, SignalWatcher, Stream,
 };
 
 use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
@@ -62,6 +62,8 @@ pub fn run(services: &[String], config: Option<&Path>, options: UpOptions) -> Re
     let printer = Printer::new(&plan, options);
     printer.banner(&cfg, &plan);
 
+    let logs = crate::commands::logs::router_for(&cfg);
+
     let stack_options = StackOptions {
         no_restart: options.no_restart,
         abort_on_failure: options.abort_on_failure,
@@ -77,7 +79,7 @@ pub fn run(services: &[String], config: Option<&Path>, options: UpOptions) -> Re
         let mut shutdown = signals.subscribe();
 
         let (events_tx, events_rx) = event_channel();
-        let renderer = tokio::spawn(render(events_rx, printer));
+        let renderer = tokio::spawn(render(events_rx, printer, logs));
 
         let supervisor = StackSupervisor::new(&cfg, plan, stack_options, events_tx);
         let outcome = supervisor.run(&mut shutdown).await;
@@ -103,9 +105,19 @@ pub fn run(services: &[String], config: Option<&Path>, options: UpOptions) -> Re
     })
 }
 
-/// Drain the event stream, rendering everything as it arrives.
-async fn render(mut events: EventReceiver, printer: Printer) -> Printer {
+/// Drain the event stream, rendering everything as it arrives and copying
+/// captured output to the log files when file logging is enabled.
+async fn render(
+    mut events: EventReceiver,
+    printer: Printer,
+    mut logs: Option<LogRouter>,
+) -> Printer {
     while let Some(event) = events.recv().await {
+        if let (Some(router), EventKind::Log { line, .. }) = (logs.as_mut(), &event.kind) {
+            if let Some(problem) = router.record(&event.service, line) {
+                printer.warn(&problem);
+            }
+        }
         printer.event(&event.service, &event.kind);
     }
     printer
@@ -233,6 +245,13 @@ impl Printer {
             self.prefix(service),
             style::paint(self.color, DIM, &format!("{symbol} {message}"))
         );
+        let _ = err.flush();
+    }
+
+    /// Report a problem with the supervisor itself (not with a service).
+    fn warn(&self, message: &str) {
+        let mut err = std::io::stderr().lock();
+        let _ = writeln!(err, "⚠  {message}");
         let _ = err.flush();
     }
 

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -116,6 +116,31 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         abort_on_failure: bool,
     },
+
+    /// Show the captured log files of one or more services.  Requires a
+    /// [project.logs] section in the configuration.
+    Logs {
+        /// Services to show.  With no names, every service that writes log
+        /// files is shown.
+        services: Vec<String>,
+
+        /// Path to the configuration file.  If omitted, discovers
+        /// servicrab.toml by walking up from the current directory.
+        #[arg(long, short = 'c')]
+        config: Option<std::path::PathBuf>,
+
+        /// Keep printing new lines as they are written.
+        #[arg(long, short = 'f', default_value_t = false)]
+        follow: bool,
+
+        /// Number of trailing lines to show per service.
+        #[arg(long, short = 'n', default_value_t = 50)]
+        lines: usize,
+
+        /// Do not prefix output lines with the service name.
+        #[arg(long, default_value_t = false)]
+        no_prefix: bool,
+    },
 }
 
 fn main() {
@@ -168,6 +193,22 @@ fn main() {
                 abort_on_failure,
             },
         ),
+        Commands::Logs {
+            services,
+            config,
+            follow,
+            lines,
+            no_prefix,
+        } => commands::logs::run(
+            &services,
+            config.as_deref(),
+            commands::logs::LogsOptions {
+                follow,
+                lines,
+                no_prefix,
+            },
+        )
+        .map(|()| 0),
     };
 
     match result {

--- a/crates/servicrab-cli/tests/logs.rs
+++ b/crates/servicrab-cli/tests/logs.rs
@@ -1,0 +1,460 @@
+//! Integration tests for file logging and `servicrab logs`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
+use tempfile::TempDir;
+
+/// Upper bound for any wait in this file; keeps a hung test from stalling CI.
+const CEILING: Duration = Duration::from_secs(10);
+
+fn script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+fn config(dir: &Path, toml: &str) -> PathBuf {
+    let path = dir.join("servicrab.toml");
+    fs::write(&path, toml).unwrap();
+    path
+}
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+/// Run any subcommand to completion and return `(exit code, stdout, stderr)`.
+fn cli(args: &[&str], config_path: &Path) -> (i32, String, String) {
+    let output = Command::new(binary())
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn spawn(args: &[&str], config_path: &Path) -> Child {
+    Command::new(binary())
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn servicrab")
+}
+
+fn wait_for_file(path: &Path) {
+    let deadline = Instant::now() + CEILING;
+    while Instant::now() < deadline {
+        if fs::metadata(path).map(|m| m.len() > 0).unwrap_or(false) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
+fn wait_bounded(child: &mut Child) -> i32 {
+    let deadline = Instant::now() + CEILING;
+    loop {
+        match child.try_wait().unwrap() {
+            Some(status) => return status.code().unwrap_or(-1),
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("servicrab did not exit within {CEILING:?}");
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    }
+}
+
+fn interrupt(child: &Child) {
+    kill(Pid::from_raw(child.id() as i32), Signal::SIGINT).unwrap();
+}
+
+#[test]
+fn up_writes_one_log_file_per_service() {
+    let dir = TempDir::new().unwrap();
+    let hello = script(dir.path(), "hello.sh", "echo hello from api");
+    let bye = script(dir.path(), "bye.sh", "echo hello from web");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+[services.api]
+command = ["{}"]
+restart = "never"
+[services.web]
+command = ["{}"]
+restart = "never"
+"#,
+            hello.display(),
+            bye.display()
+        ),
+    );
+
+    let (code, _, _) = cli(&["up"], &cfg);
+    assert_eq!(code, 0);
+
+    let logs = dir.path().join(".servicrab/logs");
+    let api = fs::read_to_string(logs.join("api.log")).unwrap();
+    let web = fs::read_to_string(logs.join("web.log")).unwrap();
+
+    assert!(api.contains("hello from api"), "{api}");
+    assert!(web.contains("hello from web"), "{web}");
+    // Each service owns its own file; nothing leaks across.
+    assert!(!api.contains("hello from web"), "{api}");
+}
+
+#[test]
+fn a_service_can_opt_out_of_file_logging() {
+    let dir = TempDir::new().unwrap();
+    let noisy = script(dir.path(), "noisy.sh", "echo secret");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+[services.api]
+command = ["{}"]
+restart = "never"
+[services.api.logs]
+enabled = false
+"#,
+            noisy.display()
+        ),
+    );
+
+    let (code, stdout, _) = cli(&["up"], &cfg);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("secret"), "{stdout}");
+    assert!(!dir.path().join("logs/api.log").exists());
+}
+
+#[test]
+fn without_a_logs_table_nothing_is_written() {
+    let dir = TempDir::new().unwrap();
+    let hello = script(dir.path(), "hello.sh", "echo hi");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "never"
+"#,
+            hello.display()
+        ),
+    );
+
+    let (code, _, _) = cli(&["up"], &cfg);
+    assert_eq!(code, 0);
+    assert!(!dir.path().join(".servicrab").exists());
+}
+
+#[test]
+fn oversized_logs_are_rotated() {
+    let dir = TempDir::new().unwrap();
+    // Each iteration writes ~100 bytes, so 40 of them cross the 1KB threshold
+    // several times over.
+    let chatty = script(
+        dir.path(),
+        "chatty.sh",
+        "i=0\nwhile [ $i -lt 40 ]; do echo \"line $i aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"; i=$((i+1)); done",
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+max_size = "1KB"
+max_files = 2
+[services.api]
+command = ["{}"]
+restart = "never"
+"#,
+            chatty.display()
+        ),
+    );
+
+    let (code, _, _) = cli(&["up"], &cfg);
+    assert_eq!(code, 0);
+
+    let logs = dir.path().join("logs");
+    assert!(logs.join("api.log").exists());
+    assert!(logs.join("api.log.1").exists(), "rotation did not happen");
+    assert!(logs.join("api.log.2").exists());
+    // max_files = 2 means the third generation is dropped.
+    assert!(!logs.join("api.log.3").exists());
+}
+
+#[test]
+fn logs_shows_the_last_lines() {
+    let dir = TempDir::new().unwrap();
+    let counter = script(
+        dir.path(),
+        "counter.sh",
+        "i=1\nwhile [ $i -le 10 ]; do echo \"line $i\"; i=$((i+1)); done",
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+[services.api]
+command = ["{}"]
+restart = "never"
+"#,
+            counter.display()
+        ),
+    );
+
+    assert_eq!(cli(&["up"], &cfg).0, 0);
+
+    let (code, stdout, _) = cli(&["logs", "-n", "3"], &cfg);
+    assert_eq!(code, 0);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines, vec!["line 8", "line 9", "line 10"], "{stdout}");
+}
+
+#[test]
+fn logs_prefixes_lines_when_several_services_are_shown() {
+    let dir = TempDir::new().unwrap();
+    let api = script(dir.path(), "api.sh", "echo from-api");
+    let web = script(dir.path(), "web.sh", "echo from-web");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+[services.api]
+command = ["{}"]
+restart = "never"
+[services.web]
+command = ["{}"]
+restart = "never"
+"#,
+            api.display(),
+            web.display()
+        ),
+    );
+
+    assert_eq!(cli(&["up"], &cfg).0, 0);
+
+    let (code, stdout, _) = cli(&["logs"], &cfg);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("api | from-api"), "{stdout}");
+    assert!(stdout.contains("web | from-web"), "{stdout}");
+
+    // Selecting a single service drops the prefix again.
+    let (_, stdout, _) = cli(&["logs", "api"], &cfg);
+    assert_eq!(stdout.trim(), "from-api");
+}
+
+#[test]
+fn logs_follows_new_output() {
+    let dir = TempDir::new().unwrap();
+    let ready = dir.path().join("ready");
+    let ticker = script(
+        dir.path(),
+        "ticker.sh",
+        &format!(
+            "echo first\necho started > {}\nsleep 0.4\necho second\nsleep 30",
+            ready.display()
+        ),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+[services.api]
+command = ["{}"]
+restart = "never"
+"#,
+            ticker.display()
+        ),
+    );
+
+    let mut stack = spawn(&["up"], &cfg);
+    wait_for_file(&ready);
+    wait_for_file(&dir.path().join("logs/api.log"));
+
+    let mut follower = spawn(&["logs", "-f", "-n", "1"], &cfg);
+    let mut reader = BufReader::new(follower.stdout.take().unwrap());
+    let mut seen = Vec::new();
+    let deadline = Instant::now() + CEILING;
+    while Instant::now() < deadline {
+        let mut line = String::new();
+        if reader.read_line(&mut line).unwrap_or(0) == 0 {
+            break;
+        }
+        seen.push(line.trim().to_string());
+        if seen.iter().any(|l| l == "second") {
+            break;
+        }
+    }
+
+    let _ = follower.kill();
+    let _ = follower.wait();
+    interrupt(&stack);
+    wait_bounded(&mut stack);
+
+    assert!(
+        seen.iter().any(|l| l == "first"),
+        "tail was not shown: {seen:?}"
+    );
+    assert!(
+        seen.iter().any(|l| l == "second"),
+        "new output was not followed: {seen:?}"
+    );
+}
+
+#[test]
+fn logs_explains_that_file_logging_is_off() {
+    let dir = TempDir::new().unwrap();
+    let hello = script(dir.path(), "hello.sh", "echo hi");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+"#,
+            hello.display()
+        ),
+    );
+
+    let (code, _, stderr) = cli(&["logs"], &cfg);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("[project.logs]"), "{stderr}");
+}
+
+#[test]
+fn logs_rejects_an_unknown_service() {
+    let dir = TempDir::new().unwrap();
+    let hello = script(dir.path(), "hello.sh", "echo hi");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+[services.api]
+command = ["{}"]
+"#,
+            hello.display()
+        ),
+    );
+
+    let (code, _, stderr) = cli(&["logs", "nope"], &cfg);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("unknown service"), "{stderr}");
+    assert!(stderr.contains("api"), "{stderr}");
+}
+
+#[test]
+fn logs_reports_when_nothing_has_been_captured_yet() {
+    let dir = TempDir::new().unwrap();
+    let hello = script(dir.path(), "hello.sh", "echo hi");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+[services.api]
+command = ["{}"]
+"#,
+            hello.display()
+        ),
+    );
+
+    let (code, _, stderr) = cli(&["logs"], &cfg);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("no log output yet"), "{stderr}");
+}
+
+#[test]
+fn run_also_writes_a_log_file_while_still_printing_output() {
+    let dir = TempDir::new().unwrap();
+    let hello = script(dir.path(), "hello.sh", "echo hello-from-run");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+[services.api]
+command = ["{}"]
+restart = "never"
+"#,
+            hello.display()
+        ),
+    );
+
+    let (code, stdout, _) = cli(&["run", "api"], &cfg);
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "hello-from-run");
+
+    let written = fs::read_to_string(dir.path().join("logs/api.log")).unwrap();
+    assert!(written.contains("hello-from-run"), "{written}");
+}

--- a/crates/servicrab-core/src/config.rs
+++ b/crates/servicrab-core/src/config.rs
@@ -108,6 +108,32 @@ impl std::fmt::Display for ShutdownSignal {
 
 // ── Project ────────────────────────────────────────────────────────────────
 
+/// Validated file-logging settings.
+///
+/// File logging is opt-in: it is only active when the config declares a
+/// `[project.logs]` table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LogSettings {
+    /// Absolute directory the log files are written to.
+    pub dir: PathBuf,
+    /// Rotate a service's log file once it grows past this many bytes.
+    pub max_size: u64,
+    /// How many rotated files to keep per service.
+    pub max_files: u32,
+}
+
+impl LogSettings {
+    /// Path of the active log file for `service`.
+    pub fn file_for(&self, service: &ServiceName) -> PathBuf {
+        self.dir.join(format!("{service}.log"))
+    }
+
+    /// Path of the `n`-th rotated file for `service` (1 is the most recent).
+    pub fn rotated_file_for(&self, service: &ServiceName, n: u32) -> PathBuf {
+        self.dir.join(format!("{service}.log.{n}"))
+    }
+}
+
 /// Validated project metadata.
 #[derive(Debug, Clone, Serialize)]
 pub struct Project {
@@ -115,6 +141,8 @@ pub struct Project {
     pub name: ProjectName,
     /// Project-level environment variables (as declared in `[project.env]`).
     pub env: BTreeMap<String, String>,
+    /// File-logging settings, when `[project.logs]` was declared.
+    pub logs: Option<LogSettings>,
 }
 
 // ── Health checks ──────────────────────────────────────────────────────────
@@ -240,6 +268,9 @@ pub struct Service {
     pub shutdown_timeout: Duration,
     /// Optional health check used for readiness gating and liveness.
     pub health: Option<HealthCheck>,
+    /// Whether this service's output is written to a log file (only relevant
+    /// when the project declares `[project.logs]`).
+    pub log_to_file: bool,
 }
 
 // ── Config ─────────────────────────────────────────────────────────────────

--- a/crates/servicrab-core/src/error.rs
+++ b/crates/servicrab-core/src/error.rs
@@ -145,6 +145,22 @@ pub enum ConfigError {
         reason: String,
     },
 
+    /// A malformed byte size in `[project.logs]`.
+    #[error("project.logs: invalid size {value:?} for field `{field}`: {reason}")]
+    InvalidSize {
+        field: &'static str,
+        value: String,
+        reason: String,
+    },
+
+    /// `[project.logs] max_files` is outside the supported range.
+    #[error("project.logs: max_files must be between 0 and 100, got {value}")]
+    InvalidMaxFiles { value: u32 },
+
+    /// The log directory could not be created.
+    #[error("project.logs: log directory {dir} could not be created: {reason}")]
+    InvalidLogDir { dir: PathBuf, reason: String },
+
     /// An unrecognised `on_unhealthy` action.
     #[error(
         "service {service:?}: unknown [health] on_unhealthy {value:?}; expected one of: restart, ignore"

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -32,8 +32,8 @@ pub mod validation;
 
 // Convenience re-exports.
 pub use config::{
-    Config, HealthCheck, HealthProbe, Project, ProjectName, RestartPolicy, Service, ServiceName,
-    ShutdownSignal, UnhealthyAction,
+    Config, HealthCheck, HealthProbe, LogSettings, Project, ProjectName, RestartPolicy, Service,
+    ServiceName, ShutdownSignal, UnhealthyAction,
 };
 pub use error::{ConfigError, ConfigWarning, RuntimeError};
 pub use lifecycle::{
@@ -43,6 +43,6 @@ pub use lifecycle::{
 pub use load::{discover_config, load, resolve_config_path};
 pub use runtime::{
     event_channel, plan_stack, EventKind, EventReceiver, EventSender, EventSink, ForegroundRunner,
-    OutputMode, RunOptions, RunOutcome, ServiceEvent, ServiceRunner, SignalWatcher, StackOptions,
-    StackOutcome, StackSupervisor, Stream,
+    LogRouter, LogWriter, OutputMode, RunOptions, RunOutcome, ServiceEvent, ServiceRunner,
+    SignalWatcher, StackOptions, StackOutcome, StackSupervisor, Stream,
 };

--- a/crates/servicrab-core/src/raw.rs
+++ b/crates/servicrab-core/src/raw.rs
@@ -36,6 +36,39 @@ pub struct RawProject {
     /// Project-level environment variables.
     #[serde(default)]
     pub env: BTreeMap<String, String>,
+
+    /// Optional file-logging settings (`[project.logs]`).
+    #[serde(default)]
+    pub logs: Option<RawLogs>,
+}
+
+/// Raw file-logging settings (`[project.logs]`).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawLogs {
+    /// Directory for the log files (relative paths resolve against the config
+    /// file's directory).  Defaults to `".servicrab/logs"`.
+    #[serde(default)]
+    pub dir: Option<String>,
+
+    /// Rotate a log file once it grows past this size, e.g. `"10MB"`.
+    /// Defaults to `"10MB"`.
+    #[serde(default)]
+    pub max_size: Option<String>,
+
+    /// How many rotated files to keep per service.  Defaults to `3`.
+    #[serde(default)]
+    pub max_files: Option<u32>,
+}
+
+/// Raw per-service logging settings (`[services.<name>.logs]`).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawServiceLogs {
+    /// Whether this service's output is written to a log file.  Defaults to
+    /// `true` when `[project.logs]` is present.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
 }
 
 /// Raw service configuration (`[services.<name>]`).
@@ -97,6 +130,10 @@ pub struct RawService {
     /// Optional health check (`[services.<name>.health]`).
     #[serde(default)]
     pub health: Option<RawHealthCheck>,
+
+    /// Optional per-service logging settings (`[services.<name>.logs]`).
+    #[serde(default)]
+    pub logs: Option<RawServiceLogs>,
 }
 
 /// Raw health-check configuration (`[services.<name>.health]`).

--- a/crates/servicrab-core/src/runtime/logs.rs
+++ b/crates/servicrab-core/src/runtime/logs.rs
@@ -1,0 +1,353 @@
+//! Writing service output to rotating log files.
+//!
+//! File logging is opt-in: it is active only when the config declares a
+//! `[project.logs]` table.  Each service gets `<dir>/<service>.log`; when a
+//! file grows past `max_size` it is rotated to `<service>.log.1`, the previous
+//! `.1` becomes `.2`, and anything beyond `max_files` is deleted.
+//!
+//! The writer is deliberately synchronous and line-oriented: supervised
+//! services produce modest volumes, and flushing every line means the log on
+//! disk is always current — including right after a crash.
+
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::config::{LogSettings, ServiceName};
+
+/// A rotating, append-only log file for one service.
+#[derive(Debug)]
+pub struct LogWriter {
+    path: PathBuf,
+    file: File,
+    size: u64,
+    max_size: u64,
+    max_files: u32,
+}
+
+impl LogWriter {
+    /// Open (or create) the log file for `service`.
+    ///
+    /// The parent directory is created when missing.
+    pub fn open(settings: &LogSettings, service: &ServiceName) -> std::io::Result<Self> {
+        fs::create_dir_all(&settings.dir)?;
+        let path = settings.file_for(service);
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let size = file.metadata().map(|m| m.len()).unwrap_or(0);
+        Ok(Self {
+            path,
+            file,
+            size,
+            max_size: settings.max_size,
+            max_files: settings.max_files,
+        })
+    }
+
+    /// Append one line, rotating first when the line would not fit.
+    pub fn write_line(&mut self, line: &str) -> std::io::Result<()> {
+        let needed = line.len() as u64 + 1;
+        // Rotating before the write keeps whole lines together, so a log file
+        // never ends mid-line.
+        if self.size > 0 && self.size + needed > self.max_size {
+            self.rotate()?;
+        }
+        self.file.write_all(line.as_bytes())?;
+        self.file.write_all(b"\n")?;
+        self.file.flush()?;
+        self.size += needed;
+        Ok(())
+    }
+
+    /// Rotate the current file out of the way and start a fresh one.
+    fn rotate(&mut self) -> std::io::Result<()> {
+        if self.max_files == 0 {
+            // No history is kept: start over from an empty file.
+            self.file = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&self.path)?;
+            self.size = 0;
+            return Ok(());
+        }
+
+        let rotated = |n: u32| rotated_path(&self.path, n);
+
+        // The oldest file falls off the end.
+        let oldest = rotated(self.max_files);
+        if oldest.exists() {
+            fs::remove_file(&oldest)?;
+        }
+        for n in (1..self.max_files).rev() {
+            let from = rotated(n);
+            if from.exists() {
+                fs::rename(&from, rotated(n + 1))?;
+            }
+        }
+        fs::rename(&self.path, rotated(1))?;
+
+        self.file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        self.size = 0;
+        Ok(())
+    }
+
+    /// Path of the file currently being written.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// `<path>.<n>` for rotated files.
+fn rotated_path(path: &Path, n: u32) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(format!(".{n}"));
+    PathBuf::from(name)
+}
+
+/// Fans service output out to one [`LogWriter`] per service.
+///
+/// Writers are opened lazily, so a service that never produces output does not
+/// leave an empty file behind.
+#[derive(Debug)]
+pub struct LogRouter {
+    settings: LogSettings,
+    writers: BTreeMap<ServiceName, LogWriter>,
+    /// Services that opted out of file logging.
+    excluded: Vec<ServiceName>,
+    /// Reported once, so a broken log directory does not spam the terminal.
+    reported_error: bool,
+}
+
+impl LogRouter {
+    /// Build a router for the given settings.
+    pub fn new(settings: LogSettings, excluded: Vec<ServiceName>) -> Self {
+        Self {
+            settings,
+            writers: BTreeMap::new(),
+            excluded,
+            reported_error: false,
+        }
+    }
+
+    /// Record one output line for `service`.
+    ///
+    /// Returns an error message the first time writing fails; later failures
+    /// are silent so a full disk cannot drown out the service's own output.
+    pub fn record(&mut self, service: &ServiceName, line: &str) -> Option<String> {
+        if self.excluded.contains(service) {
+            return None;
+        }
+
+        if !self.writers.contains_key(service) {
+            match LogWriter::open(&self.settings, service) {
+                Ok(writer) => {
+                    self.writers.insert(service.clone(), writer);
+                }
+                Err(err) => return self.report(format!("could not open a log file: {err}")),
+            }
+        }
+
+        let writer = self.writers.get_mut(service).expect("writer just inserted");
+        let failure = writer
+            .write_line(line)
+            .err()
+            .map(|err| format!("could not write to {}: {err}", writer.path.display()));
+        match failure {
+            Some(message) => self.report(message),
+            None => None,
+        }
+    }
+
+    fn report(&mut self, message: String) -> Option<String> {
+        if self.reported_error {
+            return None;
+        }
+        self.reported_error = true;
+        Some(message)
+    }
+
+    /// Whether this router writes a log file for `service`.
+    pub fn handles(&self, service: &ServiceName) -> bool {
+        !self.excluded.contains(service)
+    }
+
+    /// The settings this router writes with.
+    pub fn settings(&self) -> &LogSettings {
+        &self.settings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn settings(dir: &Path, max_size: u64, max_files: u32) -> LogSettings {
+        LogSettings {
+            dir: dir.to_path_buf(),
+            max_size,
+            max_files,
+        }
+    }
+
+    fn service(name: &str) -> ServiceName {
+        crate::validation::validate_service_name(name).expect("valid name")
+    }
+
+    #[test]
+    fn lines_are_appended_and_flushed() {
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), 1024, 3);
+        let name = service("api");
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+
+        writer.write_line("first").unwrap();
+        writer.write_line("second").unwrap();
+
+        let contents = fs::read_to_string(settings.file_for(&name)).unwrap();
+        assert_eq!(contents, "first\nsecond\n");
+    }
+
+    #[test]
+    fn an_existing_log_is_appended_to() {
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), 1024, 3);
+        let name = service("api");
+        fs::create_dir_all(dir.path()).unwrap();
+        fs::write(settings.file_for(&name), "old\n").unwrap();
+
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+        writer.write_line("new").unwrap();
+
+        let contents = fs::read_to_string(settings.file_for(&name)).unwrap();
+        assert_eq!(contents, "old\nnew\n");
+    }
+
+    #[test]
+    fn the_file_rotates_once_it_is_full() {
+        let dir = TempDir::new().unwrap();
+        // Room for exactly one 8-byte line ("1234567\n").
+        let settings = settings(dir.path(), 8, 2);
+        let name = service("api");
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+
+        writer.write_line("1234567").unwrap();
+        writer.write_line("abcdefg").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(settings.file_for(&name)).unwrap(),
+            "abcdefg\n"
+        );
+        assert_eq!(
+            fs::read_to_string(settings.rotated_file_for(&name, 1)).unwrap(),
+            "1234567\n"
+        );
+    }
+
+    #[test]
+    fn rotated_files_are_shifted_and_dropped() {
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), 8, 2);
+        let name = service("api");
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+
+        for line in ["aaaaaaa", "bbbbbbb", "ccccccc", "ddddddd"] {
+            writer.write_line(line).unwrap();
+        }
+
+        assert_eq!(
+            fs::read_to_string(settings.file_for(&name)).unwrap(),
+            "ddddddd\n"
+        );
+        assert_eq!(
+            fs::read_to_string(settings.rotated_file_for(&name, 1)).unwrap(),
+            "ccccccc\n"
+        );
+        assert_eq!(
+            fs::read_to_string(settings.rotated_file_for(&name, 2)).unwrap(),
+            "bbbbbbb\n"
+        );
+        assert!(
+            !settings.rotated_file_for(&name, 3).exists(),
+            "history beyond max_files must be deleted"
+        );
+    }
+
+    #[test]
+    fn max_files_zero_truncates_instead_of_keeping_history() {
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), 8, 0);
+        let name = service("api");
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+
+        writer.write_line("1234567").unwrap();
+        writer.write_line("abcdefg").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(settings.file_for(&name)).unwrap(),
+            "abcdefg\n"
+        );
+        assert!(!settings.rotated_file_for(&name, 1).exists());
+    }
+
+    #[test]
+    fn a_line_longer_than_the_limit_is_still_written_whole() {
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), 8, 1);
+        let name = service("api");
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+
+        writer
+            .write_line("this line is definitely too long")
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(settings.file_for(&name)).unwrap(),
+            "this line is definitely too long\n"
+        );
+    }
+
+    #[test]
+    fn the_router_writes_one_file_per_service() {
+        let dir = TempDir::new().unwrap();
+        let mut router = LogRouter::new(settings(dir.path(), 1024, 3), Vec::new());
+
+        assert!(router.record(&service("api"), "from api").is_none());
+        assert!(router.record(&service("db"), "from db").is_none());
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join("api.log")).unwrap(),
+            "from api\n"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("db.log")).unwrap(),
+            "from db\n"
+        );
+    }
+
+    #[test]
+    fn excluded_services_are_not_written_to_disk() {
+        let dir = TempDir::new().unwrap();
+        let mut router = LogRouter::new(settings(dir.path(), 1024, 3), vec![service("quiet")]);
+
+        router.record(&service("quiet"), "nothing to see");
+
+        assert!(!dir.path().join("quiet.log").exists());
+    }
+
+    #[test]
+    fn a_write_failure_is_reported_only_once() {
+        let dir = TempDir::new().unwrap();
+        // A file where the directory should be makes every open fail.
+        let blocked = dir.path().join("logs");
+        fs::write(&blocked, "not a directory").unwrap();
+        let mut router = LogRouter::new(settings(&blocked, 1024, 3), Vec::new());
+
+        assert!(router.record(&service("api"), "one").is_some());
+        assert!(router.record(&service("api"), "two").is_none());
+    }
+}

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -25,6 +25,7 @@ use crate::lifecycle::{ExitReason, ShutdownReason};
 pub mod event;
 #[cfg(unix)]
 pub mod health;
+pub mod logs;
 pub mod plan;
 
 #[cfg(unix)]
@@ -48,6 +49,7 @@ pub use event::{
 };
 #[cfg(unix)]
 pub use health::{HealthMonitor, HealthSignal};
+pub use logs::{LogRouter, LogWriter};
 pub use plan::{known_services, lookup_service, plan_stack};
 pub use stack::{
     Readiness, ServiceReport, ServiceResult, StackOptions, StackOutcome, StackSupervisor,

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -8,8 +8,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::config::{
-    Config, HealthCheck, HealthProbe, Project, ProjectName, RestartPolicy, Service, ServiceName,
-    ShutdownSignal, UnhealthyAction,
+    Config, HealthCheck, HealthProbe, LogSettings, Project, ProjectName, RestartPolicy, Service,
+    ServiceName, ShutdownSignal, UnhealthyAction,
 };
 use crate::error::{ConfigError, ConfigWarning};
 use crate::graph::topological_sort;
@@ -58,6 +58,13 @@ pub fn validate_raw(
 
     // ── 4. Project env ─────────────────────────────────────────────────────
     let project_env = validate_project_env(&raw.project.env, &mut errors);
+
+    // ── 4b. Project log settings ───────────────────────────────────────────
+    let logs = raw
+        .project
+        .logs
+        .as_ref()
+        .and_then(|raw_logs| validate_logs(raw_logs, &source_dir, &mut errors));
 
     // ── 5. At least one service ────────────────────────────────────────────
     if raw.services.is_empty() {
@@ -171,6 +178,8 @@ pub fn validate_raw(
             .as_ref()
             .and_then(|raw_health| validate_health(raw_health, raw_name, &mut errors));
 
+        let log_to_file = raw_svc.logs.as_ref().map_or(true, |logs| logs.enabled);
+
         // restart_max_delay >= restart_delay
         if restart_max_delay < restart_delay {
             errors.push(ConfigError::RestartMaxDelayTooSmall {
@@ -232,6 +241,7 @@ pub fn validate_raw(
                 shutdown_signal,
                 shutdown_timeout,
                 health,
+                log_to_file,
             },
         );
     }
@@ -280,6 +290,7 @@ pub fn validate_raw(
         project: Project {
             name: project_name.expect("project_name is Some when no errors"),
             env: project_env,
+            logs,
         },
         services,
         start_order,
@@ -493,6 +504,119 @@ fn parse_duration_field(
     }
 
     dur
+}
+
+// ── Log settings validation ────────────────────────────────────────────────
+
+/// Default log directory, relative to the config file.
+const DEFAULT_LOG_DIR: &str = ".servicrab/logs";
+/// Default rotation threshold.
+const DEFAULT_MAX_SIZE: u64 = 10 * 1024 * 1024;
+/// Smallest rotation threshold that still makes sense.
+const MIN_MAX_SIZE: u64 = 1024;
+/// Largest accepted rotation threshold (1 TiB).
+const MAX_MAX_SIZE: u64 = 1024 * 1024 * 1024 * 1024;
+
+/// Validate a `[project.logs]` table.
+fn validate_logs(
+    raw: &crate::raw::RawLogs,
+    source_dir: &Path,
+    errors: &mut Vec<ConfigError>,
+) -> Option<LogSettings> {
+    let dir = raw.dir.as_deref().unwrap_or(DEFAULT_LOG_DIR);
+    let dir = {
+        let candidate = PathBuf::from(dir);
+        if candidate.is_absolute() {
+            candidate
+        } else {
+            source_dir.join(candidate)
+        }
+    };
+
+    // Catching a file where a directory belongs here turns a confusing
+    // runtime write failure into a config error.
+    if dir.exists() && !dir.is_dir() {
+        errors.push(ConfigError::InvalidLogDir {
+            dir: dir.clone(),
+            reason: "exists but is not a directory".to_string(),
+        });
+        return None;
+    }
+
+    let max_size = match raw.max_size.as_deref() {
+        None => DEFAULT_MAX_SIZE,
+        Some(value) => match parse_size(value) {
+            Ok(size) if (MIN_MAX_SIZE..=MAX_MAX_SIZE).contains(&size) => size,
+            Ok(size) => {
+                errors.push(ConfigError::InvalidSize {
+                    field: "max_size",
+                    value: value.to_string(),
+                    reason: format!(
+                        "{size} bytes is outside the supported range ({MIN_MAX_SIZE} bytes to 1TB)"
+                    ),
+                });
+                DEFAULT_MAX_SIZE
+            }
+            Err(reason) => {
+                errors.push(ConfigError::InvalidSize {
+                    field: "max_size",
+                    value: value.to_string(),
+                    reason,
+                });
+                DEFAULT_MAX_SIZE
+            }
+        },
+    };
+
+    let max_files = raw.max_files.unwrap_or(3);
+    if max_files > 100 {
+        errors.push(ConfigError::InvalidMaxFiles { value: max_files });
+        return None;
+    }
+
+    Some(LogSettings {
+        dir,
+        max_size,
+        max_files,
+    })
+}
+
+/// Parse a byte size such as `"512"`, `"64KB"`, `"10 MB"` or `"1GiB"`.
+///
+/// Both SI-style (`KB`, `MB`, `GB`) and binary (`KiB`, `MiB`, `GiB`) suffixes
+/// are accepted and treated as powers of 1024, which is what people mean when
+/// they size a log file.
+pub(crate) fn parse_size(value: &str) -> Result<u64, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("the size must not be empty".to_string());
+    }
+
+    let split = trimmed
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(trimmed.len());
+    let (number, suffix) = trimmed.split_at(split);
+    let number: f64 = number
+        .parse()
+        .map_err(|_| format!("{number:?} is not a number"))?;
+    if number < 0.0 {
+        return Err("the size must not be negative".to_string());
+    }
+
+    let multiplier = match suffix.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1u64,
+        "k" | "kb" | "kib" => 1024,
+        "m" | "mb" | "mib" => 1024 * 1024,
+        "g" | "gb" | "gib" => 1024 * 1024 * 1024,
+        "t" | "tb" | "tib" => 1024u64 * 1024 * 1024 * 1024,
+        other => return Err(format!("unknown unit {other:?}; use B, KB, MB, GB or TB")),
+    };
+
+    let bytes = number * multiplier as f64;
+    if !bytes.is_finite() || bytes > u64::MAX as f64 {
+        return Err("the size is too large".to_string());
+    }
+    Ok(bytes as u64)
 }
 
 // ── Health-check validation ────────────────────────────────────────────────
@@ -784,6 +908,149 @@ mod tests {
         let errs = load_from_str(toml).unwrap_err();
         assert_eq!(errs.len(), 1, "expected 1 error, got: {errs:?}");
         errs.into_iter().next().unwrap()
+    }
+
+    // ── Log settings ───────────────────────────────────────────────────────
+
+    /// A config whose project carries the given `[project.logs]` body.
+    fn with_logs(body: &str, service_extra: &str) -> String {
+        format!(
+            r#"
+version = 1
+[project]
+name = "p"
+[project.logs]
+{body}
+[services.api]
+command = ["echo", "hi"]
+{service_extra}
+"#
+        )
+    }
+
+    /// The single service every log test declares.
+    fn api(cfg: &Config) -> &Service {
+        cfg.services.values().next().expect("one service")
+    }
+
+    #[test]
+    fn log_settings_default_to_a_project_local_directory() {
+        let (cfg, _) = load_from_str(&with_logs("", "")).unwrap();
+        let logs = cfg.project.logs.expect("logs enabled");
+
+        assert!(logs.dir.ends_with(".servicrab/logs"), "{:?}", logs.dir);
+        assert!(logs.dir.is_absolute());
+        assert_eq!(logs.max_size, 10 * 1024 * 1024);
+        assert_eq!(logs.max_files, 3);
+    }
+
+    #[test]
+    fn no_logs_table_means_no_file_logging() {
+        let (cfg, _) = load_from_str(
+            r#"
+version = 1
+[project]
+name = "p"
+[services.api]
+command = ["echo", "hi"]
+"#,
+        )
+        .unwrap();
+        assert!(cfg.project.logs.is_none());
+    }
+
+    #[test]
+    fn log_sizes_accept_si_and_binary_suffixes() {
+        assert_eq!(parse_size("512").unwrap(), 512);
+        assert_eq!(parse_size("1B").unwrap(), 1);
+        assert_eq!(parse_size("64KiB").unwrap(), 64 * 1024);
+        assert_eq!(parse_size("10 MB").unwrap(), 10 * 1024 * 1024);
+        assert_eq!(parse_size("1.5mb").unwrap(), 1024 * 1024 * 3 / 2);
+        assert_eq!(parse_size("2G").unwrap(), 2 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn log_sizes_reject_nonsense() {
+        assert!(parse_size("").is_err());
+        assert!(parse_size("MB").is_err());
+        assert!(parse_size("10 parsecs").is_err());
+    }
+
+    #[test]
+    fn an_unknown_size_unit_is_a_config_error() {
+        let err = expect_one_error(&with_logs(r#"max_size = "10 parsecs""#, ""));
+        assert!(
+            matches!(&err, ConfigError::InvalidSize { field, .. } if *field == "max_size"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_tiny_max_size_is_rejected() {
+        let err = expect_one_error(&with_logs(r#"max_size = "10""#, ""));
+        assert!(matches!(err, ConfigError::InvalidSize { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn too_many_rotated_files_are_rejected() {
+        let err = expect_one_error(&with_logs("max_files = 101", ""));
+        assert!(
+            matches!(err, ConfigError::InvalidMaxFiles { value: 101 }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn keeping_no_rotated_files_is_allowed() {
+        let (cfg, _) = load_from_str(&with_logs("max_files = 0", "")).unwrap();
+        assert_eq!(cfg.project.logs.unwrap().max_files, 0);
+    }
+
+    #[test]
+    fn a_service_can_opt_out_of_file_logging() {
+        let (cfg, _) =
+            load_from_str(&with_logs("", "[services.api.logs]\nenabled = false")).unwrap();
+        assert!(!api(&cfg).log_to_file);
+    }
+
+    #[test]
+    fn services_log_to_file_by_default() {
+        let (cfg, _) = load_from_str(&with_logs("", "")).unwrap();
+        assert!(api(&cfg).log_to_file);
+    }
+
+    #[test]
+    fn an_absolute_log_dir_is_used_as_is() {
+        let (cfg, _) =
+            load_from_str(&with_logs(r#"dir = "/tmp/servicrab-test-logs""#, "")).unwrap();
+        assert_eq!(
+            cfg.project.logs.unwrap().dir,
+            PathBuf::from("/tmp/servicrab-test-logs")
+        );
+    }
+
+    #[test]
+    fn a_log_file_where_a_directory_belongs_is_a_config_error() {
+        let dir = TempDir::new().unwrap();
+        let blocker = dir.path().join("not-a-dir");
+        std::fs::write(&blocker, "hi").unwrap();
+
+        let toml = with_logs(&format!(r#"dir = "{}""#, blocker.display()), "");
+        let err = expect_one_error(&toml);
+        assert!(matches!(err, ConfigError::InvalidLogDir { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn log_files_live_next_to_each_other_per_service() {
+        let (cfg, _) = load_from_str(&with_logs("", "")).unwrap();
+        let name = api(&cfg).name.clone();
+        let logs = cfg.project.logs.unwrap();
+
+        assert_eq!(logs.file_for(&name).file_name().unwrap(), "api.log");
+        assert_eq!(
+            logs.rotated_file_for(&name, 2).file_name().unwrap(),
+            "api.log.2"
+        );
     }
 
     // ── Health checks ──────────────────────────────────────────────────────
@@ -1206,6 +1473,7 @@ command = ["echo"]
         let raw = crate::raw::RawConfig {
             version: 1,
             project: crate::raw::RawProject {
+                logs: None,
                 name: "p".into(),
                 env: Default::default(),
             },
@@ -1227,6 +1495,7 @@ command = ["echo"]
                         shutdown_signal: None,
                         shutdown_timeout: None,
                         health: None,
+                        logs: None,
                     },
                 );
                 m
@@ -1582,11 +1851,13 @@ restart_delay = "2s"
                 shutdown_signal: None,
                 shutdown_timeout: None,
                 health: None,
+                logs: None,
             },
         );
         RawConfig {
             version: 1,
             project: crate::raw::RawProject {
+                logs: None,
                 name: "p".into(),
                 env: Default::default(),
             },


### PR DESCRIPTION
Adds opt-in log capture with rotation and a `logs` command to read it back.

## Config

```toml
[project.logs]
dir = ".servicrab/logs"   # default, relative to servicrab.toml
max_size = "10MB"         # rotate above this size
max_files = 3             # rotated generations to keep

[services.noisy.logs]
enabled = false           # opt one service out
```

Without `[project.logs]` nothing changes: no files, no behaviour difference.

## What it does

- `runtime::logs`: `LogWriter` appends and rotates (`api.log` → `api.log.1` → … → `api.log.N`, oldest dropped; `max_files = 0` truncates), `LogRouter` owns one writer per service and reports a write failure once instead of spamming.
- `up` tees every captured line into the router.
- `run` only switches from inherited stdio to captured output when logging is on, then echoes lines verbatim — unchanged terminal behaviour by default.
- `servicrab logs [SERVICE...] [-f] [-n N] [--no-prefix]` tails the files, prefixes when showing several services, and survives rotation while following.
- Errors are actionable: logging disabled, unknown service, service opted out, nothing captured yet.
- Config validation rejects an unknown size unit, an out-of-range `max_size`, `max_files > 100`, and a log `dir` that is an existing file.

## Testing

`cargo fmt` / `clippy -D warnings` / `cargo test --workspace --all-features` — 215 tests green locally, including 11 new integration tests (per-service files, rotation, `-n`, `-f`, opt-out, all error paths, and `run` writing a file while still printing).