### PR TITLE
Restart on file change: `[watch]` blocks and `servicrab watch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - `servicrab run <service>` — supervise a single service in the foreground with live stdout/stderr, restart policy, and process-group shutdown (Linux/macOS)
 - `servicrab up` — run your whole stack in the foreground: dependency-ordered start, interleaved and colour-prefixed output, reverse-order shutdown (Linux/macOS)
 - Health checks: `command`, `http` and `tcp` probes with readiness gating and automatic restart of unhealthy services
+- `servicrab watch` — restart a service as soon as its sources change, with ignore rules and debouncing
 - Log files: opt-in per-service capture with size-based rotation, plus `servicrab logs [-f]` to read and follow them
 - Background daemon: `servicrab start` / `status` / `stop` / `restart` / `down`, with a documented JSON-over-Unix-socket protocol (Linux/macOS)
 - Restart policies: `never`, `on-failure`, `always`, with exponential backoff
@@ -124,6 +125,7 @@ if you want shell semantics.
 | `servicrab list [--config PATH] [--json]` | List all services with their restart policies |
 | `servicrab run <SERVICE> [--config PATH] [--no-restart]` | Supervise one service in the foreground |
 | `servicrab up [SERVICE...] [--config PATH] [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure]` | Supervise a whole stack in the foreground |
+| `servicrab watch [SERVICE...] [--config PATH] [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure]` | Like `up`, and restart services when their watched files change |
 | `servicrab logs [SERVICE...] [--config PATH] [-f] [-n N] [--no-prefix]` | Show (and follow) the captured log files |
 | `servicrab start [--config PATH] [--no-restart]` | Start the stack in the background |
 | `servicrab status [--config PATH] [--json]` | Show what the background daemon is doing |
@@ -402,6 +404,49 @@ all of them are powers of 1024.
 
 ---
 
+## Restart on file change
+
+Add a `[watch]` block to a service and it restarts whenever anything under the
+watched paths changes:
+
+```toml
+[services.api]
+command = ["node", "server.js"]
+cwd = "./api"
+
+[services.api.watch]
+paths = ["src", "package.json"]      # relative to the service's cwd
+ignore = ["node_modules", "*.log"]   # names, "dir/prefix" or "*.ext"
+interval = "1s"                      # how often the tree is scanned
+debounce = "300ms"                   # quiet period before restarting
+```
+
+```bash
+servicrab watch          # like `up`, but insists that something is watched
+servicrab up             # honours [watch] too, without the check
+servicrab start          # so does the background daemon
+```
+
+```console
+api | ▶ started (pgid 40311)
+api | ↻ server.js changed; restarting
+api | ◼ stopping: stopped on request
+api | ▶ started (pgid 40388)
+```
+
+`.git` and `.servicrab` are always ignored. The watcher polls rather than
+using inotify or FSEvents: one code path on every platform, no extra
+dependency, and a scan is just a comparison of file sizes and modification
+times. A `cargo build` that rewrites a hundred files causes **one** restart,
+because the watcher waits for `debounce` of quiet before acting.
+
+A watch-triggered restart travels the same control channel as
+`servicrab restart`, so it behaves identically — including under the daemon.
+Trees larger than 20 000 files are reported once and scanned only up to that
+limit; narrow `paths` or add `ignore` entries if you hit it.
+
+---
+
 ## Environment files
 
 Anything you would otherwise repeat in `[project.env]` or
@@ -608,7 +653,7 @@ cargo test -p servicrab-core config::tests
 ### Phase 3 (current) — Stack management
 - [x] `.env` file support per project and per service
 - [x] Shell completions (`servicrab completions <SHELL>`)
-- [ ] `servicrab watch` — restart on file changes (à la `watchexec`)
+- [x] `servicrab watch` — restart on file changes, with ignore rules and debouncing
 - [ ] Config hot-reload
 
 ### Phase 4 — Platform integration (optional)

--- a/crates/servicrab-cli/src/commands/init.rs
+++ b/crates/servicrab-cli/src/commands/init.rs
@@ -57,6 +57,13 @@ name = "my-project"
 #   shutdown_signal       term | int | quit | hup  (default: term)
 #   shutdown_timeout      Wait this long before forcibly killing (default: 10s)
 #
+# Optional [services.<name>.watch] block — restart on file changes:
+#   paths         Files/directories to watch, relative to the service's cwd
+#   ignore        Names, "dir/prefix" or "*.ext" entries never to watch
+#                 (.git and .servicrab are always ignored)
+#   interval      How often the tree is scanned (default: 1s)
+#   debounce      Quiet period before the restart fires (default: 300ms)
+#
 # Optional [services.<name>.logs] block:
 #   enabled       Write this service's output to a log file (default: true,
 #                 only has an effect when [project.logs] exists)
@@ -102,6 +109,10 @@ autostart = false
 
 [services.worker.env]
 DATABASE_URL = "postgres://localhost/mydb"
+
+# [services.worker.watch]
+# paths = ["src", "package.json"]
+# ignore = ["target", "node_modules", "*.log"]
 "#;
 
 /// Run the `init` subcommand.

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -1,5 +1,8 @@
 //! `servicrab up [SERVICE...]` — run a whole stack in the foreground.
 //!
+//! `servicrab watch` is the same supervisor with a stricter entry check: it
+//! refuses to start when nothing in the plan declares a `[watch]` block.
+//!
 //! This module only renders events; starting, restarting, and stopping the
 //! services is entirely [`servicrab_core::runtime::stack`]'s job.
 
@@ -7,10 +10,12 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::Path;
 
-use servicrab_core::runtime::stack::{ServiceResult, StackOptions, StackSupervisor};
+use servicrab_core::runtime::stack::{
+    control_channel, ServiceResult, StackOptions, StackSupervisor,
+};
 use servicrab_core::{
-    event_channel, load, plan_stack, resolve_config_path, Config, EventKind, EventReceiver,
-    LogRouter, ServiceName, ShutdownReason, SignalWatcher, Stream,
+    event_channel, load, plan_stack, resolve_config_path, spawn_watchers, watched_services, Config,
+    EventKind, EventReceiver, LogRouter, ServiceName, ShutdownReason, SignalWatcher, Stream,
 };
 
 use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
@@ -31,6 +36,9 @@ pub struct UpOptions {
     pub timestamps: bool,
     /// Stop the whole stack as soon as one service fails.
     pub abort_on_failure: bool,
+    /// Fail when no service in the plan declares a `[watch]` block.  Set by
+    /// `servicrab watch`.
+    pub require_watch: bool,
 }
 
 /// Run the `up` subcommand, returning the process exit code to use.
@@ -59,8 +67,22 @@ pub fn run(services: &[String], config: Option<&Path>, options: UpOptions) -> Re
         );
     }
 
+    let watched = watched_services(&cfg, &plan);
+    if options.require_watch && watched.is_empty() {
+        let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
+        return Err(format!(
+            "nothing to watch: none of {} declares a [watch] block.\n\
+             Add one, for example:\n\n\
+             \x20 [services.{}.watch]\n\
+             \x20 paths = [\"src\"]",
+            names.join(", "),
+            names.first().copied().unwrap_or("api"),
+        ));
+    }
+
     let printer = Printer::new(&plan, options);
     printer.banner(&cfg, &plan);
+    printer.watching(&watched);
 
     let logs = crate::commands::logs::router_for(&cfg);
 
@@ -82,8 +104,17 @@ pub fn run(services: &[String], config: Option<&Path>, options: UpOptions) -> Re
         let (events_tx, events_rx) = event_channel();
         let renderer = tokio::spawn(render(events_rx, printer, logs));
 
-        let supervisor = StackSupervisor::new(&cfg, plan, stack_options, events_tx);
+        let (control_tx, control_rx) = control_channel();
+        let watchers = spawn_watchers(&cfg, &plan, &control_tx, &events_tx);
+        drop(control_tx);
+
+        let supervisor =
+            StackSupervisor::new(&cfg, plan, stack_options, events_tx).with_control(control_rx);
         let outcome = supervisor.run(&mut shutdown).await;
+
+        for watcher in watchers {
+            watcher.abort();
+        }
 
         // The supervisor owned the last sender, so the renderer stops as soon
         // as it has drained the queue.
@@ -151,11 +182,31 @@ impl Printer {
 
     fn banner(&self, config: &Config, plan: &[ServiceName]) {
         let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
+        let command = if self.options.require_watch {
+            "servicrab watch"
+        } else {
+            "servicrab up"
+        };
         eprintln!(
             "{} {} → {}",
-            style::paint(self.color, BOLD, "servicrab up"),
+            style::paint(self.color, BOLD, command),
             config.project.name,
             names.join(", ")
+        );
+    }
+
+    fn watching(&self, watched: &[ServiceName]) {
+        if watched.is_empty() {
+            return;
+        }
+        let names: Vec<&str> = watched.iter().map(|n| n.as_str()).collect();
+        eprintln!(
+            "{}",
+            style::paint(
+                self.color,
+                DIM,
+                &format!("watching for changes: {}", names.join(", "))
+            )
         );
     }
 
@@ -215,6 +266,26 @@ impl Printer {
             EventKind::Unhealthy { message } => {
                 self.status(service, "✗", &format!("unhealthy: {message}"))
             }
+            EventKind::WatchTriggered { path, changed } => {
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| path.display().to_string());
+                let detail = if *changed == 1 {
+                    format!("{name} changed")
+                } else {
+                    format!("{name} and {} more changed", changed - 1)
+                };
+                self.status(service, "↻", &format!("{detail}; restarting"))
+            }
+            EventKind::WatchFailed { message } => {
+                self.status(service, "!", &format!("watch: {message}"))
+            }
+            EventKind::WatchTruncated { limit } => self.status(
+                service,
+                "!",
+                &format!("watch: more than {limit} files; narrow `paths` or add `ignore` entries"),
+            ),
             // State transitions and the final summary are already conveyed by
             // the events above; showing them too would only add noise.
             EventKind::State(_) | EventKind::Finished { .. } => {}

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -95,10 +95,15 @@ pub fn serve(cfg: &Config, paths: &DaemonPaths, options: DaemonOptions) -> Resul
             listener,
             Arc::clone(&registry),
             stop_tx.clone(),
-            control_tx,
+            control_tx.clone(),
             names.clone(),
             project.clone(),
         ));
+
+        // Watch-triggered restarts travel the same control channel as the
+        // socket's `restart_service`, so the supervisor cannot tell them apart.
+        let watchers = servicrab_core::spawn_watchers(cfg, &plan, &control_tx, &events_tx);
+        drop(control_tx);
 
         write_pid(&paths.pid)?;
         tracing::info!(project = %project, socket = %paths.socket.display(), "daemon ready");
@@ -107,6 +112,9 @@ pub fn serve(cfg: &Config, paths: &DaemonPaths, options: DaemonOptions) -> Resul
             StackSupervisor::new(cfg, plan, stack_options, events_tx).with_control(control_rx);
         let outcome = supervisor.run(&mut stop_rx).await;
 
+        for watcher in watchers {
+            watcher.abort();
+        }
         server.abort();
         signal_task.abort();
         let _ = collector.await;

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -9,6 +9,8 @@
 //!   service in the foreground (Linux/macOS)
 //! - `servicrab up [SERVICE...]` — run a whole stack in the foreground
 //!   (Linux/macOS)
+//! - `servicrab watch [SERVICE...]` — `up` with restart-on-file-change
+//!   (Linux/macOS)
 //!
 //! - `servicrab logs [SERVICE...]` — read the captured log files
 //! - `servicrab completions <SHELL>` — print a shell completion script
@@ -94,6 +96,36 @@ enum Commands {
     /// order, interleave their output, and stop them in reverse order on
     /// Ctrl+C.  Linux and macOS only.
     Up {
+        /// Services to start.  Their dependencies are always started too.
+        /// With no names, every service with autostart = true is started.
+        services: Vec<String>,
+
+        /// Path to the configuration file.  If omitted, discovers
+        /// servicrab.toml by walking up from the current directory.
+        #[arg(long, short = 'c')]
+        config: Option<std::path::PathBuf>,
+
+        /// Never restart services, whatever their configured policy says.
+        #[arg(long, default_value_t = false)]
+        no_restart: bool,
+
+        /// Do not prefix output lines with the service name.
+        #[arg(long, default_value_t = false)]
+        no_prefix: bool,
+
+        /// Prefix output lines with a UTC timestamp.
+        #[arg(long, default_value_t = false)]
+        timestamps: bool,
+
+        /// Stop the whole stack as soon as one service fails.
+        #[arg(long, default_value_t = false)]
+        abort_on_failure: bool,
+    },
+
+    /// Run a stack in the foreground and restart services when their watched
+    /// files change.  Identical to `up`, except that it refuses to start when
+    /// no selected service declares a [watch] block.  Linux and macOS only.
+    Watch {
         /// Services to start.  Their dependencies are always started too.
         /// With no names, every service with autostart = true is started.
         services: Vec<String>,
@@ -240,7 +272,7 @@ fn main() {
     // Either way `RUST_LOG` wins (e.g. `RUST_LOG=debug servicrab up`).
     let default_filter = match cli.command {
         Commands::Run { .. } => "servicrab_core=info",
-        Commands::Up { .. } => "error",
+        Commands::Up { .. } | Commands::Watch { .. } => "error",
         // The daemon's log file is the only trace it leaves, so it keeps the
         // full lifecycle history.
         Commands::Daemon { .. } => "servicrab=info,servicrab_core=info",
@@ -282,6 +314,25 @@ fn main() {
                 no_prefix,
                 timestamps,
                 abort_on_failure,
+                require_watch: false,
+            },
+        ),
+        Commands::Watch {
+            services,
+            config,
+            no_restart,
+            no_prefix,
+            timestamps,
+            abort_on_failure,
+        } => commands::up::run(
+            &services,
+            config.as_deref(),
+            commands::up::UpOptions {
+                no_restart,
+                no_prefix,
+                timestamps,
+                abort_on_failure,
+                require_watch: true,
             },
         ),
         Commands::Start {

--- a/crates/servicrab-cli/tests/watch.rs
+++ b/crates/servicrab-cli/tests/watch.rs
@@ -1,0 +1,305 @@
+//! Integration tests for `servicrab watch` and the `[watch]` config block.
+//!
+//! Every fixture is generated into a [`TempDir`] at test time.  The watched
+//! service appends to a counter file on every start, so "did it restart?" is
+//! a question about the number of lines in that file rather than about timing.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
+use tempfile::TempDir;
+
+/// Upper bound for any wait in this file; keeps a hung test from stalling CI.
+const CEILING: Duration = Duration::from_secs(15);
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+fn script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+/// A project whose single service records every start in `starts.log`.
+///
+/// `watch_body` is dropped verbatim into `[services.app.watch]`; an empty
+/// string leaves the block out entirely.
+fn project(dir: &Path, watch_body: &str) -> PathBuf {
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(dir.join("src/a.txt"), "one\n").unwrap();
+
+    let starts = dir.join("starts.log");
+    script(
+        dir,
+        "app.sh",
+        &format!("echo start >> {}\nsleep 30", starts.display()),
+    );
+
+    let watch = if watch_body.is_empty() {
+        String::new()
+    } else {
+        format!("\n[services.app.watch]\n{watch_body}\n")
+    };
+
+    let path = dir.join("servicrab.toml");
+    fs::write(
+        &path,
+        format!(
+            r#"
+version = 1
+
+[project]
+name = "watchdemo"
+
+[services.app]
+command = ["{}"]
+cwd = "{}"
+restart = "never"
+{watch}
+"#,
+            dir.join("app.sh").display(),
+            dir.display(),
+        ),
+    )
+    .unwrap();
+    path
+}
+
+fn spawn(command: &str, config_path: &Path) -> Child {
+    Command::new(binary())
+        .arg(command)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn servicrab {command}: {e}"))
+}
+
+fn starts(path: &Path) -> usize {
+    fs::read_to_string(path).map_or(0, |text| text.lines().count())
+}
+
+/// Wait until `starts.log` has at least `count` lines.
+fn wait_for_starts(path: &Path, count: usize) {
+    let deadline = Instant::now() + CEILING;
+    while Instant::now() < deadline {
+        if starts(path) >= count {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(30));
+    }
+    panic!("timed out waiting for {count} starts; saw {}", starts(path));
+}
+
+/// Stop the supervisor the way a user would, and drain its stderr.
+fn interrupt(mut child: Child) -> String {
+    let pid = Pid::from_raw(child.id() as i32);
+    let _ = kill(pid, Signal::SIGINT);
+
+    let deadline = Instant::now() + CEILING;
+    loop {
+        match child.try_wait().unwrap() {
+            Some(_) => break,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("supervisor did not exit within {CEILING:?}");
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    }
+
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        use std::io::Read;
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    stderr
+}
+
+// ── restart on change ──────────────────────────────────────────────────────
+
+#[test]
+fn a_change_under_a_watched_path_restarts_the_service() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(
+        dir.path(),
+        "paths = [\"src\"]\ninterval = \"200ms\"\ndebounce = \"100ms\"",
+    );
+    let starts_log = dir.path().join("starts.log");
+
+    let child = spawn("watch", &cfg);
+    wait_for_starts(&starts_log, 1);
+
+    fs::write(dir.path().join("src/a.txt"), "two\n").unwrap();
+    wait_for_starts(&starts_log, 2);
+
+    let stderr = interrupt(child);
+    assert!(
+        stderr.contains("a.txt changed"),
+        "expected the change to be reported, got: {stderr}"
+    );
+}
+
+#[test]
+fn a_new_file_under_a_watched_directory_restarts_the_service() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(
+        dir.path(),
+        "paths = [\"src\"]\ninterval = \"200ms\"\ndebounce = \"100ms\"",
+    );
+    let starts_log = dir.path().join("starts.log");
+
+    let child = spawn("watch", &cfg);
+    wait_for_starts(&starts_log, 1);
+
+    fs::write(dir.path().join("src/new.txt"), "hello\n").unwrap();
+    wait_for_starts(&starts_log, 2);
+
+    interrupt(child);
+}
+
+#[test]
+fn several_changes_in_a_row_cause_a_single_restart() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(
+        dir.path(),
+        "paths = [\"src\"]\ninterval = \"200ms\"\ndebounce = \"400ms\"",
+    );
+    let starts_log = dir.path().join("starts.log");
+
+    let child = spawn("watch", &cfg);
+    wait_for_starts(&starts_log, 1);
+
+    for i in 0..5 {
+        fs::write(dir.path().join(format!("src/f{i}.txt")), "x\n").unwrap();
+        std::thread::sleep(Duration::from_millis(120));
+    }
+    wait_for_starts(&starts_log, 2);
+    std::thread::sleep(Duration::from_millis(800));
+
+    let seen = starts(&starts_log);
+    interrupt(child);
+    assert_eq!(seen, 2, "the debounce window should collapse the burst");
+}
+
+#[test]
+fn ignored_paths_do_not_trigger_a_restart() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(
+        dir.path(),
+        "paths = [\"src\"]\nignore = [\"*.log\", \"vendor\"]\ninterval = \"200ms\"\ndebounce = \"100ms\"",
+    );
+    let starts_log = dir.path().join("starts.log");
+
+    let child = spawn("watch", &cfg);
+    wait_for_starts(&starts_log, 1);
+
+    fs::create_dir_all(dir.path().join("src/vendor")).unwrap();
+    fs::write(dir.path().join("src/vendor/lib.txt"), "x\n").unwrap();
+    fs::write(dir.path().join("src/debug.log"), "noise\n").unwrap();
+    std::thread::sleep(Duration::from_millis(900));
+
+    let seen = starts(&starts_log);
+    interrupt(child);
+    assert_eq!(seen, 1, "ignored files must not restart the service");
+}
+
+// ── up honours the same config ─────────────────────────────────────────────
+
+#[test]
+fn up_also_restarts_on_a_watched_change() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(
+        dir.path(),
+        "paths = [\"src\"]\ninterval = \"200ms\"\ndebounce = \"100ms\"",
+    );
+    let starts_log = dir.path().join("starts.log");
+
+    let child = spawn("up", &cfg);
+    wait_for_starts(&starts_log, 1);
+
+    fs::write(dir.path().join("src/a.txt"), "changed\n").unwrap();
+    wait_for_starts(&starts_log, 2);
+
+    interrupt(child);
+}
+
+// ── entry checks ───────────────────────────────────────────────────────────
+
+#[test]
+fn watch_refuses_to_start_when_nothing_is_watched() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path(), "");
+
+    let output = Command::new(binary())
+        .arg("watch")
+        .arg("--config")
+        .arg(&cfg)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab watch");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("nothing to watch"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("[services.app.watch]"),
+        "the error should show how to fix it: {stderr}"
+    );
+}
+
+#[test]
+fn a_watched_path_that_does_not_exist_is_a_config_error() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path(), "paths = [\"nope\"]");
+
+    let output = Command::new(binary())
+        .arg("check")
+        .arg("--config")
+        .arg(&cfg)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab check");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("[watch]"), "unexpected stderr: {stderr}");
+}
+
+#[test]
+fn an_empty_paths_list_is_a_config_error() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path(), "paths = []");
+
+    let output = Command::new(binary())
+        .arg("check")
+        .arg("--config")
+        .arg(&cfg)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab check");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("at least one file or directory"),
+        "unexpected stderr: {stderr}"
+    );
+}

--- a/crates/servicrab-core/src/config.rs
+++ b/crates/servicrab-core/src/config.rs
@@ -237,6 +237,43 @@ pub struct HealthCheck {
 
 // ── Service ────────────────────────────────────────────────────────────────
 
+/// Validated file-watching settings for a service.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WatchSettings {
+    /// Absolute paths (files or directories) to watch.
+    pub paths: Vec<PathBuf>,
+    /// Names, path prefixes or `*.ext` patterns that are never watched.
+    pub ignore: Vec<String>,
+    /// How often the watched paths are scanned.
+    pub interval: Duration,
+    /// How long the tree must stay unchanged before the restart fires.
+    pub debounce: Duration,
+}
+
+impl WatchSettings {
+    /// Whether `relative` — a path relative to one of the watched roots —
+    /// matches any ignore entry.
+    ///
+    /// An entry matches when it equals a path component, when it is a prefix
+    /// of the relative path, or when it is a `*.ext` pattern matching the file
+    /// extension.
+    pub fn is_ignored(&self, relative: &std::path::Path) -> bool {
+        self.ignore.iter().any(|entry| {
+            if let Some(ext) = entry.strip_prefix("*.") {
+                return relative
+                    .extension()
+                    .is_some_and(|actual| actual.to_string_lossy() == ext);
+            }
+            if entry.contains('/') {
+                return relative.starts_with(entry);
+            }
+            relative
+                .components()
+                .any(|c| c.as_os_str().to_string_lossy() == *entry)
+        })
+    }
+}
+
 /// Validated configuration for a single managed service.
 #[derive(Debug, Clone, Serialize)]
 pub struct Service {
@@ -277,6 +314,9 @@ pub struct Service {
     /// Whether this service's output is written to a log file (only relevant
     /// when the project declares `[project.logs]`).
     pub log_to_file: bool,
+    /// Optional file-watching settings; when set, the supervisor restarts the
+    /// service after a change under the watched paths.
+    pub watch: Option<WatchSettings>,
 }
 
 // ── Config ─────────────────────────────────────────────────────────────────

--- a/crates/servicrab-core/src/error.rs
+++ b/crates/servicrab-core/src/error.rs
@@ -177,6 +177,15 @@ pub enum ConfigError {
         /// Human-readable reason.
         reason: String,
     },
+
+    /// A `[watch]` block is unusable.
+    #[error("service {service:?}: [watch] {reason}")]
+    InvalidWatch {
+        /// Affected service.
+        service: String,
+        /// Human-readable reason.
+        reason: String,
+    },
 }
 
 /// A non-fatal configuration warning.

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -34,7 +34,7 @@ pub mod validation;
 // Convenience re-exports.
 pub use config::{
     Config, HealthCheck, HealthProbe, LogSettings, Project, ProjectName, RestartPolicy, Service,
-    ServiceName, ShutdownSignal, UnhealthyAction,
+    ServiceName, ShutdownSignal, UnhealthyAction, WatchSettings,
 };
 pub use envfile::EnvFileError;
 pub use error::{ConfigError, ConfigWarning, RuntimeError};
@@ -43,6 +43,7 @@ pub use lifecycle::{
     ShutdownReason, StateMachine,
 };
 pub use load::{discover_config, load, resolve_config_path};
+pub use runtime::filewatch::{spawn_watchers, watched_services};
 pub use runtime::{
     control_channel, event_channel, plan_stack, Control, ControlTx, EventKind, EventReceiver,
     EventSender, EventSink, ForegroundRunner, Health, LogRouter, LogWriter, OutputMode, RunOptions,

--- a/crates/servicrab-core/src/raw.rs
+++ b/crates/servicrab-core/src/raw.rs
@@ -162,6 +162,32 @@ pub struct RawService {
     /// Optional per-service logging settings (`[services.<name>.logs]`).
     #[serde(default)]
     pub logs: Option<RawServiceLogs>,
+
+    /// Optional file-watching settings (`[services.<name>.watch]`).
+    #[serde(default)]
+    pub watch: Option<RawWatch>,
+}
+
+/// Raw file-watching settings (`[services.<name>.watch]`).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawWatch {
+    /// Files and directories to watch.  Relative paths resolve against the
+    /// service's working directory.
+    pub paths: Vec<String>,
+
+    /// Names, path prefixes or `*.ext` patterns to ignore.
+    #[serde(default)]
+    pub ignore: Vec<String>,
+
+    /// How often the watched paths are scanned.  Defaults to `"1s"`.
+    #[serde(default)]
+    pub interval: Option<String>,
+
+    /// How long the tree must stay unchanged before the restart fires.
+    /// Defaults to `"300ms"`.
+    #[serde(default)]
+    pub debounce: Option<String>,
 }
 
 /// Raw health-check configuration (`[services.<name>.health]`).

--- a/crates/servicrab-core/src/runtime/event.rs
+++ b/crates/servicrab-core/src/runtime/event.rs
@@ -93,6 +93,24 @@ pub enum EventKind {
         /// Why the last probe failed.
         message: String,
     },
+    /// A watched path changed and a restart was requested.
+    WatchTriggered {
+        /// The first changed path, in sort order.
+        path: std::path::PathBuf,
+        /// How many paths changed in this batch.
+        changed: usize,
+    },
+    /// A watch-triggered restart was refused by the supervisor.
+    WatchFailed {
+        /// Why the restart did not happen.
+        message: String,
+    },
+    /// The watched tree is larger than the scan limit, so changes beyond it
+    /// go unnoticed.
+    WatchTruncated {
+        /// How many files the watcher is willing to scan.
+        limit: usize,
+    },
     /// The service failed fatally.
     Failed {
         /// A human-readable description of the failure.

--- a/crates/servicrab-core/src/runtime/filewatch.rs
+++ b/crates/servicrab-core/src/runtime/filewatch.rs
@@ -1,0 +1,378 @@
+//! File watching: restart a service when its sources change.
+//!
+//! The watcher polls instead of using platform notification APIs.  Polling
+//! keeps the dependency footprint at zero, behaves identically on Linux and
+//! macOS, and is trivially testable: a scan is a pure function of the file
+//! system, and a change is a difference between two scans.
+//!
+//! A restart is requested through the ordinary [`Control`] channel, so the
+//! supervisor treats a watch-triggered restart exactly like `servicrab restart`.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use tokio::sync::oneshot;
+
+use crate::config::{Config, ServiceName, WatchSettings};
+use crate::runtime::event::{EventKind, EventSender, ServiceEvent};
+use crate::runtime::stack::{Control, ControlTx};
+
+/// Stop scanning after this many files, so a mis-configured `paths` entry
+/// cannot pin a core.
+const MAX_ENTRIES: usize = 20_000;
+
+/// What a single scan recorded about one file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileStamp {
+    /// Last modification time, when the platform reports one.
+    pub modified: Option<SystemTime>,
+    /// Size in bytes.
+    pub len: u64,
+}
+
+/// The state of the watched tree at one point in time.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Scan {
+    /// Every watched file, keyed by absolute path.
+    pub files: BTreeMap<PathBuf, FileStamp>,
+    /// Whether the scan hit [`MAX_ENTRIES`] and stopped early.
+    pub truncated: bool,
+}
+
+impl Scan {
+    /// Paths that appeared, disappeared or changed between `self` and `next`.
+    pub fn changes(&self, next: &Scan) -> Vec<PathBuf> {
+        let mut changed = Vec::new();
+        for (path, stamp) in &next.files {
+            if self.files.get(path) != Some(stamp) {
+                changed.push(path.clone());
+            }
+        }
+        for path in self.files.keys() {
+            if !next.files.contains_key(path) {
+                changed.push(path.clone());
+            }
+        }
+        changed.sort();
+        changed.dedup();
+        changed
+    }
+}
+
+/// Walk the configured paths and record a stamp for every file.
+///
+/// Unreadable entries are skipped rather than reported: a file that vanishes
+/// mid-scan is a change, not an error, and the next scan will notice it.
+pub fn scan(settings: &WatchSettings) -> Scan {
+    let mut out = Scan::default();
+    for root in &settings.paths {
+        walk(root, root, settings, &mut out);
+        if out.truncated {
+            break;
+        }
+    }
+    out
+}
+
+fn walk(root: &Path, path: &Path, settings: &WatchSettings, out: &mut Scan) {
+    if out.files.len() >= MAX_ENTRIES {
+        out.truncated = true;
+        return;
+    }
+
+    // Ignore rules are matched against the path relative to the watched root,
+    // so `ignore = ["target"]` means "the target directory in here".
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    if !relative.as_os_str().is_empty() && settings.is_ignored(relative) {
+        return;
+    }
+
+    // `symlink_metadata` does not follow links, which keeps a symlink loop
+    // from turning the walk into an infinite one.
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return;
+    };
+
+    if meta.is_dir() {
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return;
+        };
+        let mut children: Vec<PathBuf> = entries.filter_map(|e| e.ok()).map(|e| e.path()).collect();
+        children.sort();
+        for child in children {
+            walk(root, &child, settings, out);
+            if out.truncated {
+                return;
+            }
+        }
+        return;
+    }
+
+    out.files.insert(
+        path.to_path_buf(),
+        FileStamp {
+            modified: meta.modified().ok(),
+            len: meta.len(),
+        },
+    );
+}
+
+/// Watch one service until the control channel goes away.
+///
+/// After a change the watcher waits for `debounce` of quiet before asking for
+/// the restart, so a `cargo build` writing a hundred files causes one restart
+/// rather than a hundred.
+pub async fn watch_service(
+    service: ServiceName,
+    settings: WatchSettings,
+    control: ControlTx,
+    events: EventSender,
+) {
+    let mut previous = scan(&settings);
+    if previous.truncated {
+        let _ = events.send(ServiceEvent::new(
+            service.clone(),
+            EventKind::WatchTruncated { limit: MAX_ENTRIES },
+        ));
+    }
+
+    loop {
+        tokio::time::sleep(settings.interval).await;
+
+        let mut current = scan(&settings);
+        let mut changed = previous.changes(&current);
+        if changed.is_empty() {
+            continue;
+        }
+
+        // Wait for the tree to settle before acting on the first change.
+        loop {
+            tokio::time::sleep(settings.debounce).await;
+            let settled = scan(&settings);
+            let extra = current.changes(&settled);
+            current = settled;
+            if extra.is_empty() {
+                break;
+            }
+            changed.extend(extra);
+        }
+
+        changed.sort();
+        changed.dedup();
+
+        let first = changed.first().cloned().unwrap_or_default();
+        let _ = events.send(ServiceEvent::new(
+            service.clone(),
+            EventKind::WatchTriggered {
+                path: first,
+                changed: changed.len(),
+            },
+        ));
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        if control
+            .send(Control::Restart {
+                service: service.clone(),
+                ack: ack_tx,
+            })
+            .is_err()
+        {
+            // The supervisor is gone; nothing left to watch for.
+            return;
+        }
+
+        match ack_rx.await {
+            Ok(Err(message)) => {
+                let _ = events.send(ServiceEvent::new(
+                    service.clone(),
+                    EventKind::WatchFailed { message },
+                ));
+            }
+            Ok(Ok(_)) => {}
+            // The supervisor dropped the ack: it is shutting down.
+            Err(_) => return,
+        }
+
+        // A restart rewrites files itself (pid files, sockets); re-scan so the
+        // next comparison starts from the post-restart state.
+        previous = scan(&settings);
+    }
+}
+
+/// Spawn a watcher task for every planned service that declares `[watch]`.
+///
+/// Returns the join handles, and an empty vector when nothing is watched.
+pub fn spawn_watchers(
+    config: &Config,
+    plan: &[ServiceName],
+    control: &ControlTx,
+    events: &EventSender,
+) -> Vec<tokio::task::JoinHandle<()>> {
+    let mut handles = Vec::new();
+    for name in plan {
+        let Some(service) = config.services.get(name) else {
+            continue;
+        };
+        let Some(settings) = service.watch.clone() else {
+            continue;
+        };
+        handles.push(tokio::spawn(watch_service(
+            name.clone(),
+            settings,
+            control.clone(),
+            events.clone(),
+        )));
+    }
+    handles
+}
+
+/// Services in `plan` that declare a `[watch]` block.
+pub fn watched_services(config: &Config, plan: &[ServiceName]) -> Vec<ServiceName> {
+    plan.iter()
+        .filter(|name| {
+            config
+                .services
+                .get(*name)
+                .is_some_and(|svc| svc.watch.is_some())
+        })
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::time::Duration;
+
+    use tempfile::TempDir;
+
+    fn settings(dir: &Path, ignore: &[&str]) -> WatchSettings {
+        WatchSettings {
+            paths: vec![dir.to_path_buf()],
+            ignore: ignore.iter().map(|s| (*s).to_string()).collect(),
+            interval: Duration::from_millis(100),
+            debounce: Duration::from_millis(50),
+        }
+    }
+
+    #[test]
+    fn a_scan_records_every_file_below_the_root() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("a.txt"), "a").unwrap();
+        std::fs::write(dir.path().join("sub/b.txt"), "b").unwrap();
+
+        let s = scan(&settings(dir.path(), &[]));
+        assert_eq!(s.files.len(), 2);
+        assert!(!s.truncated);
+    }
+
+    #[test]
+    fn an_unchanged_tree_reports_no_changes() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "a").unwrap();
+        let settings = settings(dir.path(), &[]);
+
+        let before = scan(&settings);
+        let after = scan(&settings);
+        assert!(before.changes(&after).is_empty());
+    }
+
+    #[test]
+    fn a_new_file_is_a_change() {
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), &[]);
+        let before = scan(&settings);
+
+        std::fs::write(dir.path().join("new.txt"), "x").unwrap();
+        let after = scan(&settings);
+
+        let changed = before.changes(&after);
+        assert_eq!(changed.len(), 1);
+        assert!(changed[0].ends_with("new.txt"));
+    }
+
+    #[test]
+    fn a_removed_file_is_a_change() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("gone.txt"), "x").unwrap();
+        let settings = settings(dir.path(), &[]);
+        let before = scan(&settings);
+
+        std::fs::remove_file(dir.path().join("gone.txt")).unwrap();
+        let after = scan(&settings);
+
+        assert_eq!(before.changes(&after).len(), 1);
+    }
+
+    #[test]
+    fn a_resized_file_is_a_change_even_with_a_coarse_clock() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "short").unwrap();
+        let settings = settings(dir.path(), &[]);
+        let before = scan(&settings);
+
+        std::fs::write(dir.path().join("a.txt"), "considerably longer").unwrap();
+        let after = scan(&settings);
+
+        assert_eq!(before.changes(&after).len(), 1);
+    }
+
+    #[test]
+    fn ignored_directories_are_not_scanned() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("target")).unwrap();
+        std::fs::write(dir.path().join("target/big.bin"), "x").unwrap();
+        std::fs::write(dir.path().join("a.txt"), "a").unwrap();
+
+        let s = scan(&settings(dir.path(), &["target"]));
+        assert_eq!(s.files.len(), 1);
+    }
+
+    #[test]
+    fn ignored_extensions_are_not_scanned() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.log"), "a").unwrap();
+        std::fs::write(dir.path().join("a.rs"), "a").unwrap();
+
+        let s = scan(&settings(dir.path(), &["*.log"]));
+        assert_eq!(s.files.len(), 1);
+        assert!(s.files.keys().next().unwrap().ends_with("a.rs"));
+    }
+
+    #[test]
+    fn an_ignore_prefix_with_a_slash_matches_a_subtree() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("src/generated")).unwrap();
+        std::fs::write(dir.path().join("src/generated/x.rs"), "x").unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "m").unwrap();
+
+        let s = scan(&settings(dir.path(), &["src/generated"]));
+        assert_eq!(s.files.len(), 1);
+    }
+
+    #[test]
+    fn a_watched_file_may_be_a_single_path() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("only.txt");
+        std::fs::write(&file, "x").unwrap();
+
+        let s = scan(&WatchSettings {
+            paths: vec![file.clone()],
+            ignore: Vec::new(),
+            interval: Duration::from_secs(1),
+            debounce: Duration::from_millis(50),
+        });
+        assert_eq!(s.files.len(), 1);
+        assert!(s.files.contains_key(&file));
+    }
+
+    #[test]
+    fn a_missing_root_scans_to_nothing() {
+        let dir = TempDir::new().unwrap();
+        let s = scan(&settings(&dir.path().join("nope"), &[]));
+        assert!(s.files.is_empty());
+    }
+}

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -23,6 +23,7 @@ use crate::config::RestartPolicy;
 use crate::lifecycle::{ExitReason, ShutdownReason};
 
 pub mod event;
+pub mod filewatch;
 #[cfg(unix)]
 pub mod health;
 pub mod logs;
@@ -48,6 +49,7 @@ pub use stub::{ForegroundRunner, ServiceRunner, SignalWatcher};
 pub use event::{
     event_channel, EventKind, EventReceiver, EventSender, EventSink, ServiceEvent, Stream,
 };
+pub use filewatch::{scan, spawn_watchers, watch_service, watched_services, FileStamp, Scan};
 #[cfg(unix)]
 pub use health::{HealthMonitor, HealthSignal};
 pub use logs::{LogRouter, LogWriter};

--- a/crates/servicrab-core/src/runtime/status.rs
+++ b/crates/servicrab-core/src/runtime/status.rs
@@ -140,6 +140,25 @@ impl StatusRegistry {
             }
             EventKind::Failed { message } => entry.message = Some(message.clone()),
             EventKind::Finished { summary } => entry.message = Some(summary.clone()),
+            EventKind::WatchTriggered { path, changed } => {
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| path.display().to_string());
+                entry.message = Some(if *changed == 1 {
+                    format!("restarting: {name} changed")
+                } else {
+                    format!("restarting: {name} and {} more changed", changed - 1)
+                });
+            }
+            EventKind::WatchFailed { message } => {
+                entry.message = Some(format!("watch: {message}"));
+            }
+            EventKind::WatchTruncated { limit } => {
+                entry.message = Some(format!(
+                    "watch: more than {limit} files; narrow `paths` or add `ignore` entries"
+                ));
+            }
             // Log lines are far too frequent to keep, and `Exited` is already
             // reflected by the state transition that follows it.
             EventKind::Log { .. } | EventKind::Exited { .. } | EventKind::Stopping { .. } => {}

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -9,11 +9,11 @@ use std::time::Duration;
 
 use crate::config::{
     Config, HealthCheck, HealthProbe, LogSettings, Project, ProjectName, RestartPolicy, Service,
-    ServiceName, ShutdownSignal, UnhealthyAction,
+    ServiceName, ShutdownSignal, UnhealthyAction, WatchSettings,
 };
 use crate::error::{ConfigError, ConfigWarning};
 use crate::graph::topological_sort;
-use crate::raw::{RawConfig, RawEnvFile, RawHealthCheck, RawRestartPolicy};
+use crate::raw::{RawConfig, RawEnvFile, RawHealthCheck, RawRestartPolicy, RawWatch};
 
 /// The only supported schema version.
 const SUPPORTED_VERSION: u32 = 1;
@@ -196,6 +196,11 @@ pub fn validate_raw(
 
         let log_to_file = raw_svc.logs.as_ref().map_or(true, |logs| logs.enabled);
 
+        let watch = raw_svc
+            .watch
+            .as_ref()
+            .and_then(|raw_watch| validate_watch(raw_watch, &cwd, raw_name, &mut errors));
+
         // restart_max_delay >= restart_delay
         if restart_max_delay < restart_delay {
             errors.push(ConfigError::RestartMaxDelayTooSmall {
@@ -262,6 +267,7 @@ pub fn validate_raw(
                 shutdown_timeout,
                 health,
                 log_to_file,
+                watch,
             },
         );
     }
@@ -579,6 +585,97 @@ fn parse_duration_field(
     }
 
     dur
+}
+
+// ── Watch settings validation ──────────────────────────────────────────────
+
+/// Ignore entries that are always applied, on top of what the config asks for.
+const ALWAYS_IGNORED: [&str; 2] = [".git", ".servicrab"];
+
+/// Validate a `[services.<name>.watch]` table.
+fn validate_watch(
+    raw: &RawWatch,
+    cwd: &Path,
+    service: &str,
+    errors: &mut Vec<ConfigError>,
+) -> Option<WatchSettings> {
+    let mut paths = Vec::new();
+
+    if raw.paths.is_empty() {
+        errors.push(ConfigError::InvalidWatch {
+            service: service.to_string(),
+            reason: "paths must list at least one file or directory".to_string(),
+        });
+    }
+
+    for entry in &raw.paths {
+        if entry.is_empty() {
+            errors.push(ConfigError::InvalidWatch {
+                service: service.to_string(),
+                reason: "paths must not contain an empty entry".to_string(),
+            });
+            continue;
+        }
+
+        let candidate = PathBuf::from(entry);
+        let resolved = if candidate.is_absolute() {
+            candidate
+        } else {
+            cwd.join(candidate)
+        };
+
+        match resolved.canonicalize() {
+            Ok(path) => paths.push(path),
+            Err(e) => errors.push(ConfigError::InvalidWatch {
+                service: service.to_string(),
+                reason: format!("path {} cannot be watched: {e}", resolved.display()),
+            }),
+        }
+    }
+
+    let interval = parse_duration_field(
+        raw.interval.as_deref(),
+        "watch.interval",
+        Duration::from_secs(1),
+        service,
+        DUR_100MS,
+        DUR_1H,
+        errors,
+    );
+    let debounce = parse_duration_field(
+        raw.debounce.as_deref(),
+        "watch.debounce",
+        Duration::from_millis(300),
+        service,
+        Duration::from_millis(50),
+        DUR_1H,
+        errors,
+    );
+
+    let mut ignore: Vec<String> = ALWAYS_IGNORED.iter().map(|s| (*s).to_string()).collect();
+    for entry in &raw.ignore {
+        if entry.is_empty() {
+            errors.push(ConfigError::InvalidWatch {
+                service: service.to_string(),
+                reason: "ignore must not contain an empty entry".to_string(),
+            });
+            continue;
+        }
+        if !ignore.iter().any(|existing| existing == entry) {
+            ignore.push(entry.clone());
+        }
+    }
+
+    if paths.is_empty() {
+        return None;
+    }
+
+    Some(WatchSettings {
+        paths,
+        ignore,
+        interval,
+        debounce,
+    })
 }
 
 // ── Log settings validation ────────────────────────────────────────────────
@@ -1573,6 +1670,7 @@ command = ["echo"]
                         shutdown_timeout: None,
                         health: None,
                         logs: None,
+                        watch: None,
                     },
                 );
                 m
@@ -1758,6 +1856,65 @@ _SVCRAB_TEST_KEY = "service"
         let (cfg, _) = result.unwrap();
         let svc = &cfg.services[&ServiceName("s".into())];
         assert_eq!(svc.env.get("K").map(String::as_str), Some("service"));
+    }
+
+    // ── watch ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn a_watch_block_resolves_paths_against_the_service_cwd() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\n[services.s.watch]\npaths=[\"src\"]\n";
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        let path = dir.path().join("servicrab.toml");
+        std::fs::write(&path, toml).unwrap();
+        let raw: RawConfig = toml::from_str(toml).unwrap();
+        let (cfg, _) = validate_raw(raw, &path).unwrap();
+
+        let watch = cfg.services[&ServiceName("s".into())]
+            .watch
+            .as_ref()
+            .expect("watch settings");
+        assert_eq!(watch.paths.len(), 1);
+        assert!(watch.paths[0].ends_with("src"));
+        assert_eq!(watch.interval, Duration::from_secs(1));
+        assert_eq!(watch.debounce, Duration::from_millis(300));
+    }
+
+    #[test]
+    fn watch_always_ignores_git_and_servicrab_state() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\n[services.s.watch]\npaths=[\"src\"]\nignore=[\"target\"]\n";
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        let path = dir.path().join("servicrab.toml");
+        std::fs::write(&path, toml).unwrap();
+        let raw: RawConfig = toml::from_str(toml).unwrap();
+        let (cfg, _) = validate_raw(raw, &path).unwrap();
+
+        let watch = cfg.services[&ServiceName("s".into())]
+            .watch
+            .as_ref()
+            .expect("watch settings");
+        for entry in [".git", ".servicrab", "target"] {
+            assert!(
+                watch.ignore.iter().any(|i| i == entry),
+                "{entry} should be ignored, got {:?}",
+                watch.ignore
+            );
+        }
+    }
+
+    #[test]
+    fn a_watch_interval_below_the_minimum_is_a_config_error() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\n[services.s.watch]\npaths=[\"src\"]\ninterval=\"1ms\"\n";
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        let path = dir.path().join("servicrab.toml");
+        std::fs::write(&path, toml).unwrap();
+        let raw: RawConfig = toml::from_str(toml).unwrap();
+        let errs = validate_raw(raw, &path).unwrap_err();
+        assert!(errs
+            .iter()
+            .any(|e| matches!(e, ConfigError::DurationOutOfRange { field, .. } if *field == "watch.interval")));
     }
 
     #[test]
@@ -2026,6 +2183,7 @@ restart_delay = "2s"
                 shutdown_timeout: None,
                 health: None,
                 logs: None,
+                watch: None,
             },
         );
         RawConfig {


### PR DESCRIPTION
A service can now declare what it is built from, and the supervisor restarts it when that changes.

```toml
[services.api]
command = ["node", "server.js"]
cwd = "./api"

[services.api.watch]
paths = ["src", "package.json"]      # relative to the service's cwd
ignore = ["node_modules", "*.log"]   # names, "dir/prefix" or "*.ext"
interval = "1s"                      # how often the tree is scanned
debounce = "300ms"                   # quiet period before restarting
```

```console
$ servicrab watch
servicrab watch watchdemo → api
watching for changes: api
api | ▶ started (pgid 40311)
api | ↻ server.js changed; restarting
api | ◼ stopping: stopped on request
api | ▶ started (pgid 40388)
```

### Why polling

The new `runtime::filewatch` module polls instead of using inotify/FSEvents. That buys:

- **one code path** on both supported platforms, and no new dependency;
- **testability** — a scan is a pure function of the file system (`path → size + mtime`), a change is the difference between two scans, so the interesting logic is covered by ordinary unit tests;
- **predictability** — no event coalescing differences between Linux and macOS to reason about.

Symlinks are not followed (a loop cannot hang the walk) and a scan stops at 20 000 files, reporting `WatchTruncated` once instead of pinning a core.

### Debouncing

After the first change the watcher keeps scanning until the tree has been quiet for `debounce`. A `cargo build` that rewrites a hundred files causes **one** restart, which the `several_changes_in_a_row_cause_a_single_restart` test pins down.

### Reusing the control channel

The restart is requested over the `Control::Restart` channel added in #9, so a watch-triggered restart is indistinguishable from `servicrab restart` — same ack semantics, same behaviour inside the daemon. No new code path in the supervisor at all.

### CLI

- `servicrab watch [SERVICE...]` is `up` plus an entry check: it refuses to start when nothing in the plan declares `[watch]`, and the error prints the block to add.
- `up` and the daemon honour `[watch]` too, without that check.
- New `WatchTriggered` / `WatchFailed` / `WatchTruncated` events are rendered by `up` and folded into the status registry, so `servicrab status` explains why a service just bounced.

### Tests

10 filewatch unit tests, 3 validation tests, and a new `tests/watch.rs` with 8 integration tests: restart on modify, restart on a new file, the debounce collapse, ignore rules (`*.ext` and directory), `up` parity, and the three config-error paths. Workspace total: 294 tests, green locally.