### PR TITLE
Per-service control through the daemon: `start`, `stop`, `restart`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - `servicrab up` — run your whole stack in the foreground: dependency-ordered start, interleaved and colour-prefixed output, reverse-order shutdown (Linux/macOS)
 - Health checks: `command`, `http` and `tcp` probes with readiness gating and automatic restart of unhealthy services
 - Log files: opt-in per-service capture with size-based rotation, plus `servicrab logs [-f]` to read and follow them
-- Background daemon: `servicrab start` / `status` / `down`, with a documented JSON-over-Unix-socket protocol (Linux/macOS)
+- Background daemon: `servicrab start` / `status` / `stop` / `restart` / `down`, with a documented JSON-over-Unix-socket protocol (Linux/macOS)
 - Restart policies: `never`, `on-failure`, `always`, with exponential backoff
 - Per-service environment variables and working directories
 - Dependency declarations and a deterministic start order
@@ -126,6 +126,8 @@ if you want shell semantics.
 | `servicrab logs [SERVICE...] [--config PATH] [-f] [-n N] [--no-prefix]` | Show (and follow) the captured log files |
 | `servicrab start [--config PATH] [--no-restart]` | Start the stack in the background |
 | `servicrab status [--config PATH] [--json]` | Show what the background daemon is doing |
+| `servicrab stop <SERVICE...> [--config PATH]` | Stop individual services in the running daemon |
+| `servicrab restart <SERVICE...> [--config PATH]` | Restart individual services |
 | `servicrab down [--config PATH]` | Stop the daemon and every service it supervises |
 | `servicrab daemon [--config PATH] [--no-restart]` | Run the daemon in the foreground (for systemd/launchd/containers) |
 
@@ -411,6 +413,17 @@ servicrab logs -f        # follow the captured output (needs [project.logs])
 servicrab down           # stop every service in reverse order, then exit
 ```
 
+Individual services can be driven without disturbing the rest of the stack:
+
+```bash
+servicrab stop worker       # stop it; the daemon and everything else stay up
+servicrab start worker      # start it again
+servicrab restart api db    # stop and start, one service at a time
+```
+
+A service stopped this way stays stopped — the restart policy does not bring
+it back, because the stop was deliberate.
+
 ```
 SERVICE  STATE          PID    UPTIME  RESTARTS  HEALTH
 db       running      41231     4m30s         0  healthy
@@ -446,6 +459,13 @@ echo '{"type":"status"}' | nc -U .servicrab/daemon.sock
 | `{"type":"ping"}` | `{"type":"pong","project":"…","pid":123}` |
 | `{"type":"status"}` | `{"type":"status","services":[…]}` |
 | `{"type":"shutdown"}` | `{"type":"ok","message":"stopping the stack"}` |
+| `{"type":"start_service","name":"api"}` | `{"type":"ok","message":"api started"}` |
+| `{"type":"stop_service","name":"api"}` | `{"type":"ok","message":"api stopped"}` |
+| `{"type":"restart_service","name":"api"}` | `{"type":"ok","message":"api restarted"}` |
+
+`stop_service` and `restart_service` only answer once the service has actually
+stopped (and, for a restart, been replaced), so scripts can rely on the reply
+instead of polling.
 
 The wire types live in the `servicrab-protocol` crate, which depends on
 neither the runtime nor Tokio.
@@ -519,7 +539,7 @@ cargo test -p servicrab-core config::tests
 - [x] Detached daemon per project with a Unix-socket JSON API
 - [x] `servicrab start` / `status` / `down` / `daemon`
 - [x] Status snapshot: state, pid, uptime, restarts, health
-- [ ] Per-service `stop` / `restart` through the daemon
+- [x] Per-service `start` / `stop` / `restart` through the daemon
 - [ ] Live event streaming over the socket
 
 ### Phase 3 — Stack management

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -53,8 +53,16 @@ mod imp {
         server::serve(&cfg, &paths, server::DaemonOptions { no_restart })
     }
 
-    /// Spawn a detached daemon and wait until it answers.
-    pub fn start(config: Option<&Path>, no_restart: bool) -> Result<i32, String> {
+    /// Start the daemon, or individual services inside a running one.
+    pub fn start(
+        config: Option<&Path>,
+        services: &[String],
+        no_restart: bool,
+    ) -> Result<i32, String> {
+        if !services.is_empty() {
+            return control(config, services, |name| Request::StartService { name });
+        }
+
         let (cfg, config_path, paths) = setup(config)?;
 
         if client::is_running(&paths.socket) {
@@ -131,6 +139,50 @@ mod imp {
             )
         );
         Ok(0)
+    }
+
+    /// Stop individual services without touching the rest of the stack.
+    pub fn stop(config: Option<&Path>, services: &[String]) -> Result<i32, String> {
+        control(config, services, |name| Request::StopService { name })
+    }
+
+    /// Restart individual services.
+    pub fn restart(config: Option<&Path>, services: &[String]) -> Result<i32, String> {
+        control(config, services, |name| Request::RestartService { name })
+    }
+
+    /// Send one per-service command per name, reporting each outcome.
+    fn control(
+        config: Option<&Path>,
+        services: &[String],
+        build: impl Fn(String) -> Request,
+    ) -> Result<i32, String> {
+        let (cfg, _, paths) = setup(config)?;
+        if !client::is_running(&paths.socket) {
+            return Err(format!(
+                "no daemon is running for {} — start one with `servicrab start`",
+                cfg.project.name
+            ));
+        }
+
+        let color = style::color_enabled();
+        let mut failed = false;
+        for name in services {
+            match client::send(&paths.socket, &build(name.clone())) {
+                Ok(Response::Ok { message }) => println!(
+                    "{} {}",
+                    style::paint(color, GREEN, "✓"),
+                    message.unwrap_or_else(|| format!("{name} done"))
+                ),
+                Ok(Response::Error { message }) => {
+                    eprintln!("{} {message}", style::paint(color, RED, "✗"));
+                    failed = true;
+                }
+                Ok(other) => return Err(format!("unexpected response from the daemon: {other:?}")),
+                Err(err) => return Err(err.to_string()),
+            }
+        }
+        Ok(if failed { 1 } else { 0 })
     }
 
     /// Print what the daemon is doing.
@@ -296,7 +348,19 @@ mod imp {
         Err(UNSUPPORTED.to_string())
     }
 
-    pub fn start(_config: Option<&Path>, _no_restart: bool) -> Result<i32, String> {
+    pub fn start(
+        _config: Option<&Path>,
+        _services: &[String],
+        _no_restart: bool,
+    ) -> Result<i32, String> {
+        Err(UNSUPPORTED.to_string())
+    }
+
+    pub fn stop(_config: Option<&Path>, _services: &[String]) -> Result<i32, String> {
+        Err(UNSUPPORTED.to_string())
+    }
+
+    pub fn restart(_config: Option<&Path>, _services: &[String]) -> Result<i32, String> {
         Err(UNSUPPORTED.to_string())
     }
 
@@ -309,4 +373,4 @@ mod imp {
     }
 }
 
-pub use imp::{daemon, down, start, status};
+pub use imp::{daemon, down, restart, start, status, stop};

--- a/crates/servicrab-cli/src/commands/run.rs
+++ b/crates/servicrab-cli/src/commands/run.rs
@@ -131,6 +131,9 @@ fn exit_code(outcome: RunOutcome) -> i32 {
         RunOutcome::Stopped { reason } => match reason {
             ShutdownReason::UserInterrupt => EXIT_SIGINT,
             ShutdownReason::Terminated => EXIT_SIGTERM,
+            // `run` supervises a single service with no daemon around it, so
+            // nobody can ask for a targeted stop; treat it as a clean one.
+            ShutdownReason::Requested => 0,
             ShutdownReason::RestartLimit
             | ShutdownReason::StackFailure
             | ShutdownReason::Unhealthy => 1,

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -67,6 +67,7 @@ pub fn run(services: &[String], config: Option<&Path>, options: UpOptions) -> Re
     let stack_options = StackOptions {
         no_restart: options.no_restart,
         abort_on_failure: options.abort_on_failure,
+        keep_running: false,
     };
 
     let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -8,11 +8,11 @@
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use servicrab_core::runtime::stack::{StackOptions, StackSupervisor};
-use servicrab_core::runtime::{shutdown_channel, wait_for_shutdown};
+use servicrab_core::runtime::stack::{Control, ControlTx, StackOptions, StackSupervisor};
+use servicrab_core::runtime::{control_channel, shutdown_channel, wait_for_shutdown};
 use servicrab_core::{
-    event_channel, plan_stack, Config, EventKind, EventReceiver, LogRouter, ServiceState,
-    ShutdownReason, SignalWatcher, StatusRegistry,
+    event_channel, plan_stack, Config, EventKind, EventReceiver, LogRouter, ServiceName,
+    ServiceState, ShutdownReason, SignalWatcher, StatusRegistry,
 };
 use servicrab_protocol::{decode, encode, Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -57,11 +57,15 @@ pub fn serve(cfg: &Config, paths: &DaemonPaths, options: DaemonOptions) -> Resul
         (name.clone(), has_health)
     }))));
 
+    let names: Vec<ServiceName> = plan.clone();
     let logs = crate::commands::logs::router_for(cfg);
     let project = cfg.project.name.to_string();
     let stack_options = StackOptions {
         no_restart: options.no_restart,
         abort_on_failure: false,
+        // An operator may stop every service and start one again later, which
+        // is only possible while the supervisor is alive.
+        keep_running: true,
     };
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -85,18 +89,22 @@ pub fn serve(cfg: &Config, paths: &DaemonPaths, options: DaemonOptions) -> Resul
         });
 
         let (events_tx, events_rx) = event_channel();
+        let (control_tx, control_rx) = control_channel();
         let collector = tokio::spawn(collect(events_rx, Arc::clone(&registry), logs));
         let server = tokio::spawn(accept_loop(
             listener,
             Arc::clone(&registry),
             stop_tx.clone(),
+            control_tx,
+            names.clone(),
             project.clone(),
         ));
 
         write_pid(&paths.pid)?;
         tracing::info!(project = %project, socket = %paths.socket.display(), "daemon ready");
 
-        let supervisor = StackSupervisor::new(cfg, plan, stack_options, events_tx);
+        let supervisor =
+            StackSupervisor::new(cfg, plan, stack_options, events_tx).with_control(control_rx);
         let outcome = supervisor.run(&mut stop_rx).await;
 
         server.abort();
@@ -137,10 +145,13 @@ async fn collect(
 }
 
 /// Serve clients until the task is cancelled.
+#[allow(clippy::too_many_arguments)]
 async fn accept_loop(
     listener: UnixListener,
     registry: Arc<Mutex<StatusRegistry>>,
     stop: servicrab_core::runtime::ShutdownTx,
+    control: ControlTx,
+    names: Vec<ServiceName>,
     project: String,
 ) {
     loop {
@@ -149,11 +160,13 @@ async fn accept_loop(
         };
         let registry = Arc::clone(&registry);
         let stop = stop.clone();
+        let control = control.clone();
+        let names = names.clone();
         let project = project.clone();
         // One task per client keeps a stuck reader from blocking everybody
         // else.
         tokio::spawn(async move {
-            handle_client(stream, registry, stop, project).await;
+            handle_client(stream, registry, stop, control, names, project).await;
         });
     }
 }
@@ -162,6 +175,8 @@ async fn handle_client(
     stream: UnixStream,
     registry: Arc<Mutex<StatusRegistry>>,
     stop: servicrab_core::runtime::ShutdownTx,
+    control: ControlTx,
+    names: Vec<ServiceName>,
     project: String,
 ) {
     let (read_half, mut write_half) = stream.into_split();
@@ -172,7 +187,7 @@ async fn handle_client(
             continue;
         }
         let response = match decode::<Request>(&line) {
-            Ok(request) => respond(request, &registry, &stop, &project),
+            Ok(request) => respond(request, &registry, &stop, &control, &names, &project).await,
             Err(err) => Response::Error {
                 message: err.to_string(),
             },
@@ -188,10 +203,12 @@ async fn handle_client(
     }
 }
 
-fn respond(
+async fn respond(
     request: Request,
     registry: &Arc<Mutex<StatusRegistry>>,
     stop: &servicrab_core::runtime::ShutdownTx,
+    control: &ControlTx,
+    names: &[ServiceName],
     project: &str,
 ) -> Response {
     match request {
@@ -215,10 +232,70 @@ fn respond(
                 message: Some("stopping the stack".to_string()),
             }
         }
+        Request::StartService { name } => {
+            command(control, names, &name, |service, ack| Control::Start {
+                service,
+                ack,
+            })
+            .await
+        }
+        Request::StopService { name } => {
+            command(control, names, &name, |service, ack| Control::Stop {
+                service,
+                ack,
+            })
+            .await
+        }
+        Request::RestartService { name } => {
+            command(control, names, &name, |service, ack| Control::Restart {
+                service,
+                ack,
+            })
+            .await
+        }
         // `Request` is `#[non_exhaustive]`, so an older daemon can still be
         // asked something it does not know about.
         _ => Response::Error {
             message: "this daemon does not support that request".to_string(),
+        },
+    }
+}
+
+/// Send one per-service command to the supervisor and wait for its verdict.
+async fn command(
+    control: &ControlTx,
+    names: &[ServiceName],
+    name: &str,
+    build: impl FnOnce(ServiceName, servicrab_core::runtime::stack::Ack) -> Control,
+) -> Response {
+    let Some(service) = names.iter().find(|known| known.as_str() == name) else {
+        return Response::Error {
+            message: format!(
+                "unknown service {name:?}; this daemon supervises: {}",
+                names
+                    .iter()
+                    .map(|n| n.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        };
+    };
+
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    if control.send(build(service.clone(), ack_tx)).is_err() {
+        return Response::Error {
+            message: "the supervisor is no longer accepting commands".to_string(),
+        };
+    }
+
+    match ack_rx.await {
+        Ok(Ok(message)) => Response::Ok {
+            message: Some(format!("{name} {message}")),
+        },
+        Ok(Err(message)) => Response::Error { message },
+        // The ack channel is dropped when the stack shuts down mid-command.
+        Err(_) => Response::Error {
+            message: "the stack stopped before the command completed".to_string(),
         },
     }
 }

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -11,12 +11,12 @@
 //!   (Linux/macOS)
 //!
 //! - `servicrab logs [SERVICE...]` — read the captured log files
-//! - `servicrab start` / `status` / `down` — background daemon control
-//!   (Linux/macOS)
+//! - `servicrab start` / `status` / `stop` / `restart` / `down` — background
+//!   daemon control (Linux/macOS)
 //!
 //! ## Future phases (TODOs)
 //!
-//! - TODO(phase-2): Per-service `stop` / `restart` through the daemon.
+//! - TODO(phase-2): Live event streaming over the daemon socket.
 //! - TODO(phase-3): Config hot-reload (`servicrab reload`).
 
 use clap::{Parser, Subcommand};
@@ -144,9 +144,14 @@ enum Commands {
         no_prefix: bool,
     },
 
-    /// Start the stack in the background and return immediately.
+    /// Start the stack in the background and return immediately, or start
+    /// individual services inside an already running daemon.
     /// Linux and macOS only.
     Start {
+        /// Services to start inside a running daemon.  With no names, the
+        /// daemon itself is started.
+        services: Vec<String>,
+
         /// Path to the configuration file.  If omitted, discovers
         /// servicrab.toml by walking up from the current directory.
         #[arg(long, short = 'c')]
@@ -155,6 +160,32 @@ enum Commands {
         /// Never restart services, whatever their configured policy says.
         #[arg(long, default_value_t = false)]
         no_restart: bool,
+    },
+
+    /// Stop individual services without stopping the daemon.
+    /// Linux and macOS only.
+    Stop {
+        /// Services to stop.
+        #[arg(required = true)]
+        services: Vec<String>,
+
+        /// Path to the configuration file.  If omitted, discovers
+        /// servicrab.toml by walking up from the current directory.
+        #[arg(long, short = 'c')]
+        config: Option<std::path::PathBuf>,
+    },
+
+    /// Restart individual services inside the running daemon.
+    /// Linux and macOS only.
+    Restart {
+        /// Services to restart.
+        #[arg(required = true)]
+        services: Vec<String>,
+
+        /// Path to the configuration file.  If omitted, discovers
+        /// servicrab.toml by walking up from the current directory.
+        #[arg(long, short = 'c')]
+        config: Option<std::path::PathBuf>,
     },
 
     /// Show what the background daemon is doing.  Linux and macOS only.
@@ -246,8 +277,14 @@ fn main() {
                 abort_on_failure,
             },
         ),
-        Commands::Start { config, no_restart } => {
-            commands::daemon::start(config.as_deref(), no_restart)
+        Commands::Start {
+            services,
+            config,
+            no_restart,
+        } => commands::daemon::start(config.as_deref(), &services, no_restart),
+        Commands::Stop { services, config } => commands::daemon::stop(config.as_deref(), &services),
+        Commands::Restart { services, config } => {
+            commands::daemon::restart(config.as_deref(), &services)
         }
         Commands::Status { config, json } => commands::daemon::status(config.as_deref(), json),
         Commands::Down { config } => commands::daemon::down(config.as_deref()),

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -336,6 +336,125 @@ restart = "always"
     panic!("the daemon never wrote {}", log.display());
 }
 
+/// A stack with one long-lived service, used by the control tests.
+fn one_service(dir: &Path) -> PathBuf {
+    let svc = resident(dir, "api.sh");
+    config(
+        dir,
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            svc.display()
+        ),
+    )
+}
+
+#[test]
+fn a_single_service_can_be_stopped_and_started_again() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    let (code, stdout, stderr) = cli(&["stop", "api"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("api stopped"), "{stdout}");
+
+    let status = daemon.status();
+    assert!(status.contains("stopped"), "{status}");
+
+    // The daemon is still there, so the service can come back.
+    let (code, stdout, _) = cli(&["start", "api"], &cfg);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("api started"), "{stdout}");
+    daemon.wait_for_status("api to run again", |s| s.contains("running"));
+}
+
+#[test]
+fn restart_replaces_the_process() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+    let before = pid_of(&daemon);
+
+    let (code, stdout, stderr) = cli(&["restart", "api"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("api restarted"), "{stdout}");
+
+    daemon.wait_for_status("a new process", |_| pid_of(&daemon) != before);
+    assert_ne!(pid_of(&daemon), before);
+}
+
+#[test]
+fn stopping_an_already_stopped_service_is_not_an_error() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
+    let (code, stdout, _) = cli(&["stop", "api"], &cfg);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("already stopped"), "{stdout}");
+}
+
+#[test]
+fn starting_a_running_service_is_refused() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    let (code, _, stderr) = cli(&["start", "api"], &cfg);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("already running"), "{stderr}");
+}
+
+#[test]
+fn per_service_commands_need_a_daemon() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let (code, _, stderr) = cli(&["stop", "api"], &cfg);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("no daemon is running"), "{stderr}");
+}
+
+#[test]
+fn an_unknown_service_is_rejected_by_the_daemon() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    let (code, _, stderr) = cli(&["restart", "nope"], &cfg);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("unknown service"), "{stderr}");
+    assert!(stderr.contains("api"), "{stderr}");
+}
+
+/// The pid the daemon reports for `api`, or 0 when it is not running.
+fn pid_of(daemon: &Daemon) -> i64 {
+    let (_, stdout, _) = cli(&["status", "--json"], &daemon.config);
+    let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
+        Ok(value) => value,
+        Err(_) => return 0,
+    };
+    parsed["services"][0]["pid"].as_i64().unwrap_or(0)
+}
+
 #[test]
 fn a_foreground_daemon_stops_on_sigterm() {
     let dir = TempDir::new().unwrap();

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -42,8 +42,8 @@ pub use lifecycle::{
 };
 pub use load::{discover_config, load, resolve_config_path};
 pub use runtime::{
-    event_channel, plan_stack, EventKind, EventReceiver, EventSender, EventSink, ForegroundRunner,
-    Health, LogRouter, LogWriter, OutputMode, RunOptions, RunOutcome, ServiceEvent, ServiceRunner,
-    ServiceStatus, SignalWatcher, StackOptions, StackOutcome, StackSupervisor, StatusRegistry,
-    Stream,
+    control_channel, event_channel, plan_stack, Control, ControlTx, EventKind, EventReceiver,
+    EventSender, EventSink, ForegroundRunner, Health, LogRouter, LogWriter, OutputMode, RunOptions,
+    RunOutcome, ServiceEvent, ServiceRunner, ServiceStatus, SignalWatcher, StackOptions,
+    StackOutcome, StackSupervisor, StatusRegistry, Stream,
 };

--- a/crates/servicrab-core/src/lifecycle.rs
+++ b/crates/servicrab-core/src/lifecycle.rs
@@ -201,6 +201,8 @@ pub enum ShutdownReason {
     StackFailure,
     /// The service failed its health check.
     Unhealthy,
+    /// An operator asked for this specific service to stop.
+    Requested,
 }
 
 impl ShutdownReason {
@@ -209,7 +211,7 @@ impl ShutdownReason {
     pub fn is_user_requested(self) -> bool {
         matches!(
             self,
-            ShutdownReason::UserInterrupt | ShutdownReason::Terminated
+            ShutdownReason::UserInterrupt | ShutdownReason::Terminated | ShutdownReason::Requested
         )
     }
 }
@@ -221,6 +223,7 @@ impl std::fmt::Display for ShutdownReason {
             ShutdownReason::Terminated => write!(f, "supervisor terminated"),
             ShutdownReason::RestartLimit => write!(f, "restart limit exhausted"),
             ShutdownReason::StackFailure => write!(f, "another service failed"),
+            ShutdownReason::Requested => write!(f, "stopped on request"),
             ShutdownReason::Unhealthy => write!(f, "failed its health check"),
         }
     }

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -53,7 +53,8 @@ pub use health::{HealthMonitor, HealthSignal};
 pub use logs::{LogRouter, LogWriter};
 pub use plan::{known_services, lookup_service, plan_stack};
 pub use stack::{
-    Readiness, ServiceReport, ServiceResult, StackOptions, StackOutcome, StackSupervisor,
+    control_channel, Ack, Control, ControlRx, ControlTx, Readiness, ServiceReport, ServiceResult,
+    StackOptions, StackOutcome, StackSupervisor,
 };
 pub use status::{Health, ServiceStatus, StatusRegistry};
 

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -36,6 +36,11 @@ pub struct StackOptions {
     pub no_restart: bool,
     /// Tear the whole stack down as soon as one service fails.
     pub abort_on_failure: bool,
+    /// Keep supervising even when every service has stopped.
+    ///
+    /// The daemon needs this: an operator may stop every service and start one
+    /// again later, which is only possible while the supervisor is alive.
+    pub keep_running: bool,
 }
 
 /// How one service ended during a stack run.
@@ -92,12 +97,106 @@ impl StackOutcome {
     }
 }
 
+/// Acknowledgement channel for a [`Control`] command.
+///
+/// The message describes what happened ("started", "restarted", …); an error
+/// explains why the command was refused.
+pub type Ack = tokio::sync::oneshot::Sender<Result<String, String>>;
+
+/// A command an operator sends to a running stack.
+#[derive(Debug)]
+pub enum Control {
+    /// Start a service that is not running.
+    Start {
+        /// Which service.
+        service: ServiceName,
+        /// Answered once the service has been spawned.
+        ack: Ack,
+    },
+    /// Stop a running service, leaving the rest of the stack alone.
+    Stop {
+        /// Which service.
+        service: ServiceName,
+        /// Answered once the service has actually stopped.
+        ack: Ack,
+    },
+    /// Stop a service and start it again.
+    Restart {
+        /// Which service.
+        service: ServiceName,
+        /// Answered once the replacement has been spawned.
+        ack: Ack,
+    },
+}
+
+/// Sending half of the control channel.
+pub type ControlTx = mpsc::UnboundedSender<Control>;
+/// Receiving half of the control channel.
+pub type ControlRx = mpsc::UnboundedReceiver<Control>;
+
+/// Create a control channel.
+pub fn control_channel() -> (ControlTx, ControlRx) {
+    mpsc::unbounded_channel()
+}
+
+/// Everything the supervisor needs to run — and re-run — one service.
+struct Slot {
+    service: Arc<Service>,
+    deps: Vec<(ServiceName, watch::Receiver<Readiness>)>,
+    readiness: Arc<watch::Sender<Readiness>>,
+    /// Present exactly while a supervision task is alive.
+    stop: Option<crate::runtime::ShutdownTx>,
+    handle: Option<JoinHandle<()>>,
+    /// Set while a stop is only the first half of a restart.
+    restart_when_stopped: bool,
+    /// The client waiting for the in-flight command to complete.
+    pending: Option<Ack>,
+}
+
+impl Slot {
+    /// Start a supervision task for this service.
+    fn spawn(
+        &mut self,
+        events: EventSender,
+        options: RunOptions,
+        reports: mpsc::UnboundedSender<ServiceReport>,
+    ) {
+        // A previous run may have left the signal at `Gone`; dependents that
+        // are still waiting must not act on that stale verdict.
+        let _ = self.readiness.send(Readiness::Pending);
+
+        let (stop_tx, stop_rx) = shutdown_channel();
+        self.stop = Some(stop_tx);
+        self.handle = Some(tokio::spawn(supervise_service(
+            Arc::clone(&self.service),
+            self.deps.clone(),
+            Arc::clone(&self.readiness),
+            stop_rx,
+            events,
+            options,
+            reports,
+        )));
+    }
+
+    fn is_running(&self) -> bool {
+        self.handle.is_some()
+    }
+
+    /// Answer the client waiting on this slot, if there is one.
+    fn answer(&mut self, result: Result<String, String>) {
+        if let Some(ack) = self.pending.take() {
+            let _ = ack.send(result);
+        }
+    }
+}
+
 /// Supervises several services concurrently.
 pub struct StackSupervisor<'a> {
     config: &'a Config,
     plan: Vec<ServiceName>,
     options: StackOptions,
     events: EventSender,
+    control: Option<ControlRx>,
 }
 
 impl<'a> StackSupervisor<'a> {
@@ -116,7 +215,14 @@ impl<'a> StackSupervisor<'a> {
             plan,
             options,
             events,
+            control: None,
         }
+    }
+
+    /// Accept per-service commands while the stack runs.
+    pub fn with_control(mut self, control: ControlRx) -> Self {
+        self.control = Some(control);
+        self
     }
 
     /// The services this supervisor will start, in start order.
@@ -126,75 +232,107 @@ impl<'a> StackSupervisor<'a> {
 
     /// Run the stack until every service has stopped or a shutdown is
     /// requested.
-    pub async fn run(self, shutdown: &mut ShutdownRx) -> StackOutcome {
+    pub async fn run(mut self, shutdown: &mut ShutdownRx) -> StackOutcome {
         let run_options = RunOptions {
             no_restart: self.options.no_restart,
             output: OutputMode::Capture,
         };
 
         let (report_tx, mut report_rx) = mpsc::unbounded_channel::<ServiceReport>();
-        let mut states: BTreeMap<ServiceName, watch::Receiver<Readiness>> = BTreeMap::new();
-        let mut stops: BTreeMap<ServiceName, crate::runtime::ShutdownTx> = BTreeMap::new();
-        let mut handles: BTreeMap<ServiceName, JoinHandle<()>> = BTreeMap::new();
+        let mut slots: BTreeMap<ServiceName, Slot> = BTreeMap::new();
 
         for name in &self.plan {
             let Some(service) = self.config.services.get(name) else {
                 continue;
             };
-            let service = Arc::new(service.clone());
-
             let (state_tx, state_rx) = watch::channel(Readiness::Pending);
-            let (stop_tx, stop_rx) = shutdown_channel();
 
-            // Dependencies always appear earlier in the plan, so their state
-            // channels already exist.
+            // Dependencies always appear earlier in the plan, so their slots
+            // already exist.
             let deps: Vec<(ServiceName, watch::Receiver<Readiness>)> = service
                 .depends_on
                 .iter()
-                .filter_map(|dep| states.get(dep).map(|rx| (dep.clone(), rx.clone())))
+                .filter_map(|dep| {
+                    slots
+                        .get(dep)
+                        .map(|slot| (dep.clone(), slot.readiness.subscribe()))
+                })
                 .collect();
 
-            states.insert(name.clone(), state_rx);
-            stops.insert(name.clone(), stop_tx);
-
-            handles.insert(
-                name.clone(),
-                tokio::spawn(supervise_service(
-                    service,
-                    deps,
-                    state_tx,
-                    stop_rx,
-                    self.events.clone(),
-                    run_options,
-                    report_tx.clone(),
-                )),
-            );
+            let mut slot = Slot {
+                service: Arc::new(service.clone()),
+                deps,
+                readiness: Arc::new(state_tx),
+                stop: None,
+                handle: None,
+                restart_when_stopped: false,
+                pending: None,
+            };
+            drop(state_rx);
+            slot.spawn(self.events.clone(), run_options, report_tx.clone());
+            slots.insert(name.clone(), slot);
         }
 
-        drop(report_tx);
-
-        let total = handles.len();
-        let mut reports: Vec<ServiceReport> = Vec::with_capacity(total);
+        let mut running = slots.len();
+        let mut reports: Vec<ServiceReport> = Vec::with_capacity(running);
         let mut shutdown_reason: Option<ShutdownReason> = None;
 
-        while reports.len() < total {
+        loop {
+            // Without a control channel the stack is done when its services
+            // are; the daemon instead waits to be told to stop.
+            if running == 0 && !self.options.keep_running {
+                break;
+            }
+
             tokio::select! {
                 reason = wait_for_shutdown(shutdown) => {
                     shutdown_reason = Some(reason);
                     break;
                 }
-                report = report_rx.recv() => {
-                    let Some(report) = report else { break };
+                Some(report) = report_rx.recv() => {
+                    running -= 1;
                     let failed = report.result.is_failure();
                     tracing::debug!(service = %report.service, "service finished");
+
+                    if let Some(slot) = slots.get_mut(&report.service) {
+                        slot.stop = None;
+                        slot.handle = None;
+                        if slot.restart_when_stopped {
+                            slot.restart_when_stopped = false;
+                            slot.spawn(self.events.clone(), run_options, report_tx.clone());
+                            running += 1;
+                            slot.answer(Ok("restarted".to_string()));
+                        } else {
+                            slot.answer(Ok("stopped".to_string()));
+                        }
+                    }
+
                     reports.push(report);
                     if failed && self.options.abort_on_failure {
                         shutdown_reason = Some(ShutdownReason::StackFailure);
                         break;
                     }
                 }
+                command = next_control(&mut self.control) => {
+                    self.handle_control(
+                        command,
+                        &mut slots,
+                        &mut running,
+                        run_options,
+                        &report_tx,
+                    );
+                }
             }
         }
+
+        let stops: BTreeMap<ServiceName, crate::runtime::ShutdownTx> = slots
+            .iter()
+            .filter_map(|(name, slot)| slot.stop.clone().map(|stop| (name.clone(), stop)))
+            .collect();
+        let mut handles: BTreeMap<ServiceName, JoinHandle<()>> = slots
+            .iter_mut()
+            .filter_map(|(name, slot)| slot.handle.take().map(|handle| (name.clone(), handle)))
+            .collect();
 
         if let Some(reason) = shutdown_reason {
             self.stop_all(reason, &stops, &mut handles).await;
@@ -207,7 +345,9 @@ impl<'a> StackSupervisor<'a> {
         }
 
         // Every task has finished, so the remaining reports are already
-        // queued.
+        // queued.  The supervisor holds the last sender, so the channel is
+        // drained rather than waited on.
+        drop(report_tx);
         while let Some(report) = report_rx.recv().await {
             reports.push(report);
         }
@@ -215,6 +355,69 @@ impl<'a> StackSupervisor<'a> {
         StackOutcome {
             reports,
             shutdown: shutdown_reason,
+        }
+    }
+
+    /// Apply one operator command to the running stack.
+    fn handle_control(
+        &self,
+        command: Control,
+        slots: &mut BTreeMap<ServiceName, Slot>,
+        running: &mut usize,
+        run_options: RunOptions,
+        reports: &mpsc::UnboundedSender<ServiceReport>,
+    ) {
+        let service = match &command {
+            Control::Start { service, .. }
+            | Control::Stop { service, .. }
+            | Control::Restart { service, .. } => service.clone(),
+        };
+
+        let Some(slot) = slots.get_mut(&service) else {
+            let ack = into_ack(command);
+            let _ = ack.send(Err(format!("{service} is not part of the running stack")));
+            return;
+        };
+
+        // A slot can only track one command at a time; queuing them would
+        // make "stop then restart" ambiguous.
+        if slot.pending.is_some() {
+            let ack = into_ack(command);
+            let _ = ack.send(Err(format!(
+                "{service} is already busy with another command"
+            )));
+            return;
+        }
+
+        match command {
+            Control::Start { ack, .. } => {
+                if slot.is_running() {
+                    let _ = ack.send(Err(format!("{service} is already running")));
+                    return;
+                }
+                slot.spawn(self.events.clone(), run_options, reports.clone());
+                *running += 1;
+                let _ = ack.send(Ok("started".to_string()));
+            }
+            Control::Stop { ack, .. } => {
+                let Some(stop) = slot.stop.clone() else {
+                    let _ = ack.send(Ok("already stopped".to_string()));
+                    return;
+                };
+                slot.pending = Some(ack);
+                let _ = stop.send(Some(ShutdownReason::Requested));
+            }
+            Control::Restart { ack, .. } => {
+                let Some(stop) = slot.stop.clone() else {
+                    slot.spawn(self.events.clone(), run_options, reports.clone());
+                    *running += 1;
+                    let _ = ack.send(Ok("started".to_string()));
+                    return;
+                };
+                slot.restart_when_stopped = true;
+                slot.pending = Some(ack);
+                let _ = stop.send(Some(ShutdownReason::Requested));
+            }
         }
     }
 
@@ -251,6 +454,28 @@ impl<'a> StackSupervisor<'a> {
     }
 }
 
+/// Wait for the next operator command, or forever when there is no control
+/// channel.
+async fn next_control(control: &mut Option<ControlRx>) -> Control {
+    match control {
+        Some(rx) => match rx.recv().await {
+            Some(command) => command,
+            // Every client is gone; the stack keeps running unattended.
+            None => std::future::pending().await,
+        },
+        None => std::future::pending().await,
+    }
+}
+
+/// Take the acknowledgement channel out of a command.
+fn into_ack(command: Control) -> Ack {
+    match command {
+        Control::Start { ack, .. } | Control::Stop { ack, .. } | Control::Restart { ack, .. } => {
+            ack
+        }
+    }
+}
+
 /// Whether a service may start yet.
 enum DependencyWait {
     /// Every dependency is available.
@@ -281,7 +506,7 @@ pub enum Readiness {
 async fn supervise_service(
     service: Arc<Service>,
     deps: Vec<(ServiceName, watch::Receiver<Readiness>)>,
-    readiness: watch::Sender<Readiness>,
+    readiness: Arc<watch::Sender<Readiness>>,
     mut stop: ShutdownRx,
     events: EventSender,
     options: RunOptions,

--- a/crates/servicrab-core/src/runtime/stack_stub.rs
+++ b/crates/servicrab-core/src/runtime/stack_stub.rs
@@ -28,6 +28,8 @@ pub struct StackOptions {
     pub no_restart: bool,
     /// Tear the whole stack down as soon as one service fails.
     pub abort_on_failure: bool,
+    /// Keep supervising even when every service has stopped.
+    pub keep_running: bool,
 }
 
 /// How one service ended during a stack run.
@@ -84,6 +86,45 @@ impl StackOutcome {
     }
 }
 
+/// Acknowledgement channel for a [`Control`] command.
+pub type Ack = tokio::sync::oneshot::Sender<Result<String, String>>;
+
+/// A command an operator sends to a running stack.
+#[derive(Debug)]
+pub enum Control {
+    /// Start a service that is not running.
+    Start {
+        /// Which service.
+        service: ServiceName,
+        /// Answered once the command completes.
+        ack: Ack,
+    },
+    /// Stop a running service.
+    Stop {
+        /// Which service.
+        service: ServiceName,
+        /// Answered once the command completes.
+        ack: Ack,
+    },
+    /// Stop a service and start it again.
+    Restart {
+        /// Which service.
+        service: ServiceName,
+        /// Answered once the command completes.
+        ack: Ack,
+    },
+}
+
+/// Sending half of the control channel.
+pub type ControlTx = tokio::sync::mpsc::UnboundedSender<Control>;
+/// Receiving half of the control channel.
+pub type ControlRx = tokio::sync::mpsc::UnboundedReceiver<Control>;
+
+/// Create a control channel.
+pub fn control_channel() -> (ControlTx, ControlRx) {
+    tokio::sync::mpsc::unbounded_channel()
+}
+
 /// Placeholder stack supervisor.
 pub struct StackSupervisor<'a> {
     plan: Vec<ServiceName>,
@@ -106,6 +147,11 @@ impl<'a> StackSupervisor<'a> {
             _options: options,
             _events: events,
         }
+    }
+
+    /// Accept per-service commands while the stack runs.
+    pub fn with_control(self, _control: ControlRx) -> Self {
+        self
     }
 
     /// The services this supervisor would start.

--- a/crates/servicrab-core/src/runtime/status.rs
+++ b/crates/servicrab-core/src/runtime/status.rs
@@ -107,9 +107,13 @@ impl StatusRegistry {
                     entry.pid = None;
                     entry.started_at = None;
                 }
-                // A service that is starting again has not proven itself yet.
-                if matches!(state, ServiceState::Starting) && entry.health != Health::None {
-                    entry.health = Health::Starting;
+                // A service that is starting again has not proven itself yet,
+                // and whatever ended its previous run is now history.
+                if matches!(state, ServiceState::Starting) {
+                    entry.message = None;
+                    if entry.health != Health::None {
+                        entry.health = Health::Starting;
+                    }
                 }
             }
             EventKind::Started { pgid } => {
@@ -253,9 +257,11 @@ mod tests {
             .unwrap()
             .contains("connection refused"));
 
-        // A restart puts the verdict back to "not proven yet".
+        // A restart puts the verdict back to "not proven yet", and drops the
+        // note about the previous run.
         registry.apply(&event("db", EventKind::State(ServiceState::Starting)));
         assert_eq!(registry.snapshot()[0].health, Health::Starting);
+        assert!(registry.snapshot()[0].message.is_none());
     }
 
     #[test]

--- a/crates/servicrab-protocol/src/request.rs
+++ b/crates/servicrab-protocol/src/request.rs
@@ -15,4 +15,22 @@ pub enum Request {
 
     /// Ask the daemon to stop the whole stack and exit.
     Shutdown,
+
+    /// Start one service that is currently stopped.
+    StartService {
+        /// Service name as declared in `servicrab.toml`.
+        name: String,
+    },
+
+    /// Stop one service, leaving the rest of the stack alone.
+    StopService {
+        /// Service name as declared in `servicrab.toml`.
+        name: String,
+    },
+
+    /// Stop one service and start it again.
+    RestartService {
+        /// Service name as declared in `servicrab.toml`.
+        name: String,
+    },
 }


### PR DESCRIPTION
The daemon from #8 could only run the whole stack and shut it down. This adds runtime control of individual services over the Unix socket.

```console
$ servicrab daemon &
$ servicrab stop api
api stopped
$ servicrab start api
api started
$ servicrab restart worker
worker restarted
```

### Core

- `ShutdownReason::Requested` marks a stop the user asked for, so it never triggers an automatic restart.
- `StackSupervisor` is rebuilt around a `Slot` per service that owns the readiness sender, the shutdown channel and the join handle. That is what makes a service respawnable at runtime.
- New `Control::{Start, Stop, Restart}` messages with an ack channel, a `control_channel()` constructor and `StackSupervisor::with_control()`.
- `StackOptions::keep_running` keeps the supervisor alive when every service has stopped — what a daemon wants, unlike `up`.
- One in-flight command per slot; a second one gets "already busy". `Stop` acks when the process is actually gone, `Restart` acks once the replacement is spawned.
- `Slot::spawn` resets readiness to `Pending`, so dependents never act on a stale `Gone`.
- `StatusRegistry` clears the stale last message when a service starts again.

### Protocol

`Request::{StartService, StopService, RestartService}`, answered with the usual `Ok`/`Error`.

### CLI

`servicrab start [SERVICE...]`, `servicrab stop <SERVICE...>`, `servicrab restart <SERVICE...>`. Names are validated against the plan before anything is dispatched.

### Known limitation

Restarting a dependency does not cascade to its dependents, and a dependent still waiting on a `Gone` dependency is skipped. Documented in the README, worth revisiting once hot-reload lands.

### Tests

6 new daemon integration tests (14 in the suite): stop/start round trip, restart replaces the pid, idempotent stop, refusing to start a running service, commands needing a daemon, unknown service names. Full workspace suite is green locally on macOS.