### PR TITLE
Environment files (`env_file`) and shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +573,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap_complete",
  "humantime",
  "nix",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1", features = ["full"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - Log files: opt-in per-service capture with size-based rotation, plus `servicrab logs [-f]` to read and follow them
 - Background daemon: `servicrab start` / `status` / `stop` / `restart` / `down`, with a documented JSON-over-Unix-socket protocol (Linux/macOS)
 - Restart policies: `never`, `on-failure`, `always`, with exponential backoff
-- Per-service environment variables and working directories
+- Environment: per-service variables, working directories, and dotenv-style `env_file` layering
+- Shell completions for bash, zsh, fish, PowerShell and elvish
 - Dependency declarations and a deterministic start order
 
 ---
@@ -130,6 +131,7 @@ if you want shell semantics.
 | `servicrab restart <SERVICE...> [--config PATH]` | Restart individual services |
 | `servicrab down [--config PATH]` | Stop the daemon and every service it supervises |
 | `servicrab daemon [--config PATH] [--no-restart]` | Run the daemon in the foreground (for systemd/launchd/containers) |
+| `servicrab completions <SHELL>` | Print a completion script for bash, zsh, fish, PowerShell or elvish |
 
 If `--config` is omitted, Servicrab discovers `servicrab.toml` by walking up
 from the current directory.
@@ -400,6 +402,67 @@ all of them are powers of 1024.
 
 ---
 
+## Environment files
+
+Anything you would otherwise repeat in `[project.env]` or
+`[services.<name>.env]` can live in a dotenv-style file instead:
+
+```toml
+[project]
+name = "my-project"
+env_file = ".env"                    # or a list: [".env", ".env.local"]
+
+[services.api]
+command = ["node", "server.js"]
+env_file = [".env.api", ".env.api.local"]
+
+[services.api.env]
+PORT = "3000"                        # wins over anything in the files
+```
+
+Paths are relative to `servicrab.toml`. Files are read once, when the config is
+loaded, and layered lowest to highest:
+
+```
+inherited shell environment
+  → project env_file (in declaration order)
+    → [project.env]
+      → service env_file (in declaration order)
+        → [services.<name>.env]
+```
+
+The file format is deliberately small:
+
+```sh
+# a comment
+KEY=value
+export KEY=value          # `export` is accepted and ignored
+QUOTED="hello world"      # double quotes support \n \r \t \\ \" escapes
+LITERAL='no $expansion'   # single quotes are literal
+EMPTY=
+PORT=3000                 # trailing comments are stripped
+```
+
+There is no variable expansion: what is written is what the service receives.
+A missing file, an unterminated quote or a line without `=` is a configuration
+error, reported by `servicrab check` with the file name and line number — the
+stack never starts with a half-loaded environment.
+
+---
+
+## Shell completions
+
+```bash
+servicrab completions bash > /etc/bash_completion.d/servicrab
+servicrab completions zsh  > ~/.zfunc/_servicrab
+servicrab completions fish > ~/.config/fish/completions/servicrab.fish
+```
+
+`powershell` and `elvish` are supported too. The script is written to stdout,
+so nothing is installed behind your back.
+
+---
+
 ## Running in the background
 
 `up` is the interactive mode; `start` is the same stack without a terminal
@@ -542,9 +605,10 @@ cargo test -p servicrab-core config::tests
 - [x] Per-service `start` / `stop` / `restart` through the daemon
 - [ ] Live event streaming over the socket
 
-### Phase 3 — Stack management
+### Phase 3 (current) — Stack management
+- [x] `.env` file support per project and per service
+- [x] Shell completions (`servicrab completions <SHELL>`)
 - [ ] `servicrab watch` — restart on file changes (à la `watchexec`)
-- [ ] `.env` file support per service
 - [ ] Config hot-reload
 
 ### Phase 4 — Platform integration (optional)

--- a/crates/servicrab-cli/Cargo.toml
+++ b/crates/servicrab-cli/Cargo.toml
@@ -17,6 +17,7 @@ servicrab-core = { workspace = true }
 servicrab-protocol = { workspace = true }
 tokio = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }

--- a/crates/servicrab-cli/src/commands/completions.rs
+++ b/crates/servicrab-cli/src/commands/completions.rs
@@ -1,0 +1,21 @@
+//! `servicrab completions <SHELL>` — print a shell completion script.
+//!
+//! The script is written to stdout so it can be piped straight into the
+//! shell's completion directory:
+//!
+//! ```console
+//! $ servicrab completions bash > /etc/bash_completion.d/servicrab
+//! $ servicrab completions zsh  > ~/.zfunc/_servicrab
+//! $ servicrab completions fish > ~/.config/fish/completions/servicrab.fish
+//! ```
+
+use clap::CommandFactory;
+use clap_complete::Shell;
+
+/// Write the completion script for `shell` to stdout.
+pub fn run<C: CommandFactory>(shell: Shell) -> Result<(), String> {
+    let mut command = C::command();
+    let name = command.get_name().to_string();
+    clap_complete::generate(shell, &mut command, name, &mut std::io::stdout());
+    Ok(())
+}

--- a/crates/servicrab-cli/src/commands/init.rs
+++ b/crates/servicrab-cli/src/commands/init.rs
@@ -21,6 +21,13 @@ name = "my-project"
 # [project.env]
 # RUST_LOG = "info"
 
+# ── Environment files ─────────────────────────────────────────────────────────
+# Dotenv-style files loaded for every service.  Paths are relative to this file.
+# Layering, later wins:  shell env -> project env_file -> [project.env]
+#                        -> service env_file -> [services.<name>.env]
+# env_file = ".env"
+# env_file = [".env", ".env.local"]
+
 # ── Log files ─────────────────────────────────────────────────────────────────
 # Uncomment to keep a copy of every service's output on disk.  Files are
 # rotated once they cross max_size:  api.log -> api.log.1 -> api.log.2 ...
@@ -39,6 +46,7 @@ name = "my-project"
 # Optional fields:
 #   cwd           Working directory (default: config file's directory)
 #   env           Per-service environment variables
+#   env_file      Dotenv file(s) loaded before `env`, e.g. ".env" or a list
 #   depends_on    Services that must start before this one, e.g. ["db"]
 #   autostart     Whether to start automatically (default: true)
 #   restart       never | on-failure | always  (default: never)

--- a/crates/servicrab-cli/src/commands/mod.rs
+++ b/crates/servicrab-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI subcommand implementations.
 
 pub mod check;
+pub mod completions;
 pub mod daemon;
 pub mod init;
 pub mod list;

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -11,6 +11,7 @@
 //!   (Linux/macOS)
 //!
 //! - `servicrab logs [SERVICE...]` — read the captured log files
+//! - `servicrab completions <SHELL>` — print a shell completion script
 //! - `servicrab start` / `status` / `stop` / `restart` / `down` — background
 //!   daemon control (Linux/macOS)
 //!
@@ -209,6 +210,12 @@ enum Commands {
         config: Option<std::path::PathBuf>,
     },
 
+    /// Print a shell completion script to stdout.
+    Completions {
+        /// Shell to generate completions for.
+        shell: clap_complete::Shell,
+    },
+
     /// Supervise the stack in the foreground while serving the daemon socket.
     /// This is what `start` runs in the background; use it directly under
     /// systemd, launchd or a container.  Linux and macOS only.
@@ -291,6 +298,7 @@ fn main() {
         Commands::Daemon { config, no_restart } => {
             commands::daemon::daemon(config.as_deref(), no_restart)
         }
+        Commands::Completions { shell } => commands::completions::run::<Cli>(shell).map(|()| 0),
         Commands::Logs {
             services,
             config,

--- a/crates/servicrab-cli/tests/cli.rs
+++ b/crates/servicrab-cli/tests/cli.rs
@@ -212,3 +212,87 @@ fn list_failure_on_invalid_config() {
         .assert()
         .failure();
 }
+
+// ── completions ────────────────────────────────────────────────────────────
+
+#[test]
+fn completions_are_generated_for_every_supported_shell() {
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        let output = cmd()
+            .arg("completions")
+            .arg(shell)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let text = String::from_utf8(output).unwrap();
+        assert!(
+            text.contains("servicrab"),
+            "{shell} completions should mention the binary name"
+        );
+        assert!(
+            text.len() > 200,
+            "{shell} completions look suspiciously short"
+        );
+    }
+}
+
+#[test]
+fn completions_mention_the_subcommands() {
+    let output = cmd()
+        .arg("completions")
+        .arg("bash")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    for sub in ["up", "down", "logs", "status", "restart"] {
+        assert!(text.contains(sub), "bash completions should list {sub}");
+    }
+}
+
+#[test]
+fn completions_reject_an_unknown_shell() {
+    cmd().arg("completions").arg("tcsh").assert().failure();
+}
+
+// ── env_file ───────────────────────────────────────────────────────────────
+
+#[test]
+fn env_file_values_reach_the_service() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join(".env"), "GREETING=from-file\n").unwrap();
+    let path = dir.path().join("servicrab.toml");
+    fs::write(
+        &path,
+        "version = 1\n[project]\nname = \"p\"\n[services.web]\ncommand = [\"sh\", \"-c\", \"echo $GREETING\"]\nenv_file = \".env\"\n",
+    )
+    .unwrap();
+
+    cmd()
+        .arg("run")
+        .arg("web")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .success()
+        .stdout(contains("from-file"));
+}
+
+#[test]
+fn a_missing_env_file_fails_the_config() {
+    let (_dir, path) = temp_dir_with_config(
+        "version = 1\n[project]\nname = \"p\"\n[services.web]\ncommand = [\"echo\"]\nenv_file = \"nope.env\"\n",
+    );
+
+    cmd()
+        .arg("check")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .failure()
+        .stderr(contains("env_file"));
+}

--- a/crates/servicrab-core/src/config.rs
+++ b/crates/servicrab-core/src/config.rs
@@ -141,6 +141,9 @@ pub struct Project {
     pub name: ProjectName,
     /// Project-level environment variables (as declared in `[project.env]`).
     pub env: BTreeMap<String, String>,
+    /// Absolute paths of the project-level `env_file` entries, in declaration
+    /// order.
+    pub env_files: Vec<PathBuf>,
     /// File-logging settings, when `[project.logs]` was declared.
     pub logs: Option<LogSettings>,
 }
@@ -245,9 +248,12 @@ pub struct Service {
     pub args: Vec<String>,
     /// Absolute, canonicalized working directory.
     pub cwd: PathBuf,
-    /// Effective environment: process env + project env + service env (later
-    /// entries override earlier ones).
+    /// Effective environment: process env + project env files + project env +
+    /// service env files + service env (later entries override earlier ones).
     pub env: BTreeMap<String, String>,
+    /// Absolute paths of the service-level `env_file` entries, in declaration
+    /// order.
+    pub env_files: Vec<PathBuf>,
     /// Validated list of service names that must start before this one.
     pub depends_on: Vec<ServiceName>,
     /// Whether the supervisor should start this service automatically.

--- a/crates/servicrab-core/src/envfile.rs
+++ b/crates/servicrab-core/src/envfile.rs
@@ -1,0 +1,272 @@
+//! Parser for dotenv-style environment files.
+//!
+//! The format is intentionally small and predictable:
+//!
+//! ```text
+//! # a comment
+//! KEY=value
+//! export KEY=value          # `export` is accepted and ignored
+//! QUOTED="hello world"      # double quotes support \n \r \t \\ \" escapes
+//! LITERAL='no $expansion'   # single quotes are taken literally
+//! EMPTY=
+//! ```
+//!
+//! Rules:
+//!
+//! * Blank lines and lines whose first non-blank character is `#` are skipped.
+//! * A UTF-8 BOM at the start of the file is ignored.
+//! * Keys must be valid environment keys: non-empty, no `=`, no NUL.
+//! * Unquoted values are trimmed and may carry a trailing `#` comment when the
+//!   `#` is preceded by whitespace.
+//! * Quoted values must have a closing quote on the same line.
+//!
+//! Variable expansion is deliberately *not* supported: what is written is what
+//! the service receives.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Why an environment file could not be turned into key/value pairs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvFileError {
+    /// The file could not be read (missing, unreadable, not UTF-8, ...).
+    Read(String),
+    /// A line could not be parsed.
+    Syntax {
+        /// 1-based line number.
+        line: usize,
+        /// Human-readable reason.
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for EnvFileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EnvFileError::Read(reason) => write!(f, "{reason}"),
+            EnvFileError::Syntax { line, reason } => write!(f, "line {line}: {reason}"),
+        }
+    }
+}
+
+/// Read `path` and parse it as a dotenv-style file.
+///
+/// Later assignments to the same key win, matching the behaviour of a shell
+/// sourcing the file top to bottom.
+pub fn load(path: &Path) -> Result<BTreeMap<String, String>, EnvFileError> {
+    let text = std::fs::read_to_string(path).map_err(|e| EnvFileError::Read(e.to_string()))?;
+    parse(&text)
+}
+
+/// Parse the contents of a dotenv-style file.
+pub fn parse(text: &str) -> Result<BTreeMap<String, String>, EnvFileError> {
+    let mut out = BTreeMap::new();
+    let text = text.strip_prefix('\u{feff}').unwrap_or(text);
+
+    for (index, raw_line) in text.lines().enumerate() {
+        let line_no = index + 1;
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let line = line.strip_prefix("export ").map_or(line, str::trim_start);
+
+        let Some((key, rest)) = line.split_once('=') else {
+            return Err(EnvFileError::Syntax {
+                line: line_no,
+                reason: format!("expected KEY=VALUE, got {line:?}"),
+            });
+        };
+
+        let key = key.trim();
+        if key.is_empty() || key.contains(char::is_whitespace) || key.contains('\0') {
+            return Err(EnvFileError::Syntax {
+                line: line_no,
+                reason: format!("invalid key {key:?}"),
+            });
+        }
+
+        let value = parse_value(rest.trim_start()).map_err(|reason| EnvFileError::Syntax {
+            line: line_no,
+            reason,
+        })?;
+
+        out.insert(key.to_string(), value);
+    }
+
+    Ok(out)
+}
+
+fn parse_value(raw: &str) -> Result<String, String> {
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some('"') => unquote(raw, '"', true),
+        Some('\'') => unquote(raw, '\'', false),
+        _ => Ok(strip_trailing_comment(raw).trim_end().to_string()),
+    }
+}
+
+/// Parse a quoted value; `raw` starts with `quote`.
+fn unquote(raw: &str, quote: char, escapes: bool) -> Result<String, String> {
+    let mut out = String::new();
+    let mut chars = raw.chars();
+    chars.next(); // opening quote
+
+    let mut closed = false;
+    while let Some(c) = chars.next() {
+        if c == quote {
+            closed = true;
+            break;
+        }
+        if escapes && c == '\\' {
+            match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('r') => out.push('\r'),
+                Some('t') => out.push('\t'),
+                Some('\\') => out.push('\\'),
+                Some('"') => out.push('"'),
+                Some('$') => out.push('$'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => return Err("value ends with a dangling backslash".to_string()),
+            }
+            continue;
+        }
+        out.push(c);
+    }
+
+    if !closed {
+        return Err(format!("unterminated {quote} quote"));
+    }
+
+    let trailing = chars.as_str().trim();
+    if !trailing.is_empty() && !trailing.starts_with('#') {
+        return Err(format!(
+            "unexpected text after the closing quote: {trailing:?}"
+        ));
+    }
+
+    Ok(out)
+}
+
+/// Strip an ` # comment` suffix from an unquoted value.
+fn strip_trailing_comment(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'#' && (i == 0 || bytes[i - 1].is_ascii_whitespace()) {
+            return &value[..i];
+        }
+        i += 1;
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parsed(text: &str) -> BTreeMap<String, String> {
+        parse(text).expect("parse")
+    }
+
+    #[test]
+    fn plain_assignments_are_parsed() {
+        let env = parsed("A=1\nB=two\n");
+        assert_eq!(env.get("A").map(String::as_str), Some("1"));
+        assert_eq!(env.get("B").map(String::as_str), Some("two"));
+    }
+
+    #[test]
+    fn comments_and_blank_lines_are_skipped() {
+        let env = parsed("# leading\n\n  \nA=1\n   # indented\n");
+        assert_eq!(env.len(), 1);
+    }
+
+    #[test]
+    fn export_prefix_is_accepted() {
+        let env = parsed("export A=1\n");
+        assert_eq!(env.get("A").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn empty_values_are_allowed() {
+        let env = parsed("A=\n");
+        assert_eq!(env.get("A").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn double_quotes_keep_spaces_and_expand_escapes() {
+        let env = parsed("A=\"hello world\\nline\"\n");
+        assert_eq!(env.get("A").map(String::as_str), Some("hello world\nline"));
+    }
+
+    #[test]
+    fn single_quotes_are_literal() {
+        let env = parsed("A='no \\n escape'\n");
+        assert_eq!(env.get("A").map(String::as_str), Some("no \\n escape"));
+    }
+
+    #[test]
+    fn trailing_comment_after_an_unquoted_value_is_stripped() {
+        let env = parsed("A=1 # why not\n");
+        assert_eq!(env.get("A").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn a_hash_inside_a_value_is_kept() {
+        let env = parsed("A=ab#cd\n");
+        assert_eq!(env.get("A").map(String::as_str), Some("ab#cd"));
+    }
+
+    #[test]
+    fn a_comment_may_follow_a_quoted_value() {
+        let env = parsed("A=\"x\"  # note\n");
+        assert_eq!(env.get("A").map(String::as_str), Some("x"));
+    }
+
+    #[test]
+    fn later_assignments_win() {
+        let env = parsed("A=1\nA=2\n");
+        assert_eq!(env.get("A").map(String::as_str), Some("2"));
+    }
+
+    #[test]
+    fn a_line_without_equals_is_an_error() {
+        let err = parse("JUST_A_WORD\n").unwrap_err();
+        assert!(matches!(err, EnvFileError::Syntax { line: 1, .. }));
+    }
+
+    #[test]
+    fn an_unterminated_quote_is_an_error() {
+        let err = parse("A=\"oops\n").unwrap_err();
+        assert!(err.to_string().contains("unterminated"));
+    }
+
+    #[test]
+    fn text_after_the_closing_quote_is_an_error() {
+        let err = parse("A=\"x\" y\n").unwrap_err();
+        assert!(err.to_string().contains("after the closing quote"));
+    }
+
+    #[test]
+    fn a_key_with_spaces_is_an_error() {
+        let err = parse("A B=1\n").unwrap_err();
+        assert!(err.to_string().contains("invalid key"));
+    }
+
+    #[test]
+    fn a_byte_order_mark_is_ignored() {
+        let env = parsed("\u{feff}A=1\n");
+        assert_eq!(env.get("A").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn a_missing_file_is_a_read_error() {
+        let err = load(Path::new("/definitely/not/here/.env")).unwrap_err();
+        assert!(matches!(err, EnvFileError::Read(_)));
+    }
+}

--- a/crates/servicrab-core/src/error.rs
+++ b/crates/servicrab-core/src/error.rs
@@ -166,6 +166,17 @@ pub enum ConfigError {
         "service {service:?}: unknown [health] on_unhealthy {value:?}; expected one of: restart, ignore"
     )]
     InvalidUnhealthyAction { service: String, value: String },
+
+    /// An `env_file` could not be read or parsed.
+    #[error("{scope}: env_file {path} could not be loaded: {reason}")]
+    InvalidEnvFile {
+        /// `"project"` or `service "name"`, used as the message prefix.
+        scope: String,
+        /// The path as resolved against the config directory.
+        path: PathBuf,
+        /// Human-readable reason.
+        reason: String,
+    },
 }
 
 /// A non-fatal configuration warning.

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -22,6 +22,7 @@
 //!   across multiple files.
 
 pub mod config;
+pub mod envfile;
 pub mod error;
 pub mod graph;
 pub mod lifecycle;
@@ -35,6 +36,7 @@ pub use config::{
     Config, HealthCheck, HealthProbe, LogSettings, Project, ProjectName, RestartPolicy, Service,
     ServiceName, ShutdownSignal, UnhealthyAction,
 };
+pub use envfile::EnvFileError;
 pub use error::{ConfigError, ConfigWarning, RuntimeError};
 pub use lifecycle::{
     ExitReason, InvalidTransition, ProcessOutcome, RestartDecision, RestartTracker, ServiceState,

--- a/crates/servicrab-core/src/raw.rs
+++ b/crates/servicrab-core/src/raw.rs
@@ -37,9 +37,33 @@ pub struct RawProject {
     #[serde(default)]
     pub env: BTreeMap<String, String>,
 
+    /// Dotenv-style file(s) loaded for every service, before `env`.
+    #[serde(default)]
+    pub env_file: Option<RawEnvFile>,
+
     /// Optional file-logging settings (`[project.logs]`).
     #[serde(default)]
     pub logs: Option<RawLogs>,
+}
+
+/// One path or a list of paths, as accepted by the `env_file` keys.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum RawEnvFile {
+    /// `env_file = ".env"`
+    One(String),
+    /// `env_file = [".env", ".env.local"]`
+    Many(Vec<String>),
+}
+
+impl RawEnvFile {
+    /// The declared paths, in declaration order.
+    pub fn paths(&self) -> &[String] {
+        match self {
+            RawEnvFile::One(p) => std::slice::from_ref(p),
+            RawEnvFile::Many(ps) => ps,
+        }
+    }
 }
 
 /// Raw file-logging settings (`[project.logs]`).
@@ -86,6 +110,10 @@ pub struct RawService {
     /// Service-level environment variables.
     #[serde(default)]
     pub env: BTreeMap<String, String>,
+
+    /// Dotenv-style file(s) loaded for this service, before `env`.
+    #[serde(default)]
+    pub env_file: Option<RawEnvFile>,
 
     /// Services that must be started before this one.
     #[serde(default)]

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -13,7 +13,7 @@ use crate::config::{
 };
 use crate::error::{ConfigError, ConfigWarning};
 use crate::graph::topological_sort;
-use crate::raw::{RawConfig, RawHealthCheck, RawRestartPolicy};
+use crate::raw::{RawConfig, RawEnvFile, RawHealthCheck, RawRestartPolicy};
 
 /// The only supported schema version.
 const SUPPORTED_VERSION: u32 = 1;
@@ -58,6 +58,14 @@ pub fn validate_raw(
 
     // ── 4. Project env ─────────────────────────────────────────────────────
     let project_env = validate_project_env(&raw.project.env, &mut errors);
+
+    // ── 4a. Project env files ──────────────────────────────────────────────
+    let (project_env_files, project_file_env) = load_env_files(
+        raw.project.env_file.as_ref(),
+        &source_dir,
+        "project",
+        &mut errors,
+    );
 
     // ── 4b. Project log settings ───────────────────────────────────────────
     let logs = raw
@@ -119,6 +127,14 @@ pub fn validate_raw(
 
         // Service env
         let svc_env = validate_service_env(&raw_svc.env, raw_name, &mut errors);
+
+        // Service env files
+        let (svc_env_files, svc_file_env) = load_env_files(
+            raw_svc.env_file.as_ref(),
+            &source_dir,
+            &format!("service {raw_name:?}"),
+            &mut errors,
+        );
 
         // Restart policy
         let restart = match raw_svc.restart {
@@ -209,9 +225,12 @@ pub fn validate_raw(
         // Warning: executable not in PATH
         check_executable_in_path(executable, raw_name, &mut warnings);
 
-        // Merge environment: process → project → service  (later overrides earlier)
+        // Merge environment, later layers override earlier ones:
+        //   process → project env_file → project env → service env_file → service env
         let mut merged_env: BTreeMap<String, String> = std::env::vars().collect();
+        merged_env.extend(project_file_env.clone());
         merged_env.extend(project_env.clone());
+        merged_env.extend(svc_file_env);
         merged_env.extend(svc_env);
 
         // Collect depends_on as ServiceNames (cross-service validation deferred)
@@ -231,6 +250,7 @@ pub fn validate_raw(
                 args,
                 cwd,
                 env: merged_env,
+                env_files: svc_env_files,
                 depends_on,
                 autostart: raw_svc.autostart,
                 restart,
@@ -290,6 +310,7 @@ pub fn validate_raw(
         project: Project {
             name: project_name.expect("project_name is Some when no errors"),
             env: project_env,
+            env_files: project_env_files,
             logs,
         },
         services,
@@ -400,6 +421,60 @@ fn validate_service_env(
 
 fn is_valid_env_key(key: &str) -> bool {
     !key.is_empty() && !key.contains('=') && !key.contains('\0')
+}
+
+/// Resolve and read the declared `env_file` entries.
+///
+/// Returns the resolved absolute paths (in declaration order) and the merged
+/// key/value pairs, where a later file overrides an earlier one.  Every failure
+/// is pushed onto `errors`; the caller keeps validating so that a run reports
+/// all problems at once.
+fn load_env_files(
+    declared: Option<&RawEnvFile>,
+    source_dir: &Path,
+    scope: &str,
+    errors: &mut Vec<ConfigError>,
+) -> (Vec<PathBuf>, BTreeMap<String, String>) {
+    let mut paths = Vec::new();
+    let mut merged = BTreeMap::new();
+
+    let Some(declared) = declared else {
+        return (paths, merged);
+    };
+
+    for candidate in declared.paths() {
+        let raw = Path::new(candidate);
+        let path = if raw.is_absolute() {
+            raw.to_path_buf()
+        } else {
+            source_dir.join(raw)
+        };
+
+        match crate::envfile::load(&path) {
+            Ok(vars) => {
+                for (key, value) in vars {
+                    if !is_valid_env_key(&key) || value.contains('\0') {
+                        errors.push(ConfigError::InvalidEnvFile {
+                            scope: scope.to_string(),
+                            path: path.clone(),
+                            reason: format!("invalid entry for key {key:?}"),
+                        });
+                        continue;
+                    }
+                    merged.insert(key, value);
+                }
+            }
+            Err(e) => errors.push(ConfigError::InvalidEnvFile {
+                scope: scope.to_string(),
+                path: path.clone(),
+                reason: e.to_string(),
+            }),
+        }
+
+        paths.push(path);
+    }
+
+    (paths, merged)
 }
 
 // ── cwd resolution ─────────────────────────────────────────────────────────
@@ -1476,6 +1551,7 @@ command = ["echo"]
                 logs: None,
                 name: "p".into(),
                 env: Default::default(),
+                env_file: None,
             },
             services: {
                 let mut m = std::collections::BTreeMap::new();
@@ -1485,6 +1561,7 @@ command = ["echo"]
                         command: vec!["exe\0cutable".to_string()],
                         cwd: None,
                         env: Default::default(),
+                        env_file: None,
                         depends_on: vec![],
                         autostart: true,
                         restart: Default::default(),
@@ -1609,6 +1686,102 @@ _SVCRAB_TEST_KEY = "service"
             Some("service")
         );
         std::env::remove_var("_SVCRAB_TEST_KEY");
+    }
+
+    // ── env_file ───────────────────────────────────────────────────────────
+
+    /// Result of validating a config written into a temp dir.
+    type Validated = Result<(Config, Vec<ConfigWarning>), Vec<ConfigError>>;
+
+    /// Write `servicrab.toml` plus a set of sibling files, then validate.
+    /// The `TempDir` is returned so the caller keeps the tree alive.
+    fn load_with_files(toml: &str, files: &[(&str, &str)]) -> (TempDir, Validated) {
+        let dir = TempDir::new().unwrap();
+        for (name, body) in files {
+            std::fs::write(dir.path().join(name), body).unwrap();
+        }
+        let path = dir.path().join("servicrab.toml");
+        std::fs::write(&path, toml).unwrap();
+        let raw: RawConfig = toml::from_str(toml).expect("raw parse failed in test");
+        let result = validate_raw(raw, &path);
+        (dir, result)
+    }
+
+    #[test]
+    fn a_service_env_file_is_loaded() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nenv_file=\".env\"\n";
+        let (_dir, result) = load_with_files(toml, &[(".env", "FROM_FILE=yes\n")]);
+        let (cfg, _) = result.unwrap();
+        let svc = &cfg.services[&ServiceName("s".into())];
+        assert_eq!(svc.env.get("FROM_FILE").map(String::as_str), Some("yes"));
+        assert_eq!(svc.env_files.len(), 1);
+    }
+
+    #[test]
+    fn a_project_env_file_reaches_every_service() {
+        let toml = "version=1\n[project]\nname=\"p\"\nenv_file=[\".env\"]\n[services.s]\ncommand=[\"echo\"]\n[services.t]\ncommand=[\"echo\"]\n";
+        let (_dir, result) = load_with_files(toml, &[(".env", "SHARED=1\n")]);
+        let (cfg, _) = result.unwrap();
+        for name in ["s", "t"] {
+            let svc = &cfg.services[&ServiceName(name.into())];
+            assert_eq!(svc.env.get("SHARED").map(String::as_str), Some("1"));
+        }
+        assert_eq!(cfg.project.env_files.len(), 1);
+    }
+
+    #[test]
+    fn env_files_are_layered_in_declaration_order() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nenv_file=[\".env\", \".env.local\"]\n";
+        let (_dir, result) =
+            load_with_files(toml, &[(".env", "K=base\n"), (".env.local", "K=local\n")]);
+        let (cfg, _) = result.unwrap();
+        let svc = &cfg.services[&ServiceName("s".into())];
+        assert_eq!(svc.env.get("K").map(String::as_str), Some("local"));
+    }
+
+    #[test]
+    fn an_explicit_env_entry_beats_the_env_file() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nenv_file=\".env\"\n[services.s.env]\nK=\"inline\"\n";
+        let (_dir, result) = load_with_files(toml, &[(".env", "K=file\n")]);
+        let (cfg, _) = result.unwrap();
+        let svc = &cfg.services[&ServiceName("s".into())];
+        assert_eq!(svc.env.get("K").map(String::as_str), Some("inline"));
+    }
+
+    #[test]
+    fn a_service_env_file_beats_the_project_env_file() {
+        let toml = "version=1\n[project]\nname=\"p\"\nenv_file=\".env\"\n[services.s]\ncommand=[\"echo\"]\nenv_file=\".env.svc\"\n";
+        let (_dir, result) = load_with_files(
+            toml,
+            &[(".env", "K=project\n"), (".env.svc", "K=service\n")],
+        );
+        let (cfg, _) = result.unwrap();
+        let svc = &cfg.services[&ServiceName("s".into())];
+        assert_eq!(svc.env.get("K").map(String::as_str), Some("service"));
+    }
+
+    #[test]
+    fn a_missing_env_file_is_a_config_error() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nenv_file=\"nope.env\"\n";
+        let (_dir, result) = load_with_files(toml, &[]);
+        let errs = result.unwrap_err();
+        assert!(errs
+            .iter()
+            .any(|e| matches!(e, ConfigError::InvalidEnvFile { .. })));
+    }
+
+    #[test]
+    fn a_malformed_env_file_is_a_config_error() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nenv_file=\".env\"\n";
+        let (_dir, result) = load_with_files(toml, &[(".env", "not an assignment\n")]);
+        let errs = result.unwrap_err();
+        let message = errs
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(message.contains("env_file"), "got: {message}");
+        assert!(message.contains("line 1"), "got: {message}");
     }
 
     // ── Restart policies ───────────────────────────────────────────────────
@@ -1841,6 +2014,7 @@ restart_delay = "2s"
                 command: vec!["echo".to_string()],
                 cwd: None,
                 env: env.into_iter().collect(),
+                env_file: None,
                 depends_on: vec![],
                 autostart: true,
                 restart: Default::default(),
@@ -1860,6 +2034,7 @@ restart_delay = "2s"
                 logs: None,
                 name: "p".into(),
                 env: Default::default(),
+                env_file: None,
             },
             services,
         }


### PR DESCRIPTION
Two quality-of-life features that people ask for on day one.

### Environment files

```toml
[project]
name = "my-project"
env_file = ".env"                    # or a list: [".env", ".env.local"]

[services.api]
command = ["node", "server.js"]
env_file = [".env.api", ".env.api.local"]

[services.api.env]
PORT = "3000"                        # wins over anything in the files
```

Layering, later wins:

```
inherited shell environment
  → project env_file (in declaration order)
    → [project.env]
      → service env_file (in declaration order)
        → [services.<name>.env]
```

New `servicrab_core::envfile` module parses the format: comments, blank lines, an ignored `export` prefix, single quotes (literal) and double quotes (with `\n \r \t \\ \" \$` escapes), trailing `#` comments on unquoted values, and a UTF-8 BOM. There is deliberately **no** variable expansion — what is written is what the service receives.

Anything wrong with a file (missing, unterminated quote, a line without `=`) is a `ConfigError` carrying the path and the line number, so `servicrab check` catches it and the stack never starts with a half-loaded environment.

`Project::env_files` and `Service::env_files` keep the resolved absolute paths; config hot-reload and `watch` will want them.

### Shell completions

```bash
servicrab completions bash > /etc/bash_completion.d/servicrab
servicrab completions zsh  > ~/.zfunc/_servicrab
servicrab completions fish > ~/.config/fish/completions/servicrab.fish
```

`powershell` and `elvish` work too. The script goes to stdout; nothing is installed behind your back.

### Docs

README gains an "Environment files" and a "Shell completions" section, the command table and roadmap are updated, and the `servicrab init` template documents `env_file`.

### Tests

16 unit tests for the parser, 7 validation tests covering the layering and every error path, 5 CLI integration tests. Whole workspace: 273 tests, green locally.