### PR TITLE
Config hot-reload: `servicrab reload`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - `servicrab watch` — restart a service as soon as its sources change, with ignore rules and debouncing
 - Log files: opt-in per-service capture with size-based rotation, plus `servicrab logs [-f]` to read and follow them
 - Background daemon: `servicrab start` / `status` / `stop` / `restart` / `down`, with a documented JSON-over-Unix-socket protocol (Linux/macOS)
+- `servicrab reload` — apply config changes to a running stack without stopping the services you did not touch
 - Restart policies: `never`, `on-failure`, `always`, with exponential backoff
 - Environment: per-service variables, working directories, and dotenv-style `env_file` layering
 - Shell completions for bash, zsh, fish, PowerShell and elvish
@@ -131,6 +132,7 @@ if you want shell semantics.
 | `servicrab status [--config PATH] [--json]` | Show what the background daemon is doing |
 | `servicrab stop <SERVICE...> [--config PATH]` | Stop individual services in the running daemon |
 | `servicrab restart <SERVICE...> [--config PATH]` | Restart individual services |
+| `servicrab reload [--config PATH]` | Re-read the config and apply the difference to the running daemon |
 | `servicrab down [--config PATH]` | Stop the daemon and every service it supervises |
 | `servicrab daemon [--config PATH] [--no-restart]` | Run the daemon in the foreground (for systemd/launchd/containers) |
 | `servicrab completions <SHELL>` | Print a completion script for bash, zsh, fish, PowerShell or elvish |
@@ -570,10 +572,48 @@ echo '{"type":"status"}' | nc -U .servicrab/daemon.sock
 | `{"type":"start_service","name":"api"}` | `{"type":"ok","message":"api started"}` |
 | `{"type":"stop_service","name":"api"}` | `{"type":"ok","message":"api stopped"}` |
 | `{"type":"restart_service","name":"api"}` | `{"type":"ok","message":"api restarted"}` |
+| `{"type":"reload"}` | `{"type":"ok","message":"reloaded demo: 1 added, 1 changed, 0 removed"}` |
 
 `stop_service` and `restart_service` only answer once the service has actually
 stopped (and, for a restart, been replaced), so scripts can rely on the reply
 instead of polling.
+
+### Config hot-reload
+
+`servicrab reload` makes the running daemon re-read its `servicrab.toml` and
+apply only what changed:
+
+```console
+$ servicrab reload
+✓ reloaded demo: 1 added, 1 changed, 1 removed
+  from /srv/demo/servicrab.toml
+```
+
+| Difference | What the daemon does |
+| --- | --- |
+| A service was added | It is started (and becomes visible to `status`, `stop`, `restart`, …) |
+| A service definition changed | It is restarted with the new definition |
+| A service was removed | It is stopped and disappears from the stack |
+| Nothing changed | Nothing at all — uptime and restart counters are preserved |
+
+A service you stopped by hand stays stopped; it picks up its new definition the
+next time you start it. Comparison is exact: any field that affects the process
+(command, environment, env files, restart policy, health check, watch rules, …)
+counts as a change.
+
+If the new config is invalid the reload is refused and the stack keeps running
+untouched, so a typo can never take a stack down:
+
+```console
+$ servicrab reload
+✗ servicrab.toml has 1 error(s); the stack was left untouched:
+  • service "api": depends on unknown service "ghost"
+```
+
+Project-level settings — `[project.logs]`, the log directory and rotation
+rules — are bound to the daemon process and need a `servicrab down` +
+`servicrab start` to change. File watchers (`[services.x.watch]`) *are*
+re-created on every reload.
 
 The wire types live in the `servicrab-protocol` crate, which depends on
 neither the runtime nor Tokio.
@@ -643,20 +683,20 @@ cargo test -p servicrab-core config::tests
 - [x] `servicrab logs [SERVICE...] [-f] [-n N]`
 - [x] Per-service opt-out via `[services.<name>.logs] enabled = false`
 
-### Phase 2 (current) — Background daemon ✅
+### Phase 2 — Background daemon ✅
 - [x] Detached daemon per project with a Unix-socket JSON API
 - [x] `servicrab start` / `status` / `down` / `daemon`
 - [x] Status snapshot: state, pid, uptime, restarts, health
 - [x] Per-service `start` / `stop` / `restart` through the daemon
 - [ ] Live event streaming over the socket
 
-### Phase 3 (current) — Stack management
+### Phase 3 — Stack management ✅
 - [x] `.env` file support per project and per service
 - [x] Shell completions (`servicrab completions <SHELL>`)
 - [x] `servicrab watch` — restart on file changes, with ignore rules and debouncing
-- [ ] Config hot-reload
+- [x] Config hot-reload (`servicrab reload`)
 
-### Phase 4 — Platform integration (optional)
+### Phase 4 (current) — Platform integration
 - [ ] systemd unit generation
 - [ ] launchd plist generation
 - [ ] Windows Service wrapper

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -49,8 +49,13 @@ mod imp {
 
     /// Run the daemon in the foreground (this is the process `start` spawns).
     pub fn daemon(config: Option<&Path>, no_restart: bool) -> Result<i32, String> {
-        let (cfg, _, paths) = setup(config)?;
-        server::serve(&cfg, &paths, server::DaemonOptions { no_restart })
+        let (cfg, config_path, paths) = setup(config)?;
+        server::serve(
+            &cfg,
+            &config_path,
+            &paths,
+            server::DaemonOptions { no_restart },
+        )
     }
 
     /// Start the daemon, or individual services inside a running one.
@@ -149,6 +154,39 @@ mod imp {
     /// Restart individual services.
     pub fn restart(config: Option<&Path>, services: &[String]) -> Result<i32, String> {
         control(config, services, |name| Request::RestartService { name })
+    }
+
+    /// Ask the daemon to re-read the configuration file.
+    pub fn reload(config: Option<&Path>) -> Result<i32, String> {
+        let (cfg, config_path, paths) = setup(config)?;
+        if !client::is_running(&paths.socket) {
+            return Err(format!(
+                "no daemon is running for {} — start one with `servicrab start`",
+                cfg.project.name
+            ));
+        }
+
+        let color = style::color_enabled();
+        match client::send(&paths.socket, &Request::Reload) {
+            Ok(Response::Ok { message }) => {
+                println!(
+                    "{} {}",
+                    style::paint(color, GREEN, "✓"),
+                    message.unwrap_or_else(|| "reloaded".to_string())
+                );
+                println!(
+                    "{}",
+                    style::paint(color, DIM, &format!("  from {}", config_path.display()))
+                );
+                Ok(0)
+            }
+            Ok(Response::Error { message }) => {
+                eprintln!("{} {message}", style::paint(color, RED, "✗"));
+                Ok(1)
+            }
+            Ok(other) => Err(format!("unexpected response from the daemon: {other:?}")),
+            Err(err) => Err(err.to_string()),
+        }
     }
 
     /// Send one per-service command per name, reporting each outcome.
@@ -364,6 +402,10 @@ mod imp {
         Err(UNSUPPORTED.to_string())
     }
 
+    pub fn reload(_config: Option<&Path>) -> Result<i32, String> {
+        Err(UNSUPPORTED.to_string())
+    }
+
     pub fn status(_config: Option<&Path>, _json: bool) -> Result<i32, String> {
         Err(UNSUPPORTED.to_string())
     }
@@ -373,4 +415,4 @@ mod imp {
     }
 }
 
-pub use imp::{daemon, down, restart, start, status, stop};
+pub use imp::{daemon, down, reload, restart, start, status, stop};

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -5,20 +5,24 @@
 //! through the same channel the signal handler uses — so a slow or hostile
 //! client cannot interfere with process supervision.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use servicrab_core::runtime::stack::{Control, ControlTx, StackOptions, StackSupervisor};
 use servicrab_core::runtime::{control_channel, shutdown_channel, wait_for_shutdown};
 use servicrab_core::{
-    event_channel, plan_stack, Config, EventKind, EventReceiver, LogRouter, ServiceName,
-    ServiceState, ShutdownReason, SignalWatcher, StatusRegistry,
+    event_channel, load, plan_stack, Config, EventKind, EventReceiver, EventSender, LogRouter,
+    ServiceName, ServiceState, ShutdownReason, SignalWatcher, StatusRegistry,
 };
 use servicrab_protocol::{decode, encode, Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
+use tokio::task::JoinHandle;
 
 use super::paths::DaemonPaths;
+
+/// How long the daemon waits for the log collector to drain on shutdown.
+const COLLECTOR_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Options for the daemon body.
 #[derive(Debug, Clone, Copy, Default)]
@@ -27,9 +31,81 @@ pub struct DaemonOptions {
     pub no_restart: bool,
 }
 
+/// Everything the socket side of the daemon may touch.
+///
+/// The supervisor is never reached directly: commands travel the control
+/// channel, shutdown travels the same channel the signal handler uses, and
+/// status is read from a snapshot the collector task keeps current.
+struct Session {
+    registry: Arc<Mutex<StatusRegistry>>,
+    stop: servicrab_core::runtime::ShutdownTx,
+    control: ControlTx,
+    /// The services the running configuration knows about; a reload replaces
+    /// this list.
+    names: Mutex<Vec<ServiceName>>,
+    project: String,
+    /// Where the configuration was loaded from, so it can be re-read.
+    config_path: PathBuf,
+    /// Kept so reloads can rebuild the watchers.  It is dropped when the
+    /// daemon stops, which is what lets the collector task finish: it ends
+    /// when the last event sender is gone.
+    events: Mutex<Option<EventSender>>,
+    /// File watchers, replaced wholesale on reload.
+    watchers: Mutex<Vec<JoinHandle<()>>>,
+    /// Serializes reloads: two clients must not diff against each other.
+    reloading: tokio::sync::Mutex<()>,
+}
+
+impl Session {
+    fn known_names(&self) -> Vec<ServiceName> {
+        self.names
+            .lock()
+            .map(|names| names.clone())
+            .unwrap_or_default()
+    }
+
+    /// Replace the file watchers with ones built from `cfg`.
+    fn respawn_watchers(&self, cfg: &Config, plan: &[ServiceName]) {
+        let Some(events) = self
+            .events
+            .lock()
+            .ok()
+            .and_then(|events| events.as_ref().cloned())
+        else {
+            // The daemon is shutting down; no point in starting watchers.
+            return;
+        };
+        let fresh = servicrab_core::spawn_watchers(cfg, plan, &self.control, &events);
+        let Ok(mut watchers) = self.watchers.lock() else {
+            return;
+        };
+        for watcher in watchers.drain(..) {
+            watcher.abort();
+        }
+        *watchers = fresh;
+    }
+
+    /// Stop the watchers and let go of the event sender.
+    fn shutdown(&self) {
+        if let Ok(mut watchers) = self.watchers.lock() {
+            for watcher in watchers.drain(..) {
+                watcher.abort();
+            }
+        }
+        if let Ok(mut events) = self.events.lock() {
+            *events = None;
+        }
+    }
+}
+
 /// Run the daemon in this process until the stack stops or shutdown is
 /// requested. Returns the exit code to use.
-pub fn serve(cfg: &Config, paths: &DaemonPaths, options: DaemonOptions) -> Result<i32, String> {
+pub fn serve(
+    cfg: &Config,
+    config_path: &Path,
+    paths: &DaemonPaths,
+    options: DaemonOptions,
+) -> Result<i32, String> {
     let plan = plan_stack(cfg, &[]).map_err(|e| e.to_string())?;
     if plan.is_empty() {
         return Err(
@@ -57,7 +133,6 @@ pub fn serve(cfg: &Config, paths: &DaemonPaths, options: DaemonOptions) -> Resul
         (name.clone(), has_health)
     }))));
 
-    let names: Vec<ServiceName> = plan.clone();
     let logs = crate::commands::logs::router_for(cfg);
     let project = cfg.project.name.to_string();
     let stack_options = StackOptions {
@@ -91,19 +166,24 @@ pub fn serve(cfg: &Config, paths: &DaemonPaths, options: DaemonOptions) -> Resul
         let (events_tx, events_rx) = event_channel();
         let (control_tx, control_rx) = control_channel();
         let collector = tokio::spawn(collect(events_rx, Arc::clone(&registry), logs));
-        let server = tokio::spawn(accept_loop(
-            listener,
-            Arc::clone(&registry),
-            stop_tx.clone(),
-            control_tx.clone(),
-            names.clone(),
-            project.clone(),
-        ));
+
+        let session = Arc::new(Session {
+            registry: Arc::clone(&registry),
+            stop: stop_tx.clone(),
+            control: control_tx.clone(),
+            names: Mutex::new(plan.clone()),
+            project: project.clone(),
+            config_path: config_path.to_path_buf(),
+            events: Mutex::new(Some(events_tx.clone())),
+            watchers: Mutex::new(Vec::new()),
+            reloading: tokio::sync::Mutex::new(()),
+        });
+        drop(control_tx);
 
         // Watch-triggered restarts travel the same control channel as the
         // socket's `restart_service`, so the supervisor cannot tell them apart.
-        let watchers = servicrab_core::spawn_watchers(cfg, &plan, &control_tx, &events_tx);
-        drop(control_tx);
+        session.respawn_watchers(cfg, &plan);
+        let server = tokio::spawn(accept_loop(listener, Arc::clone(&session)));
 
         write_pid(&paths.pid)?;
         tracing::info!(project = %project, socket = %paths.socket.display(), "daemon ready");
@@ -112,12 +192,14 @@ pub fn serve(cfg: &Config, paths: &DaemonPaths, options: DaemonOptions) -> Resul
             StackSupervisor::new(cfg, plan, stack_options, events_tx).with_control(control_rx);
         let outcome = supervisor.run(&mut stop_rx).await;
 
-        for watcher in watchers {
-            watcher.abort();
-        }
+        // Dropping the last event senders is what ends the collector, so the
+        // socket side has to let go of its clone first.
+        session.shutdown();
         server.abort();
         signal_task.abort();
-        let _ = collector.await;
+        // The collector only has queued events left; the timeout is a
+        // backstop so a lost sender can never keep the daemon alive.
+        let _ = tokio::time::timeout(COLLECTOR_GRACE, collector).await;
 
         Ok::<_, String>(outcome)
     });
@@ -153,40 +235,21 @@ async fn collect(
 }
 
 /// Serve clients until the task is cancelled.
-#[allow(clippy::too_many_arguments)]
-async fn accept_loop(
-    listener: UnixListener,
-    registry: Arc<Mutex<StatusRegistry>>,
-    stop: servicrab_core::runtime::ShutdownTx,
-    control: ControlTx,
-    names: Vec<ServiceName>,
-    project: String,
-) {
+async fn accept_loop(listener: UnixListener, session: Arc<Session>) {
     loop {
         let Ok((stream, _)) = listener.accept().await else {
             continue;
         };
-        let registry = Arc::clone(&registry);
-        let stop = stop.clone();
-        let control = control.clone();
-        let names = names.clone();
-        let project = project.clone();
+        let session = Arc::clone(&session);
         // One task per client keeps a stuck reader from blocking everybody
         // else.
         tokio::spawn(async move {
-            handle_client(stream, registry, stop, control, names, project).await;
+            handle_client(stream, session).await;
         });
     }
 }
 
-async fn handle_client(
-    stream: UnixStream,
-    registry: Arc<Mutex<StatusRegistry>>,
-    stop: servicrab_core::runtime::ShutdownTx,
-    control: ControlTx,
-    names: Vec<ServiceName>,
-    project: String,
-) {
+async fn handle_client(stream: UnixStream, session: Arc<Session>) {
     let (read_half, mut write_half) = stream.into_split();
     let mut lines = BufReader::new(read_half).lines();
 
@@ -195,7 +258,7 @@ async fn handle_client(
             continue;
         }
         let response = match decode::<Request>(&line) {
-            Ok(request) => respond(request, &registry, &stop, &control, &names, &project).await,
+            Ok(request) => respond(request, &session).await,
             Err(err) => Response::Error {
                 message: err.to_string(),
             },
@@ -211,21 +274,14 @@ async fn handle_client(
     }
 }
 
-async fn respond(
-    request: Request,
-    registry: &Arc<Mutex<StatusRegistry>>,
-    stop: &servicrab_core::runtime::ShutdownTx,
-    control: &ControlTx,
-    names: &[ServiceName],
-    project: &str,
-) -> Response {
+async fn respond(request: Request, session: &Session) -> Response {
     match request {
         Request::Ping => Response::Pong {
-            project: project.to_string(),
+            project: session.project.clone(),
             pid: std::process::id(),
         },
         Request::Status => {
-            let Ok(registry) = registry.lock() else {
+            let Ok(registry) = session.registry.lock() else {
                 return Response::Error {
                     message: "the status registry is poisoned".to_string(),
                 };
@@ -235,32 +291,33 @@ async fn respond(
             }
         }
         Request::Shutdown => {
-            let _ = stop.send(Some(ShutdownReason::Terminated));
+            let _ = session.stop.send(Some(ShutdownReason::Terminated));
             Response::Ok {
                 message: Some("stopping the stack".to_string()),
             }
         }
         Request::StartService { name } => {
-            command(control, names, &name, |service, ack| Control::Start {
+            command(session, &name, |service, ack| Control::Start {
                 service,
                 ack,
             })
             .await
         }
         Request::StopService { name } => {
-            command(control, names, &name, |service, ack| Control::Stop {
+            command(session, &name, |service, ack| Control::Stop {
                 service,
                 ack,
             })
             .await
         }
         Request::RestartService { name } => {
-            command(control, names, &name, |service, ack| Control::Restart {
+            command(session, &name, |service, ack| Control::Restart {
                 service,
                 ack,
             })
             .await
         }
+        Request::Reload => reload(session).await,
         // `Request` is `#[non_exhaustive]`, so an older daemon can still be
         // asked something it does not know about.
         _ => Response::Error {
@@ -269,13 +326,113 @@ async fn respond(
     }
 }
 
+/// Re-read the configuration and apply the difference to the running stack.
+///
+/// Only services change: project-level settings such as `[project.logs]` are
+/// bound to the process and need a daemon restart.
+async fn reload(session: &Session) -> Response {
+    // Two clients reloading at once would each diff against a stack the other
+    // one is still changing.
+    let _guard = session.reloading.lock().await;
+
+    let (cfg, warnings) = match load(&session.config_path) {
+        Ok(loaded) => loaded,
+        Err(errors) => {
+            let details: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
+            return Response::Error {
+                message: format!(
+                    "{} has {} error(s); the stack was left untouched:\n{}",
+                    session.config_path.display(),
+                    errors.len(),
+                    details.join("\n")
+                ),
+            };
+        }
+    };
+    for warning in &warnings {
+        tracing::warn!("{warning}");
+    }
+
+    let plan = match plan_stack(&cfg, &[]) {
+        Ok(plan) => plan,
+        Err(err) => {
+            return Response::Error {
+                message: format!("{err}; the stack was left untouched"),
+            }
+        }
+    };
+    if plan.is_empty() {
+        return Response::Error {
+            message: "no services would be left running: none have autostart = true".to_string(),
+        };
+    }
+
+    // The registry is updated first so that events from services the reload
+    // adds are not dropped for lack of an entry.
+    let previous = session.known_names();
+    sync_registry(session, &cfg, &plan);
+
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    let command = Control::Reload {
+        config: Box::new(cfg.clone()),
+        plan: plan.clone(),
+        ack: ack_tx,
+    };
+    if session.control.send(command).is_err() {
+        restore_registry(session, &cfg, &previous);
+        return Response::Error {
+            message: "the supervisor is no longer accepting commands".to_string(),
+        };
+    }
+
+    match ack_rx.await {
+        Ok(Ok(message)) => {
+            session.respawn_watchers(&cfg, &plan);
+            Response::Ok {
+                message: Some(format!("reloaded {}: {message}", session.project)),
+            }
+        }
+        Ok(Err(message)) => {
+            restore_registry(session, &cfg, &previous);
+            Response::Error { message }
+        }
+        Err(_) => {
+            restore_registry(session, &cfg, &previous);
+            Response::Error {
+                message: "the stack stopped before the reload completed".to_string(),
+            }
+        }
+    }
+}
+
+/// Point the registry and the known-name list at a new plan.
+fn sync_registry(session: &Session, cfg: &Config, plan: &[ServiceName]) {
+    if let Ok(mut registry) = session.registry.lock() {
+        registry.sync(plan.iter().map(|name| {
+            let has_health = cfg
+                .services
+                .get(name)
+                .is_some_and(|svc| svc.health.is_some());
+            (name.clone(), has_health)
+        }));
+    }
+    if let Ok(mut names) = session.names.lock() {
+        *names = plan.to_vec();
+    }
+}
+
+/// Undo [`sync_registry`] after a reload the supervisor refused.
+fn restore_registry(session: &Session, cfg: &Config, previous: &[ServiceName]) {
+    sync_registry(session, cfg, previous);
+}
+
 /// Send one per-service command to the supervisor and wait for its verdict.
 async fn command(
-    control: &ControlTx,
-    names: &[ServiceName],
+    session: &Session,
     name: &str,
     build: impl FnOnce(ServiceName, servicrab_core::runtime::stack::Ack) -> Control,
 ) -> Response {
+    let names = session.known_names();
     let Some(service) = names.iter().find(|known| known.as_str() == name) else {
         return Response::Error {
             message: format!(
@@ -290,7 +447,11 @@ async fn command(
     };
 
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-    if control.send(build(service.clone(), ack_tx)).is_err() {
+    if session
+        .control
+        .send(build(service.clone(), ack_tx))
+        .is_err()
+    {
         return Response::Error {
             message: "the supervisor is no longer accepting commands".to_string(),
         };

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -221,6 +221,15 @@ enum Commands {
         config: Option<std::path::PathBuf>,
     },
 
+    /// Re-read the configuration and apply it to the running daemon.
+    /// Linux and macOS only.
+    Reload {
+        /// Path to the configuration file.  If omitted, discovers
+        /// servicrab.toml by walking up from the current directory.
+        #[arg(long, short = 'c')]
+        config: Option<std::path::PathBuf>,
+    },
+
     /// Show what the background daemon is doing.  Linux and macOS only.
     Status {
         /// Path to the configuration file.  If omitted, discovers
@@ -344,6 +353,7 @@ fn main() {
         Commands::Restart { services, config } => {
             commands::daemon::restart(config.as_deref(), &services)
         }
+        Commands::Reload { config } => commands::daemon::reload(config.as_deref()),
         Commands::Status { config, json } => commands::daemon::status(config.as_deref(), json),
         Commands::Down { config } => commands::daemon::down(config.as_deref()),
         Commands::Daemon { config, no_restart } => {

--- a/crates/servicrab-cli/tests/reload.rs
+++ b/crates/servicrab-cli/tests/reload.rs
@@ -1,0 +1,420 @@
+//! Integration tests for `servicrab reload` (config hot-reload).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Upper bound for any wait in this file; keeps a hung test from stalling CI.
+const CEILING: Duration = Duration::from_secs(20);
+
+fn script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+/// A long-lived service that exits cleanly on SIGTERM.
+fn resident(dir: &Path, name: &str) -> PathBuf {
+    script(
+        dir,
+        name,
+        "trap 'exit 0' TERM INT\necho up\nwhile true; do sleep 0.2; done",
+    )
+}
+
+fn write_config(dir: &Path, toml: &str) -> PathBuf {
+    let path = dir.join("servicrab.toml");
+    fs::write(&path, toml).unwrap();
+    path
+}
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+fn cli(args: &[&str], config_path: &Path) -> (i32, String, String) {
+    let output = Command::new(binary())
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Stops the daemon when the test ends, however it ends.
+struct Daemon {
+    config: PathBuf,
+}
+
+impl Daemon {
+    fn start(config: &Path) -> Self {
+        let (code, stdout, stderr) = cli(&["start"], config);
+        assert_eq!(code, 0, "start failed: {stdout}{stderr}");
+        Self {
+            config: config.to_path_buf(),
+        }
+    }
+
+    fn status(&self) -> String {
+        let (_, stdout, _) = cli(&["status"], &self.config);
+        stdout
+    }
+
+    fn reload(&self) -> (i32, String, String) {
+        cli(&["reload"], &self.config)
+    }
+
+    /// Poll `status` until `predicate` holds.
+    fn wait_for_status(&self, what: &str, predicate: impl Fn(&str) -> bool) -> String {
+        let deadline = Instant::now() + CEILING;
+        loop {
+            let status = self.status();
+            if predicate(&status) {
+                return status;
+            }
+            if Instant::now() >= deadline {
+                panic!("timed out waiting for {what}; last status:\n{status}");
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    /// The pid column of one service, if it currently has one.
+    fn pid_of(&self, service: &str) -> Option<u32> {
+        pid_in(&self.status(), service)
+    }
+
+    fn wait_for_pid_change(&self, service: &str, was: Option<u32>) -> Option<u32> {
+        let deadline = Instant::now() + CEILING;
+        loop {
+            let now = self.pid_of(service);
+            if now.is_some() && now != was {
+                return now;
+            }
+            if Instant::now() >= deadline {
+                panic!(
+                    "timed out waiting for {service} to be restarted; last status:\n{}",
+                    self.status()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = Command::new(binary())
+            .arg("down")
+            .arg("--config")
+            .arg(&self.config)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+/// Pull one service's pid out of a `status` table.
+fn pid_in(status: &str, service: &str) -> Option<u32> {
+    status
+        .lines()
+        .find(|line| line.split_whitespace().next() == Some(service))
+        .and_then(|line| line.split_whitespace().nth(2))
+        .and_then(|pid| pid.parse().ok())
+}
+
+fn two_service_config(api: &Path, worker: &Path) -> String {
+    format!(
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+[services.worker]
+command = ["{}"]
+restart = "always"
+"#,
+        api.display(),
+        worker.display()
+    )
+}
+
+#[test]
+fn a_reload_without_changes_reports_no_changes() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let worker = resident(dir.path(), "worker.sh");
+    let cfg = write_config(dir.path(), &two_service_config(&api, &worker));
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        s.matches("running").count() == 2
+    });
+    let before = daemon.pid_of("api");
+
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("no changes"), "{stdout}");
+    assert_eq!(
+        daemon.pid_of("api"),
+        before,
+        "an untouched service restarted"
+    );
+}
+
+#[test]
+fn a_reload_starts_an_added_service() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let worker = resident(dir.path(), "worker.sh");
+    let cfg = write_config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display()
+        ),
+    );
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+    let api_pid = daemon.pid_of("api");
+
+    fs::write(&cfg, two_service_config(&api, &worker)).unwrap();
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("1 added"), "{stdout}");
+
+    let status = daemon.wait_for_status("worker to run", |s| {
+        pid_in(s, "worker").is_some() && s.matches("running").count() == 2
+    });
+    assert!(status.contains("worker"), "{status}");
+    // The service that was already up is left alone.
+    assert_eq!(daemon.pid_of("api"), api_pid);
+}
+
+#[test]
+fn a_reload_stops_a_removed_service() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let worker = resident(dir.path(), "worker.sh");
+    let cfg = write_config(dir.path(), &two_service_config(&api, &worker));
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        s.matches("running").count() == 2
+    });
+    let api_pid = daemon.pid_of("api");
+
+    fs::write(
+        &cfg,
+        format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display()
+        ),
+    )
+    .unwrap();
+
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("1 removed"), "{stdout}");
+
+    let status = daemon.wait_for_status("worker to disappear", |s| !s.contains("worker"));
+    assert!(status.contains("api"), "{status}");
+    assert_eq!(daemon.pid_of("api"), api_pid);
+}
+
+#[test]
+fn a_reload_restarts_a_changed_service() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let worker = resident(dir.path(), "worker.sh");
+    let cfg = write_config(dir.path(), &two_service_config(&api, &worker));
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        s.matches("running").count() == 2
+    });
+    let api_pid = daemon.pid_of("api");
+    let worker_pid = daemon.pid_of("worker");
+
+    fs::write(
+        &cfg,
+        format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+env = {{ EDITED = "yes" }}
+[services.worker]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display(),
+            worker.display()
+        ),
+    )
+    .unwrap();
+
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("1 changed"), "{stdout}");
+
+    let fresh = daemon.wait_for_pid_change("api", api_pid);
+    assert_ne!(fresh, api_pid);
+    // Only the edited service is restarted.
+    assert_eq!(daemon.pid_of("worker"), worker_pid);
+}
+
+#[test]
+fn an_invalid_config_is_refused_and_the_stack_keeps_running() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let worker = resident(dir.path(), "worker.sh");
+    let cfg = write_config(dir.path(), &two_service_config(&api, &worker));
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        s.matches("running").count() == 2
+    });
+    let api_pid = daemon.pid_of("api");
+
+    fs::write(
+        &cfg,
+        format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+depends_on = ["ghost"]
+"#,
+            api.display()
+        ),
+    )
+    .unwrap();
+
+    let (code, _, stderr) = daemon.reload();
+    assert_eq!(code, 1, "a broken config was accepted: {stderr}");
+    assert!(stderr.contains("ghost"), "{stderr}");
+
+    // The daemon is untouched, so restoring the file makes it work again.
+    fs::write(&cfg, two_service_config(&api, &worker)).unwrap();
+    assert_eq!(daemon.pid_of("api"), api_pid);
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("no changes"), "{stdout}");
+}
+
+#[test]
+fn reload_needs_a_running_daemon() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let cfg = write_config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+"#,
+            api.display()
+        ),
+    );
+
+    let (code, _, stderr) = cli(&["reload"], &cfg);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("no daemon is running"), "{stderr}");
+}
+
+#[test]
+fn a_reloaded_service_can_be_controlled_by_name() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let worker = resident(dir.path(), "worker.sh");
+    let cfg = write_config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display()
+        ),
+    );
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    fs::write(&cfg, two_service_config(&api, &worker)).unwrap();
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    daemon.wait_for_status("worker to run", |s| pid_in(s, "worker").is_some());
+
+    // The daemon's idea of which services exist has to follow the reload.
+    let (code, stdout, stderr) = cli(&["restart", "worker"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+
+    // …and the service that is gone is no longer accepted.
+    fs::write(
+        &cfg,
+        format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display()
+        ),
+    )
+    .unwrap();
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    daemon.wait_for_status("worker to disappear", |s| !s.contains("worker"));
+
+    let (code, _, stderr) = cli(&["restart", "worker"], &cfg);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("unknown service"), "{stderr}");
+}

--- a/crates/servicrab-core/src/config.rs
+++ b/crates/servicrab-core/src/config.rs
@@ -275,7 +275,11 @@ impl WatchSettings {
 }
 
 /// Validated configuration for a single managed service.
-#[derive(Debug, Clone, Serialize)]
+///
+/// `PartialEq` is what config hot-reload uses to decide whether a service has
+/// to be restarted, so every field that affects the running process must take
+/// part in the comparison.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Service {
     /// Validated service name.
     pub name: ServiceName,

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -127,6 +127,19 @@ pub enum Control {
         /// Answered once the replacement has been spawned.
         ack: Ack,
     },
+    /// Replace the running configuration.
+    ///
+    /// Services that disappeared are stopped, new ones are started, and the
+    /// ones whose definition changed are restarted with it.  Everything else
+    /// keeps running untouched.
+    Reload {
+        /// The freshly validated configuration.
+        config: Box<Config>,
+        /// The start plan derived from it.
+        plan: Vec<ServiceName>,
+        /// Answered once the difference has been applied.
+        ack: Ack,
+    },
 }
 
 /// Sending half of the control channel.
@@ -149,6 +162,9 @@ struct Slot {
     handle: Option<JoinHandle<()>>,
     /// Set while a stop is only the first half of a restart.
     restart_when_stopped: bool,
+    /// Set when a reload dropped the service: the slot disappears as soon as
+    /// its supervision task reports back.
+    retired: bool,
     /// The client waiting for the in-flight command to complete.
     pending: Option<Ack>,
 }
@@ -239,41 +255,28 @@ impl<'a> StackSupervisor<'a> {
         };
 
         let (report_tx, mut report_rx) = mpsc::unbounded_channel::<ServiceReport>();
-        let mut slots: BTreeMap<ServiceName, Slot> = BTreeMap::new();
+        let mut state = RunState {
+            config: Arc::new(self.config.clone()),
+            plan: std::mem::take(&mut self.plan),
+            slots: BTreeMap::new(),
+        };
 
-        for name in &self.plan {
-            let Some(service) = self.config.services.get(name) else {
+        // Every slot exists before any of them is spawned, so a service can
+        // subscribe to the readiness of the ones it depends on.
+        for name in state.plan.clone() {
+            let Some(service) = state.config.services.get(&name).cloned() else {
                 continue;
             };
-            let (state_tx, state_rx) = watch::channel(Readiness::Pending);
-
-            // Dependencies always appear earlier in the plan, so their slots
-            // already exist.
-            let deps: Vec<(ServiceName, watch::Receiver<Readiness>)> = service
-                .depends_on
-                .iter()
-                .filter_map(|dep| {
-                    slots
-                        .get(dep)
-                        .map(|slot| (dep.clone(), slot.readiness.subscribe()))
-                })
-                .collect();
-
-            let mut slot = Slot {
-                service: Arc::new(service.clone()),
-                deps,
-                readiness: Arc::new(state_tx),
-                stop: None,
-                handle: None,
-                restart_when_stopped: false,
-                pending: None,
-            };
-            drop(state_rx);
-            slot.spawn(self.events.clone(), run_options, report_tx.clone());
-            slots.insert(name.clone(), slot);
+            state.insert_slot(&name, Arc::new(service));
+        }
+        state.rewire_dependencies();
+        for name in state.plan.clone() {
+            if let Some(slot) = state.slots.get_mut(&name) {
+                slot.spawn(self.events.clone(), run_options, report_tx.clone());
+            }
         }
 
-        let mut running = slots.len();
+        let mut running = state.slots.len();
         let mut reports: Vec<ServiceReport> = Vec::with_capacity(running);
         let mut shutdown_reason: Option<ShutdownReason> = None;
 
@@ -294,10 +297,14 @@ impl<'a> StackSupervisor<'a> {
                     let failed = report.result.is_failure();
                     tracing::debug!(service = %report.service, "service finished");
 
-                    if let Some(slot) = slots.get_mut(&report.service) {
+                    let mut retire = false;
+                    if let Some(slot) = state.slots.get_mut(&report.service) {
                         slot.stop = None;
                         slot.handle = None;
-                        if slot.restart_when_stopped {
+                        if slot.retired {
+                            slot.answer(Ok("stopped".to_string()));
+                            retire = true;
+                        } else if slot.restart_when_stopped {
                             slot.restart_when_stopped = false;
                             slot.spawn(self.events.clone(), run_options, report_tx.clone());
                             running += 1;
@@ -306,17 +313,24 @@ impl<'a> StackSupervisor<'a> {
                             slot.answer(Ok("stopped".to_string()));
                         }
                     }
+                    if retire {
+                        state.slots.remove(&report.service);
+                    }
 
-                    reports.push(report);
-                    if failed && self.options.abort_on_failure {
-                        shutdown_reason = Some(ShutdownReason::StackFailure);
-                        break;
+                    // A service the operator removed is not part of the run's
+                    // verdict; it did exactly what it was told to do.
+                    if !retire {
+                        reports.push(report);
+                        if failed && self.options.abort_on_failure {
+                            shutdown_reason = Some(ShutdownReason::StackFailure);
+                            break;
+                        }
                     }
                 }
                 command = next_control(&mut self.control) => {
                     self.handle_control(
                         command,
-                        &mut slots,
+                        &mut state,
                         &mut running,
                         run_options,
                         &report_tx,
@@ -325,17 +339,19 @@ impl<'a> StackSupervisor<'a> {
             }
         }
 
-        let stops: BTreeMap<ServiceName, crate::runtime::ShutdownTx> = slots
+        let stops: BTreeMap<ServiceName, crate::runtime::ShutdownTx> = state
+            .slots
             .iter()
             .filter_map(|(name, slot)| slot.stop.clone().map(|stop| (name.clone(), stop)))
             .collect();
-        let mut handles: BTreeMap<ServiceName, JoinHandle<()>> = slots
+        let mut handles: BTreeMap<ServiceName, JoinHandle<()>> = state
+            .slots
             .iter_mut()
             .filter_map(|(name, slot)| slot.handle.take().map(|handle| (name.clone(), handle)))
             .collect();
 
         if let Some(reason) = shutdown_reason {
-            self.stop_all(reason, &stops, &mut handles).await;
+            stop_all(&state, reason, &stops, &mut handles).await;
         }
 
         for (name, handle) in handles {
@@ -362,18 +378,28 @@ impl<'a> StackSupervisor<'a> {
     fn handle_control(
         &self,
         command: Control,
-        slots: &mut BTreeMap<ServiceName, Slot>,
+        state: &mut RunState,
         running: &mut usize,
         run_options: RunOptions,
         reports: &mpsc::UnboundedSender<ServiceReport>,
     ) {
+        let command = match command {
+            Control::Reload { config, plan, ack } => {
+                let result = self.reload(state, running, *config, plan, run_options, reports);
+                let _ = ack.send(result);
+                return;
+            }
+            other => other,
+        };
+
         let service = match &command {
             Control::Start { service, .. }
             | Control::Stop { service, .. }
             | Control::Restart { service, .. } => service.clone(),
+            Control::Reload { .. } => unreachable!("handled above"),
         };
 
-        let Some(slot) = slots.get_mut(&service) else {
+        let Some(slot) = state.slots.get_mut(&service) else {
             let ack = into_ack(command);
             let _ = ack.send(Err(format!("{service} is not part of the running stack")));
             return;
@@ -418,38 +444,233 @@ impl<'a> StackSupervisor<'a> {
                 slot.pending = Some(ack);
                 let _ = stop.send(Some(ShutdownReason::Requested));
             }
+            Control::Reload { .. } => unreachable!("handled above"),
         }
     }
 
-    /// Stop the stack in reverse dependency order, waiting for each service
-    /// before moving on to the ones it depends on.
-    async fn stop_all(
+    /// Swap the running configuration for a freshly validated one.
+    ///
+    /// Only the difference is acted on: removed services are stopped, added
+    /// ones are started, and changed ones are restarted.  Services whose
+    /// definition is untouched keep running, including their uptime and
+    /// restart counters.
+    fn reload(
         &self,
-        reason: ShutdownReason,
-        stops: &BTreeMap<ServiceName, crate::runtime::ShutdownTx>,
-        handles: &mut BTreeMap<ServiceName, JoinHandle<()>>,
-    ) {
-        for name in self.plan.iter().rev() {
-            let Some(stop) = stops.get(name) else {
+        state: &mut RunState,
+        running: &mut usize,
+        config: Config,
+        plan: Vec<ServiceName>,
+        run_options: RunOptions,
+        reports: &mpsc::UnboundedSender<ServiceReport>,
+    ) -> Result<String, String> {
+        // Applying a difference on top of a half-finished command would make
+        // the outcome depend on the order the two complete in.
+        if let Some(busy) = state
+            .slots
+            .iter()
+            .find(|(_, slot)| slot.pending.is_some())
+            .map(|(name, _)| name.clone())
+        {
+            return Err(format!("{busy} is busy with another command"));
+        }
+
+        let diff = state.diff(&config, &plan);
+        let config = Arc::new(config);
+        state.config = config.clone();
+        state.plan = plan;
+
+        for name in &diff.removed {
+            let Some(slot) = state.slots.get_mut(name) else {
                 continue;
             };
-            let _ = stop.send(Some(reason));
-
-            let Some(mut handle) = handles.remove(name) else {
-                continue;
-            };
-            let grace = self
-                .config
-                .services
-                .get(name)
-                .map(|service| service.shutdown_timeout)
-                .unwrap_or_default()
-                + STOP_GRACE;
-
-            if tokio::time::timeout(grace, &mut handle).await.is_err() {
-                tracing::warn!(service = %name, ?grace, "service did not stop in time; detaching");
-                handle.abort();
+            match slot.stop.clone() {
+                Some(stop) => {
+                    slot.retired = true;
+                    slot.restart_when_stopped = false;
+                    let _ = stop.send(Some(ShutdownReason::Requested));
+                }
+                None => {
+                    state.slots.remove(name);
+                }
             }
+        }
+
+        for name in &diff.added {
+            let Some(service) = config.services.get(name).cloned() else {
+                continue;
+            };
+            state.insert_slot(name, Arc::new(service));
+        }
+
+        for name in &diff.changed {
+            let Some(service) = config.services.get(name).cloned() else {
+                continue;
+            };
+            let Some(slot) = state.slots.get_mut(name) else {
+                continue;
+            };
+            slot.service = Arc::new(service);
+            // A service that was stopped on purpose stays stopped; it picks
+            // the new definition up when it is started again.
+            if let Some(stop) = slot.stop.clone() {
+                slot.restart_when_stopped = true;
+                let _ = stop.send(Some(ShutdownReason::Requested));
+            }
+        }
+
+        // New slots are wired to their dependencies before they are spawned,
+        // exactly like they would be on a fresh start.
+        state.rewire_dependencies();
+
+        for name in &diff.added {
+            if let Some(slot) = state.slots.get_mut(name) {
+                slot.spawn(self.events.clone(), run_options, reports.clone());
+                *running += 1;
+            }
+        }
+
+        if diff.is_empty() {
+            return Ok("no changes".to_string());
+        }
+        Ok(format!(
+            "{} added, {} changed, {} removed",
+            diff.added.len(),
+            diff.changed.len(),
+            diff.removed.len()
+        ))
+    }
+}
+
+/// The parts of a running stack that config reloads may change.
+struct RunState {
+    config: Arc<Config>,
+    plan: Vec<ServiceName>,
+    slots: BTreeMap<ServiceName, Slot>,
+}
+
+impl RunState {
+    /// Add an idle slot for a service.
+    ///
+    /// Dependencies are wired up separately, once every slot exists: a
+    /// service must be able to subscribe to slots added after it.
+    fn insert_slot(&mut self, name: &ServiceName, service: Arc<Service>) {
+        let (state_tx, state_rx) = watch::channel(Readiness::Pending);
+        drop(state_rx);
+        self.slots.insert(
+            name.clone(),
+            Slot {
+                service,
+                deps: Vec::new(),
+                readiness: Arc::new(state_tx),
+                stop: None,
+                handle: None,
+                restart_when_stopped: false,
+                retired: false,
+                pending: None,
+            },
+        );
+    }
+
+    /// Point every slot at the readiness of the dependencies it currently has.
+    fn rewire_dependencies(&mut self) {
+        let readiness: BTreeMap<ServiceName, Arc<watch::Sender<Readiness>>> = self
+            .slots
+            .iter()
+            .map(|(name, slot)| (name.clone(), slot.readiness.clone()))
+            .collect();
+
+        for (name, slot) in self.slots.iter_mut() {
+            let Some(service) = self.config.services.get(name) else {
+                continue;
+            };
+            slot.deps = service
+                .depends_on
+                .iter()
+                .filter_map(|dep| {
+                    readiness
+                        .get(dep)
+                        .map(|sender| (dep.clone(), sender.subscribe()))
+                })
+                .collect();
+        }
+    }
+
+    /// Compare the running configuration with a new one.
+    fn diff(&self, config: &Config, plan: &[ServiceName]) -> ConfigDiff {
+        let mut diff = ConfigDiff::default();
+
+        for name in plan {
+            match self.slots.get(name) {
+                Some(slot) if slot.retired => diff.added.push(name.clone()),
+                Some(slot) => {
+                    if config.services.get(name) != Some(slot.service.as_ref()) {
+                        diff.changed.push(name.clone());
+                    }
+                }
+                None => diff.added.push(name.clone()),
+            }
+        }
+
+        for name in self.slots.keys() {
+            if !plan.contains(name) {
+                diff.removed.push(name.clone());
+            }
+        }
+
+        diff
+    }
+}
+
+/// What a configuration reload changes about the running stack.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ConfigDiff {
+    added: Vec<ServiceName>,
+    changed: Vec<ServiceName>,
+    removed: Vec<ServiceName>,
+}
+
+impl ConfigDiff {
+    fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.changed.is_empty() && self.removed.is_empty()
+    }
+}
+
+/// Stop the stack in reverse dependency order, waiting for each service
+/// before moving on to the ones it depends on.
+async fn stop_all(
+    state: &RunState,
+    reason: ShutdownReason,
+    stops: &BTreeMap<ServiceName, crate::runtime::ShutdownTx>,
+    handles: &mut BTreeMap<ServiceName, JoinHandle<()>>,
+) {
+    // Services dropped by a reload are no longer in the plan but may still be
+    // winding down, so they are stopped first.
+    let retired = stops
+        .keys()
+        .filter(|name| !state.plan.contains(name))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    for name in retired.iter().chain(state.plan.iter().rev()) {
+        let Some(stop) = stops.get(name) else {
+            continue;
+        };
+        let _ = stop.send(Some(reason));
+
+        let Some(mut handle) = handles.remove(name) else {
+            continue;
+        };
+        let grace = state
+            .config
+            .services
+            .get(name)
+            .map(|service| service.shutdown_timeout)
+            .unwrap_or_default()
+            + STOP_GRACE;
+
+        if tokio::time::timeout(grace, &mut handle).await.is_err() {
+            tracing::warn!(service = %name, ?grace, "service did not stop in time; detaching");
+            handle.abort();
         }
     }
 }
@@ -470,9 +691,10 @@ async fn next_control(control: &mut Option<ControlRx>) -> Control {
 /// Take the acknowledgement channel out of a command.
 fn into_ack(command: Control) -> Ack {
     match command {
-        Control::Start { ack, .. } | Control::Stop { ack, .. } | Control::Restart { ack, .. } => {
-            ack
-        }
+        Control::Start { ack, .. }
+        | Control::Stop { ack, .. }
+        | Control::Restart { ack, .. }
+        | Control::Reload { ack, .. } => ack,
     }
 }
 
@@ -681,6 +903,178 @@ mod tests {
 
     fn name(raw: &str) -> ServiceName {
         crate::validation::validate_service_name(raw).expect("valid test name")
+    }
+
+    /// Build a validated config from TOML, as if it had been read from disk.
+    fn config(toml: &str) -> Config {
+        let raw: crate::raw::RawConfig = toml::from_str(toml).expect("valid test toml");
+        crate::validation::validate_raw(raw, std::path::Path::new("/tmp/servicrab.toml"))
+            .expect("valid test config")
+            .0
+    }
+
+    /// A run state holding idle slots for every service in the config.
+    fn state_for(cfg: Config) -> RunState {
+        let plan = crate::runtime::plan_stack(&cfg, &[]).expect("plannable test config");
+        let mut state = RunState {
+            config: Arc::new(cfg),
+            plan: Vec::new(),
+            slots: BTreeMap::new(),
+        };
+        for name in &plan {
+            let service = state
+                .config
+                .services
+                .get(name)
+                .cloned()
+                .expect("planned service exists");
+            state.insert_slot(name, Arc::new(service));
+        }
+        state.plan = plan;
+        state.rewire_dependencies();
+        state
+    }
+
+    const BASE: &str = r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["sleep", "60"]
+[services.worker]
+command = ["sleep", "60"]
+"#;
+
+    #[test]
+    fn an_unchanged_config_produces_an_empty_diff() {
+        let state = state_for(config(BASE));
+        let cfg = config(BASE);
+        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+
+        let diff = state.diff(&cfg, &plan);
+        assert!(diff.is_empty(), "{diff:?}");
+    }
+
+    #[test]
+    fn a_new_service_is_reported_as_added() {
+        let state = state_for(config(BASE));
+        let cfg = config(&format!(
+            "{BASE}
+[services.cache]
+command = [\"sleep\", \"60\"]
+"
+        ));
+        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+
+        let diff = state.diff(&cfg, &plan);
+        assert_eq!(diff.added, vec![name("cache")]);
+        assert!(diff.changed.is_empty());
+        assert!(diff.removed.is_empty());
+    }
+
+    #[test]
+    fn a_dropped_service_is_reported_as_removed() {
+        let state = state_for(config(BASE));
+        let cfg = config(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["sleep", "60"]
+"#,
+        );
+        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+
+        let diff = state.diff(&cfg, &plan);
+        assert_eq!(diff.removed, vec![name("worker")]);
+        assert!(diff.added.is_empty());
+        assert!(diff.changed.is_empty());
+    }
+
+    #[test]
+    fn an_edited_service_is_reported_as_changed() {
+        let state = state_for(config(BASE));
+        let cfg = config(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["sleep", "90"]
+[services.worker]
+command = ["sleep", "60"]
+"#,
+        );
+        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+
+        let diff = state.diff(&cfg, &plan);
+        assert_eq!(diff.changed, vec![name("api")]);
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+    }
+
+    #[test]
+    fn a_changed_environment_counts_as_a_change() {
+        let state = state_for(config(BASE));
+        let cfg = config(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["sleep", "60"]
+env = { PORT = "8080" }
+[services.worker]
+command = ["sleep", "60"]
+"#,
+        );
+        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+
+        assert_eq!(state.diff(&cfg, &plan).changed, vec![name("api")]);
+    }
+
+    #[test]
+    fn a_retired_slot_is_added_again_rather_than_reused() {
+        let mut state = state_for(config(BASE));
+        state
+            .slots
+            .get_mut(&name("worker"))
+            .expect("slot exists")
+            .retired = true;
+
+        let cfg = config(BASE);
+        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+        assert_eq!(state.diff(&cfg, &plan).added, vec![name("worker")]);
+    }
+
+    #[test]
+    fn dependencies_are_rewired_after_a_reload() {
+        let mut state = state_for(config(BASE));
+        assert!(state.slots[&name("api")].deps.is_empty());
+
+        let cfg = config(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["sleep", "60"]
+depends_on = ["worker"]
+[services.worker]
+command = ["sleep", "60"]
+"#,
+        );
+        state.plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+        state.config = Arc::new(cfg);
+        state.rewire_dependencies();
+
+        let deps: Vec<ServiceName> = state.slots[&name("api")]
+            .deps
+            .iter()
+            .map(|(dep, _)| dep.clone())
+            .collect();
+        assert_eq!(deps, vec![name("worker")]);
     }
 
     #[test]

--- a/crates/servicrab-core/src/runtime/stack_stub.rs
+++ b/crates/servicrab-core/src/runtime/stack_stub.rs
@@ -113,6 +113,15 @@ pub enum Control {
         /// Answered once the command completes.
         ack: Ack,
     },
+    /// Replace the running configuration.
+    Reload {
+        /// The freshly validated configuration.
+        config: Box<Config>,
+        /// The start plan derived from it.
+        plan: Vec<ServiceName>,
+        /// Answered once the difference has been applied.
+        ack: Ack,
+    },
 }
 
 /// Sending half of the control channel.

--- a/crates/servicrab-core/src/runtime/status.rs
+++ b/crates/servicrab-core/src/runtime/status.rs
@@ -94,6 +94,22 @@ impl StatusRegistry {
         }
     }
 
+    /// Bring the registry in line with a reloaded configuration.
+    ///
+    /// Services that are still present keep their state, so a reload does not
+    /// reset uptime or restart counters for anything it did not touch.
+    pub fn sync(&mut self, services: impl IntoIterator<Item = (ServiceName, bool)>) {
+        let mut order = Vec::new();
+        for (name, has_health) in services {
+            self.services
+                .entry(name.clone())
+                .or_insert_with(|| Entry::new(has_health));
+            order.push(name);
+        }
+        self.services.retain(|name, _| order.contains(name));
+        self.order = order;
+    }
+
     /// Fold one event into the registry.
     pub fn apply(&mut self, event: &ServiceEvent) {
         let Some(entry) = self.services.get_mut(&event.service) else {
@@ -212,6 +228,45 @@ mod tests {
         // The second service has no health check at all.
         assert_eq!(snapshot[1].health, Health::None);
         assert!(snapshot[0].pid.is_none());
+    }
+
+    #[test]
+    fn sync_adds_and_drops_services_without_disturbing_the_rest() {
+        let mut registry = registry();
+        registry.apply(&event("db", EventKind::Started { pgid: 42 }));
+        registry.apply(&event("db", EventKind::State(ServiceState::Running)));
+
+        registry.sync([(name("db"), true), (name("cache"), false)]);
+
+        let snapshot = registry.snapshot();
+        let names: Vec<&str> = snapshot.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["db", "cache"]);
+        // The service that survived the reload kept its state.
+        assert_eq!(snapshot[0].state, ServiceState::Running);
+        assert_eq!(snapshot[0].pid, Some(42));
+        assert_eq!(snapshot[1].state, ServiceState::Pending);
+    }
+
+    #[test]
+    fn sync_reports_services_in_the_new_order() {
+        let mut registry = registry();
+        registry.sync([(name("api"), false), (name("db"), true)]);
+
+        let names: Vec<String> = registry
+            .snapshot()
+            .iter()
+            .map(|s| s.name.to_string())
+            .collect();
+        assert_eq!(names, vec!["api".to_string(), "db".to_string()]);
+    }
+
+    #[test]
+    fn events_for_dropped_services_are_ignored() {
+        let mut registry = registry();
+        registry.sync([(name("api"), false)]);
+        registry.apply(&event("db", EventKind::Started { pgid: 7 }));
+
+        assert_eq!(registry.snapshot().len(), 1);
     }
 
     #[test]

--- a/crates/servicrab-protocol/src/request.rs
+++ b/crates/servicrab-protocol/src/request.rs
@@ -33,4 +33,7 @@ pub enum Request {
         /// Service name as declared in `servicrab.toml`.
         name: String,
     },
+
+    /// Re-read the configuration file and apply the difference.
+    Reload,
 }


### PR DESCRIPTION
Apply configuration changes to a running daemon without stopping the services that did not change.

```console
$ servicrab reload
✓ reloaded demo: 1 added, 1 changed, 1 removed
  from /srv/demo/servicrab.toml
```

## What changed

**Supervisor (`servicrab-core`)**

- `StackSupervisor` now owns its configuration instead of borrowing it, so it can be swapped at runtime. The mutable parts of a run (config, plan, slots) moved into a `RunState`.
- New `Control::Reload { config, plan, ack }`: the supervisor diffs the new config against what it is running and acts only on the difference.

| Difference | What happens |
| --- | --- |
| Added | A slot is created and started, in plan order |
| Changed | The slot's definition is replaced and the service is restarted |
| Removed | The service is stopped and its slot is dropped |
| Unchanged | Nothing — uptime and restart counters survive |

- A service the operator stopped by hand stays stopped and picks up its new definition when started again.
- Services are compared by value, so `Service` derives `PartialEq`.
- `StatusRegistry::sync` brings the status table in line with a reloaded plan while preserving the state of surviving services.

**Daemon + CLI**

- `Request::Reload` on the socket; the daemon re-reads the config file it was started with, so the client's `--config` only selects *which* daemon to talk to.
- An invalid config is refused with its validation errors and leaves the stack untouched.
- A successful reload also refreshes the known-name list (`stop`/`restart` accept new services and reject removed ones) and re-creates the file watchers.
- `[project.logs]` and the log directory stay bound to the daemon process; documented in the README.
- The socket state moved into a single `Session` struct instead of six positional arguments threaded through the accept loop.

## Two bugs this surfaced

- Slots were spawned as they were created, so a service could start before the slots it depends on existed. Every slot is now created before any is spawned — the health suite caught this.
- The socket side held an event-sender clone, which kept the log collector's channel open and stopped the daemon from ever exiting. It now drops the sender on shutdown, with a 5s backstop around the collector.

## Tests

311 total (was 294): 7 supervisor diff tests, 3 registry `sync` tests, and a new `tests/reload.rs` with 7 integration tests covering add / change / remove / no-op reloads, an invalid config leaving the stack running, controlling a service added by a reload, and `reload` without a daemon.

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings` and `cargo test --workspace --all-features` are green locally.