### PR TITLE
Generate systemd units and launchd jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
   check:
     name: fmt + clippy + test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # The suite runs in about a minute; anything close to this means a test
+    # deadlocked, and a hung job should fail fast instead of burning an hour.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -47,4 +50,4 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test --all
+        run: cargo test --workspace --all-features

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - Log files: opt-in per-service capture with size-based rotation, plus `servicrab logs [-f]` to read and follow them
 - Background daemon: `servicrab start` / `status` / `stop` / `restart` / `down`, with a documented JSON-over-Unix-socket protocol (Linux/macOS)
 - `servicrab reload` — apply config changes to a running stack without stopping the services you did not touch
+- `servicrab generate systemd|launchd` — hand the stack over to the init system, with `systemctl reload` wired to `servicrab reload`
 - Restart policies: `never`, `on-failure`, `always`, with exponential backoff
 - Environment: per-service variables, working directories, and dotenv-style `env_file` layering
 - Shell completions for bash, zsh, fish, PowerShell and elvish
@@ -135,6 +136,7 @@ if you want shell semantics.
 | `servicrab reload [--config PATH]` | Re-read the config and apply the difference to the running daemon |
 | `servicrab down [--config PATH]` | Stop the daemon and every service it supervises |
 | `servicrab daemon [--config PATH] [--no-restart]` | Run the daemon in the foreground (for systemd/launchd/containers) |
+| `servicrab generate <systemd\|launchd> [--config PATH] [--scope system\|user] [-o PATH] [--user NAME]` | Generate an init-system unit that runs the stack |
 | `servicrab completions <SHELL>` | Print a completion script for bash, zsh, fish, PowerShell or elvish |
 
 If `--config` is omitted, Servicrab discovers `servicrab.toml` by walking up
@@ -620,6 +622,41 @@ neither the runtime nor Tokio.
 
 ---
 
+## Running under systemd or launchd
+
+`servicrab generate` writes a unit that starts `servicrab daemon` — the
+foreground supervisor — so the init system supervises one process and
+servicrab supervises the stack:
+
+```console
+$ servicrab generate systemd
+[Unit]
+Description=servicrab stack "demo"
+…
+$ servicrab generate systemd -o .            # writes servicrab-demo.service
+$ servicrab generate launchd --scope user -o ~/Library/LaunchAgents/
+```
+
+Install instructions are printed to stderr, so `servicrab generate systemd >
+demo.service` keeps the file clean.
+
+| Flag | What it does |
+| --- | --- |
+| `--scope system` (default) | `/etc/systemd/system` or `/Library/LaunchDaemons`, started at boot |
+| `--scope user` | `systemctl --user` or `~/Library/LaunchAgents`, started at login |
+| `--user NAME` | Run the daemon as another account (system scope only) |
+| `-o PATH` | Write to a file, or into a directory using the conventional name |
+
+The generated unit contains no service definitions — it points at your
+`servicrab.toml`. Adding a service means editing the config and reloading, not
+regenerating the unit. On systemd, `ExecReload` is wired to `servicrab reload`,
+so `systemctl reload servicrab-demo.service` applies config changes without
+touching the services that did not change. `TimeoutStopSec` (and launchd's
+`ExitTimeOut`) follow the slowest `shutdown_timeout` in your config, so the init
+system never kills the daemon while it is still stopping the stack.
+
+---
+
 ## Workspace layout
 
 ```
@@ -697,9 +734,10 @@ cargo test -p servicrab-core config::tests
 - [x] Config hot-reload (`servicrab reload`)
 
 ### Phase 4 (current) — Platform integration
-- [ ] systemd unit generation
-- [ ] launchd plist generation
-- [ ] Windows Service wrapper
+- [x] systemd unit generation (`servicrab generate systemd`)
+- [x] launchd plist generation (`servicrab generate launchd`)
+- [ ] Live event streaming over the socket
+- [ ] `--json` event stream for `up`
 
 ---
 

--- a/crates/servicrab-cli/src/commands/generate.rs
+++ b/crates/servicrab-cli/src/commands/generate.rs
@@ -1,0 +1,574 @@
+//! `servicrab generate <systemd|launchd>` — emit an init-system unit that
+//! supervises the whole project through `servicrab daemon`.
+//!
+//! The generated unit never contains service definitions: it starts the
+//! servicrab daemon, which reads `servicrab.toml` at boot. That keeps the unit
+//! stable — adding a service to the stack means editing the config and running
+//! `servicrab reload`, not regenerating and reinstalling anything.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use servicrab_core::{load, resolve_config_path, Config};
+
+/// Which init system to generate for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum Target {
+    /// A systemd unit file (Linux).
+    Systemd,
+    /// A launchd property list (macOS).
+    Launchd,
+}
+
+/// Whether the unit belongs to the machine or to the current user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum Scope {
+    /// A system-wide unit, started at boot (`/etc/systemd/system`,
+    /// `/Library/LaunchDaemons`).
+    #[default]
+    System,
+    /// A per-user unit, started at login (`systemctl --user`,
+    /// `~/Library/LaunchAgents`).
+    User,
+}
+
+/// Options for `servicrab generate`.
+#[derive(Debug, Clone, Default)]
+pub struct GenerateOptions {
+    /// System-wide or per-user unit.
+    pub scope: Scope,
+    /// Where to write the unit; stdout when omitted. A directory gets the
+    /// conventional file name for the target.
+    pub output: Option<PathBuf>,
+    /// Account the daemon should run as (system scope only).
+    pub user: Option<String>,
+}
+
+/// Everything a unit template needs that does not come from the config.
+#[derive(Debug, Clone)]
+struct Context {
+    /// Absolute path of the `servicrab` executable.
+    program: PathBuf,
+    /// Absolute path of the config file.
+    config: PathBuf,
+    /// Directory the daemon should run in (the config's directory).
+    working_dir: PathBuf,
+    scope: Scope,
+    user: Option<String>,
+    /// How long the init system should wait for a clean stop.
+    stop_timeout: Duration,
+}
+
+/// Extra time on top of the slowest service's shutdown timeout, so the init
+/// system never kills the daemon while it is still stopping the stack.
+const STOP_MARGIN: Duration = Duration::from_secs(15);
+/// Lower bound for the stop timeout, matching systemd's usual default.
+const MIN_STOP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Run the `generate` subcommand.
+pub fn run(target: Target, config: Option<&Path>, options: GenerateOptions) -> Result<i32, String> {
+    let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
+    let (cfg, warnings) = load(&path).map_err(|errors| {
+        let msgs: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
+        format!(
+            "✗ {} has {} error(s):\n{}",
+            path.display(),
+            errors.len(),
+            msgs.join("\n")
+        )
+    })?;
+    for warning in &warnings {
+        eprintln!("⚠  {warning}");
+    }
+
+    let program = std::env::current_exe()
+        .map_err(|e| format!("could not find the servicrab executable: {e}"))?;
+    let context = Context {
+        program,
+        working_dir: path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from(".")),
+        config: path,
+        scope: options.scope,
+        user: options.user.clone(),
+        stop_timeout: stop_timeout(&cfg),
+    };
+
+    let unit = match target {
+        Target::Systemd => systemd_unit(&cfg, &context),
+        Target::Launchd => launchd_plist(&cfg, &context),
+    };
+    let file_name = unit_file_name(target, &cfg);
+
+    match options.output.as_deref() {
+        None => {
+            print!("{unit}");
+            eprintln!("{}", install_hint(target, options.scope, &file_name));
+        }
+        Some(output) => {
+            let destination = if output.is_dir() {
+                output.join(&file_name)
+            } else {
+                output.to_path_buf()
+            };
+            std::fs::write(&destination, &unit)
+                .map_err(|e| format!("could not write {}: {e}", destination.display()))?;
+            println!("✓ wrote {}", destination.display());
+            println!("{}", install_hint(target, options.scope, &file_name));
+        }
+    }
+    Ok(0)
+}
+
+/// The conventional file name for a generated unit.
+fn unit_file_name(target: Target, cfg: &Config) -> String {
+    match target {
+        Target::Systemd => format!("servicrab-{}.service", cfg.project.name),
+        Target::Launchd => format!("{}.plist", launchd_label(cfg)),
+    }
+}
+
+/// The reverse-DNS label launchd identifies the job by.
+fn launchd_label(cfg: &Config) -> String {
+    format!("com.servicrab.{}", cfg.project.name)
+}
+
+/// How long the init system should allow for a clean stop.
+///
+/// The daemon stops its services in reverse dependency order, so the slowest
+/// service's shutdown timeout is the floor for the whole stack.
+fn stop_timeout(cfg: &Config) -> Duration {
+    let slowest = cfg
+        .services
+        .values()
+        .map(|service| service.shutdown_timeout)
+        .max()
+        .unwrap_or_default();
+    (slowest + STOP_MARGIN).max(MIN_STOP_TIMEOUT)
+}
+
+/// Render a systemd unit for the project.
+fn systemd_unit(cfg: &Config, context: &Context) -> String {
+    let program = quote_systemd(&context.program);
+    let config = quote_systemd(&context.config);
+    let mut unit = String::new();
+
+    unit.push_str(&format!(
+        "# systemd unit for the servicrab project \"{}\".\n\
+         # Generated by servicrab {}; edit it freely, it is never regenerated.\n\n",
+        cfg.project.name,
+        env!("CARGO_PKG_VERSION")
+    ));
+
+    unit.push_str("[Unit]\n");
+    unit.push_str(&format!(
+        "Description=servicrab stack \"{}\"\n",
+        cfg.project.name
+    ));
+    unit.push_str("Documentation=https://github.com/gaborini/servicrab\n");
+    if context.scope == Scope::System {
+        unit.push_str("Wants=network-online.target\n");
+        unit.push_str("After=network-online.target\n");
+    }
+    unit.push('\n');
+
+    unit.push_str("[Service]\n");
+    unit.push_str("Type=simple\n");
+    unit.push_str(&format!(
+        "WorkingDirectory={}\n",
+        quote_systemd(&context.working_dir)
+    ));
+    unit.push_str(&format!("ExecStart={program} daemon --config {config}\n"));
+    // `systemctl reload` picks up config changes without stopping services
+    // that did not change.
+    unit.push_str(&format!("ExecReload={program} reload --config {config}\n"));
+    unit.push_str("Restart=on-failure\n");
+    unit.push_str("RestartSec=5\n");
+    unit.push_str("KillSignal=SIGTERM\n");
+    // The daemon stops its own children, but `mixed` guarantees nothing is
+    // left behind if it dies unexpectedly.
+    unit.push_str("KillMode=mixed\n");
+    unit.push_str(&format!(
+        "TimeoutStopSec={}\n",
+        context.stop_timeout.as_secs()
+    ));
+    if context.scope == Scope::System {
+        if let Some(user) = &context.user {
+            unit.push_str(&format!("User={user}\n"));
+            unit.push_str(&format!("Group={user}\n"));
+        }
+    }
+    unit.push('\n');
+
+    unit.push_str("[Install]\n");
+    unit.push_str(match context.scope {
+        Scope::System => "WantedBy=multi-user.target\n",
+        Scope::User => "WantedBy=default.target\n",
+    });
+    unit
+}
+
+/// Render a launchd property list for the project.
+fn launchd_plist(cfg: &Config, context: &Context) -> String {
+    let label = launchd_label(cfg);
+    let logs = context.working_dir.join(".servicrab");
+    let mut plist = String::new();
+
+    plist.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    plist.push_str(
+        "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+         \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n",
+    );
+    plist.push_str(&format!(
+        "<!-- launchd job for the servicrab project \"{}\", generated by servicrab {}. -->\n",
+        escape_xml(cfg.project.name.as_str()),
+        env!("CARGO_PKG_VERSION")
+    ));
+    plist.push_str("<plist version=\"1.0\">\n<dict>\n");
+
+    plist.push_str(&format!(
+        "\t<key>Label</key>\n\t<string>{}</string>\n",
+        escape_xml(&label)
+    ));
+    plist.push_str("\t<key>ProgramArguments</key>\n\t<array>\n");
+    for argument in [
+        context.program.display().to_string(),
+        "daemon".to_string(),
+        "--config".to_string(),
+        context.config.display().to_string(),
+    ] {
+        plist.push_str(&format!("\t\t<string>{}</string>\n", escape_xml(&argument)));
+    }
+    plist.push_str("\t</array>\n");
+
+    plist.push_str(&format!(
+        "\t<key>WorkingDirectory</key>\n\t<string>{}</string>\n",
+        escape_xml(&context.working_dir.display().to_string())
+    ));
+    plist.push_str("\t<key>RunAtLoad</key>\n\t<true/>\n");
+    // Restart the daemon when it dies, but respect a clean `servicrab down`.
+    plist.push_str(
+        "\t<key>KeepAlive</key>\n\t<dict>\n\t\t<key>SuccessfulExit</key>\n\t\t<false/>\n\t</dict>\n",
+    );
+    plist.push_str(&format!(
+        "\t<key>StandardOutPath</key>\n\t<string>{}</string>\n",
+        escape_xml(&logs.join("launchd.out.log").display().to_string())
+    ));
+    plist.push_str(&format!(
+        "\t<key>StandardErrorPath</key>\n\t<string>{}</string>\n",
+        escape_xml(&logs.join("launchd.err.log").display().to_string())
+    ));
+    plist.push_str(&format!(
+        "\t<key>ExitTimeOut</key>\n\t<integer>{}</integer>\n",
+        context.stop_timeout.as_secs()
+    ));
+    plist.push_str("\t<key>ProcessType</key>\n\t<string>Background</string>\n");
+    if context.scope == Scope::System {
+        if let Some(user) = &context.user {
+            plist.push_str(&format!(
+                "\t<key>UserName</key>\n\t<string>{}</string>\n",
+                escape_xml(user)
+            ));
+        }
+    }
+
+    plist.push_str("</dict>\n</plist>\n");
+    plist
+}
+
+/// How to install the generated unit, printed next to it rather than into it.
+fn install_hint(target: Target, scope: Scope, file_name: &str) -> String {
+    match (target, scope) {
+        (Target::Systemd, Scope::System) => format!(
+            "\nInstall with:\n  \
+             sudo cp {file_name} /etc/systemd/system/\n  \
+             sudo systemctl daemon-reload\n  \
+             sudo systemctl enable --now {file_name}\n\n\
+             Then `sudo systemctl reload {file_name}` applies config changes."
+        ),
+        (Target::Systemd, Scope::User) => format!(
+            "\nInstall with:\n  \
+             mkdir -p ~/.config/systemd/user\n  \
+             cp {file_name} ~/.config/systemd/user/\n  \
+             systemctl --user daemon-reload\n  \
+             systemctl --user enable --now {file_name}\n\n\
+             Then `systemctl --user reload {file_name}` applies config changes."
+        ),
+        (Target::Launchd, Scope::System) => format!(
+            "\nInstall with:\n  \
+             sudo cp {file_name} /Library/LaunchDaemons/\n  \
+             sudo launchctl bootstrap system /Library/LaunchDaemons/{file_name}\n\n\
+             Then `servicrab reload` applies config changes."
+        ),
+        (Target::Launchd, Scope::User) => format!(
+            "\nInstall with:\n  \
+             cp {file_name} ~/Library/LaunchAgents/\n  \
+             launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/{file_name}\n\n\
+             Then `servicrab reload` applies config changes."
+        ),
+    }
+}
+
+/// Quote a path for a systemd directive when it contains whitespace.
+fn quote_systemd(path: &Path) -> String {
+    let text = path.display().to_string();
+    if text.contains(char::is_whitespace) {
+        format!("\"{}\"", text.replace('"', "\\\""))
+    } else {
+        text
+    }
+}
+
+/// Escape the five XML entities so odd paths cannot break the plist.
+fn escape_xml(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len());
+    for character in text.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+
+    use tempfile::TempDir;
+
+    /// Load a config from TOML the way the command does.
+    fn config(toml: &str) -> (TempDir, Config) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("servicrab.toml");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(toml.as_bytes()).unwrap();
+        let (cfg, _) = load(&path).expect("valid test config");
+        (dir, cfg)
+    }
+
+    const BASE: &str = r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["/usr/bin/api"]
+"#;
+
+    fn context() -> Context {
+        Context {
+            program: PathBuf::from("/usr/local/bin/servicrab"),
+            config: PathBuf::from("/srv/demo/servicrab.toml"),
+            working_dir: PathBuf::from("/srv/demo"),
+            scope: Scope::System,
+            user: None,
+            stop_timeout: Duration::from_secs(30),
+        }
+    }
+
+    #[test]
+    fn a_systemd_unit_starts_the_daemon_and_reloads_the_config() {
+        let (_dir, cfg) = config(BASE);
+        let unit = systemd_unit(&cfg, &context());
+
+        assert!(
+            unit.contains("Description=servicrab stack \"demo\""),
+            "{unit}"
+        );
+        assert!(
+            unit.contains(
+                "ExecStart=/usr/local/bin/servicrab daemon --config /srv/demo/servicrab.toml"
+            ),
+            "{unit}"
+        );
+        assert!(
+            unit.contains(
+                "ExecReload=/usr/local/bin/servicrab reload --config /srv/demo/servicrab.toml"
+            ),
+            "{unit}"
+        );
+        assert!(unit.contains("WorkingDirectory=/srv/demo"), "{unit}");
+        assert!(unit.contains("WantedBy=multi-user.target"), "{unit}");
+        assert!(unit.contains("KillMode=mixed"), "{unit}");
+    }
+
+    #[test]
+    fn a_user_scoped_systemd_unit_drops_system_only_directives() {
+        let (_dir, cfg) = config(BASE);
+        let unit = systemd_unit(
+            &cfg,
+            &Context {
+                scope: Scope::User,
+                user: Some("deploy".to_string()),
+                ..context()
+            },
+        );
+
+        assert!(unit.contains("WantedBy=default.target"), "{unit}");
+        assert!(!unit.contains("network-online.target"), "{unit}");
+        // A user unit already runs as the user.
+        assert!(!unit.contains("User="), "{unit}");
+    }
+
+    #[test]
+    fn a_system_unit_can_run_as_another_account() {
+        let (_dir, cfg) = config(BASE);
+        let unit = systemd_unit(
+            &cfg,
+            &Context {
+                user: Some("deploy".to_string()),
+                ..context()
+            },
+        );
+
+        assert!(unit.contains("User=deploy"), "{unit}");
+        assert!(unit.contains("Group=deploy"), "{unit}");
+    }
+
+    #[test]
+    fn paths_with_spaces_are_quoted_for_systemd() {
+        let (_dir, cfg) = config(BASE);
+        let unit = systemd_unit(
+            &cfg,
+            &Context {
+                config: PathBuf::from("/srv/my demo/servicrab.toml"),
+                working_dir: PathBuf::from("/srv/my demo"),
+                ..context()
+            },
+        );
+
+        assert!(
+            unit.contains("--config \"/srv/my demo/servicrab.toml\""),
+            "{unit}"
+        );
+        assert!(unit.contains("WorkingDirectory=\"/srv/my demo\""), "{unit}");
+    }
+
+    #[test]
+    fn the_stop_timeout_follows_the_slowest_service() {
+        let (_dir, cfg) = config(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["/usr/bin/api"]
+shutdown_timeout = "60s"
+[services.worker]
+command = ["/usr/bin/worker"]
+shutdown_timeout = "5s"
+"#,
+        );
+
+        assert_eq!(stop_timeout(&cfg), Duration::from_secs(75));
+    }
+
+    #[test]
+    fn the_stop_timeout_never_drops_below_the_floor() {
+        let (_dir, cfg) = config(BASE);
+        assert_eq!(stop_timeout(&cfg), MIN_STOP_TIMEOUT);
+    }
+
+    #[test]
+    fn a_launchd_plist_is_well_formed() {
+        let (_dir, cfg) = config(BASE);
+        let plist = launchd_plist(&cfg, &context());
+
+        assert!(plist.starts_with("<?xml version=\"1.0\""), "{plist}");
+        assert!(plist.trim_end().ends_with("</plist>"), "{plist}");
+        assert!(
+            plist.contains("<key>Label</key>\n\t<string>com.servicrab.demo</string>"),
+            "{plist}"
+        );
+        assert!(
+            plist.contains("<string>/usr/local/bin/servicrab</string>"),
+            "{plist}"
+        );
+        assert!(plist.contains("<string>--config</string>"), "{plist}");
+        assert!(
+            plist.contains("<string>/srv/demo/.servicrab/launchd.out.log</string>"),
+            "{plist}"
+        );
+        assert!(plist.contains("<integer>30</integer>"), "{plist}");
+        assert_eq!(
+            plist.matches("<dict>").count(),
+            plist.matches("</dict>").count()
+        );
+    }
+
+    #[test]
+    fn a_system_plist_can_run_as_another_account() {
+        let (_dir, cfg) = config(BASE);
+        let plist = launchd_plist(
+            &cfg,
+            &Context {
+                user: Some("deploy".to_string()),
+                ..context()
+            },
+        );
+        assert!(plist.contains("<key>UserName</key>"), "{plist}");
+
+        let agent = launchd_plist(
+            &cfg,
+            &Context {
+                scope: Scope::User,
+                user: Some("deploy".to_string()),
+                ..context()
+            },
+        );
+        assert!(!agent.contains("UserName"), "{agent}");
+    }
+
+    #[test]
+    fn xml_special_characters_are_escaped() {
+        assert_eq!(
+            escape_xml("a&b<c>d\"e'f"),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
+
+        let (_dir, cfg) = config(BASE);
+        let plist = launchd_plist(
+            &cfg,
+            &Context {
+                working_dir: PathBuf::from("/srv/a&b"),
+                ..context()
+            },
+        );
+        assert!(plist.contains("<string>/srv/a&amp;b</string>"), "{plist}");
+        assert!(!plist.contains("/srv/a&b<"), "{plist}");
+    }
+
+    #[test]
+    fn unit_file_names_follow_each_platforms_convention() {
+        let (_dir, cfg) = config(BASE);
+        assert_eq!(
+            unit_file_name(Target::Systemd, &cfg),
+            "servicrab-demo.service"
+        );
+        assert_eq!(
+            unit_file_name(Target::Launchd, &cfg),
+            "com.servicrab.demo.plist"
+        );
+    }
+
+    #[test]
+    fn install_hints_match_the_scope() {
+        assert!(install_hint(Target::Systemd, Scope::System, "u.service")
+            .contains("/etc/systemd/system/"));
+        assert!(
+            install_hint(Target::Systemd, Scope::User, "u.service").contains("systemctl --user")
+        );
+        assert!(install_hint(Target::Launchd, Scope::System, "u.plist")
+            .contains("/Library/LaunchDaemons/"));
+        assert!(install_hint(Target::Launchd, Scope::User, "u.plist").contains("LaunchAgents"));
+    }
+}

--- a/crates/servicrab-cli/src/commands/mod.rs
+++ b/crates/servicrab-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@
 pub mod check;
 pub mod completions;
 pub mod daemon;
+pub mod generate;
 pub mod init;
 pub mod list;
 pub mod logs;

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -251,6 +251,31 @@ enum Commands {
         config: Option<std::path::PathBuf>,
     },
 
+    /// Generate an init-system unit that runs the stack through
+    /// `servicrab daemon`.
+    Generate {
+        /// Which init system to generate for.
+        target: commands::generate::Target,
+
+        /// Path to the configuration file.  If omitted, discovers
+        /// servicrab.toml by walking up from the current directory.
+        #[arg(long, short = 'c')]
+        config: Option<std::path::PathBuf>,
+
+        /// Whether the unit is system-wide or per-user.
+        #[arg(long, value_enum, default_value_t = commands::generate::Scope::System)]
+        scope: commands::generate::Scope,
+
+        /// Write the unit to this file (or into this directory) instead of
+        /// stdout.
+        #[arg(long, short = 'o')]
+        output: Option<std::path::PathBuf>,
+
+        /// Account the daemon should run as (system scope only).
+        #[arg(long)]
+        user: Option<String>,
+    },
+
     /// Print a shell completion script to stdout.
     Completions {
         /// Shell to generate completions for.
@@ -359,6 +384,21 @@ fn main() {
         Commands::Daemon { config, no_restart } => {
             commands::daemon::daemon(config.as_deref(), no_restart)
         }
+        Commands::Generate {
+            target,
+            config,
+            scope,
+            output,
+            user,
+        } => commands::generate::run(
+            target,
+            config.as_deref(),
+            commands::generate::GenerateOptions {
+                scope,
+                output,
+                user,
+            },
+        ),
         Commands::Completions { shell } => commands::completions::run::<Cli>(shell).map(|()| 0),
         Commands::Logs {
             services,

--- a/crates/servicrab-cli/tests/generate.rs
+++ b/crates/servicrab-cli/tests/generate.rs
@@ -1,0 +1,158 @@
+//! Integration tests for `servicrab generate`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+fn cli(args: &[&str], config_path: &Path) -> (i32, String, String) {
+    let output = Command::new(binary())
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn project(dir: &Path) -> PathBuf {
+    let path = dir.join("servicrab.toml");
+    fs::write(
+        &path,
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["/usr/bin/api"]
+"#,
+    )
+    .unwrap();
+    path
+}
+
+#[test]
+fn a_systemd_unit_is_written_to_stdout() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path());
+
+    let (code, stdout, stderr) = cli(&["generate", "systemd"], &cfg);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stdout.contains("[Service]"), "{stdout}");
+    assert!(stdout.contains("ExecStart="), "{stdout}");
+    assert!(stdout.contains("daemon --config"), "{stdout}");
+    // The install hints must not pollute the unit itself.
+    assert!(!stdout.contains("Install with"), "{stdout}");
+    assert!(stderr.contains("systemctl"), "{stderr}");
+}
+
+#[test]
+fn a_launchd_plist_is_written_to_stdout() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path());
+
+    let (code, stdout, stderr) = cli(&["generate", "launchd"], &cfg);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stdout.starts_with("<?xml"), "{stdout}");
+    assert!(stdout.contains("com.servicrab.demo"), "{stdout}");
+    assert!(stdout.trim_end().ends_with("</plist>"), "{stdout}");
+    assert!(stderr.contains("launchctl"), "{stderr}");
+}
+
+#[test]
+fn the_unit_can_be_written_to_a_file() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path());
+    let target = dir.path().join("demo.service");
+
+    let (code, stdout, stderr) = cli(
+        &["generate", "systemd", "-o", target.to_str().unwrap()],
+        &cfg,
+    );
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stdout.contains("wrote"), "{stdout}");
+    assert!(fs::read_to_string(&target).unwrap().contains("[Unit]"));
+}
+
+#[test]
+fn a_directory_target_gets_the_conventional_file_name() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path());
+    let out = dir.path().join("units");
+    fs::create_dir(&out).unwrap();
+
+    let (code, _, stderr) = cli(&["generate", "systemd", "-o", out.to_str().unwrap()], &cfg);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(out.join("servicrab-demo.service").is_file());
+
+    let (code, _, stderr) = cli(&["generate", "launchd", "-o", out.to_str().unwrap()], &cfg);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(out.join("com.servicrab.demo.plist").is_file());
+}
+
+#[test]
+fn the_scope_switches_the_install_target() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path());
+
+    let (_, stdout, stderr) = cli(&["generate", "systemd", "--scope", "user"], &cfg);
+    assert!(stdout.contains("WantedBy=default.target"), "{stdout}");
+    assert!(stderr.contains("--user"), "{stderr}");
+
+    let (_, stdout, _) = cli(&["generate", "systemd", "--scope", "system"], &cfg);
+    assert!(stdout.contains("WantedBy=multi-user.target"), "{stdout}");
+}
+
+#[test]
+fn a_system_unit_can_name_the_account_to_run_as() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path());
+
+    let (code, stdout, stderr) = cli(&["generate", "systemd", "--user", "deploy"], &cfg);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stdout.contains("User=deploy"), "{stdout}");
+}
+
+#[test]
+fn an_invalid_config_is_reported_instead_of_a_unit() {
+    let dir = TempDir::new().unwrap();
+    let cfg = dir.path().join("servicrab.toml");
+    fs::write(
+        &cfg,
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["/usr/bin/api"]
+depends_on = ["ghost"]
+"#,
+    )
+    .unwrap();
+
+    let (code, stdout, stderr) = cli(&["generate", "systemd"], &cfg);
+    assert_ne!(code, 0);
+    assert!(stdout.is_empty(), "{stdout}");
+    assert!(stderr.contains("ghost"), "{stderr}");
+}
+
+#[test]
+fn an_unknown_target_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path());
+
+    let (code, _, stderr) = cli(&["generate", "upstart"], &cfg);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("invalid value"), "{stderr}");
+}

--- a/crates/servicrab-cli/tests/health.rs
+++ b/crates/servicrab-cli/tests/health.rs
@@ -187,10 +187,11 @@ retries = 2
 fn an_unhealthy_service_is_restarted() {
     let dir = TempDir::new().unwrap();
     let runs = dir.path().join("runs.txt");
-    let flag = dir.path().join("healthy");
 
-    // The probe fails on the first run and succeeds once the service has been
-    // restarted, so the run must end cleanly after exactly one restart.
+    // The probe answers "unhealthy" for the first run of the service and
+    // "healthy" from the second one on.  It keys off the service's own run
+    // log rather than off its own invocation count, so the answer does not
+    // depend on how many times it happens to be called per run.
     script(
         dir.path(),
         "svc.sh",
@@ -200,8 +201,8 @@ fn an_unhealthy_service_is_restarted() {
         dir.path(),
         "probe.sh",
         &format!(
-            "if [ -f {flag} ]; then exit 0; fi\necho x > {flag}\nexit 1",
-            flag = flag.display()
+            "[ \"$(wc -l < {runs} 2>/dev/null || echo 0)\" -ge 2 ]",
+            runs = runs.display()
         ),
     );
 

--- a/crates/servicrab-core/src/runtime/unix.rs
+++ b/crates/servicrab-core/src/runtime/unix.rs
@@ -139,7 +139,8 @@ impl ProcessHandle {
     /// A group that has already gone away is not an error.
     fn signal_group(&self, service: &str, sig: Signal) -> Result<(), RuntimeError> {
         match killpg(self.pgid, sig) {
-            Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
+            Ok(()) => Ok(()),
+            Err(errno) if group_is_gone(errno) => Ok(()),
             Err(errno) => Err(RuntimeError::SignalDeliveryFailed {
                 service: service.to_string(),
                 signal: sig.as_str().to_string(),
@@ -153,7 +154,16 @@ impl ProcessHandle {
     /// group.  Used to make sure no descendant outlives the supervisor.
     fn kill_group(&self, service: &str, timeout: Duration) -> Result<(), RuntimeError> {
         match killpg(self.pgid, Signal::SIGKILL) {
-            Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
+            Ok(()) => Ok(()),
+            Err(errno) if group_is_gone(errno) => {
+                tracing::debug!(
+                    service = %service,
+                    pgid = self.pgid.as_raw(),
+                    %errno,
+                    "the process group was already gone"
+                );
+                Ok(())
+            }
             Err(errno) => Err(RuntimeError::ForceKillFailed {
                 service: service.to_string(),
                 pgid: self.pgid.as_raw(),
@@ -650,9 +660,30 @@ impl<'a> ForegroundRunner<'a> {
     }
 }
 
+/// Whether a `killpg(2)` error means "there is nothing of ours left to
+/// signal".
+///
+/// `ESRCH` is the documented answer for an empty group.  macOS also answers
+/// `EPERM` once the group holds nothing we own — for example when the leader
+/// has been reaped and only unrelated processes could still claim the id.
+/// Either way there is no process of ours left to kill, and failing the run
+/// over it would turn a successful shutdown into a spurious error.
+fn group_is_gone(errno: nix::errno::Errno) -> bool {
+    matches!(errno, nix::errno::Errno::ESRCH | nix::errno::Errno::EPERM)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_vanished_group_is_not_an_error() {
+        assert!(group_is_gone(nix::errno::Errno::ESRCH));
+        // macOS reports a group we can no longer signal this way.
+        assert!(group_is_gone(nix::errno::Errno::EPERM));
+        // Anything else is a real failure worth reporting.
+        assert!(!group_is_gone(nix::errno::Errno::EINVAL));
+    }
 
     #[test]
     fn shutdown_signals_map_to_os_signals() {


### PR DESCRIPTION
`servicrab generate systemd|launchd` writes an init-system unit that runs the stack through `servicrab daemon`, so the init system supervises one process and servicrab supervises the services.

```console
$ servicrab generate systemd
[Unit]
Description=servicrab stack "demo"
…
[Service]
Type=simple
WorkingDirectory=/srv/demo
ExecStart=/usr/local/bin/servicrab daemon --config /srv/demo/servicrab.toml
ExecReload=/usr/local/bin/servicrab reload --config /srv/demo/servicrab.toml
…
```

## Design

- **The unit holds no service definitions.** It points at `servicrab.toml`, so adding a service means editing the config and reloading — not regenerating and reinstalling a unit.
- **`ExecReload` is `servicrab reload`**, so `systemctl reload servicrab-demo.service` applies config changes without touching the services that did not change.
- **The stop timeout follows the config**: `TimeoutStopSec` / `ExitTimeOut` = slowest `shutdown_timeout` + 15s, floored at 30s, so the init system never kills the daemon while it is still stopping the stack in reverse dependency order.
- **Install hints go to stderr**, so `servicrab generate systemd > demo.service` produces a clean file.

| Flag | Effect |
| --- | --- |
| `--scope system` (default) | `/etc/systemd/system` or `/Library/LaunchDaemons`, `WantedBy=multi-user.target`, `network-online.target` ordering |
| `--scope user` | `systemctl --user` or `~/Library/LaunchAgents`, `WantedBy=default.target` |
| `--user NAME` | `User=`/`Group=` (systemd) or `UserName` (launchd), system scope only |
| `-o PATH` | Write to a file, or into a directory as `servicrab-<project>.service` / `com.servicrab.<project>.plist` |

Both templates are pure functions over the validated config, so they are unit-tested on every platform. Paths with whitespace are quoted for systemd and XML-escaped for launchd; generated plists pass `plutil -lint`.

## Also in this PR: the macOS CI flakes, fixed at the root

The first run of this branch tripped over two long-standing macOS flakes, so they are fixed here rather than worked around with reruns.

- **`killpg(2)` answered `EPERM`.** On macOS a process group whose members are all gone answers `EPERM` instead of `ESRCH` once the leader has been reaped. The last-resort force-kill after the grace period then failed the whole run even though the shutdown had succeeded. Both errnos now mean "nothing of ours left to signal".
- **A health probe that was not idempotent.** `an_unhealthy_service_is_restarted` used a probe that reported "unhealthy" exactly once, by creating a flag file. With `retries = 1` the runtime probes twice per run, so whenever the second probe landed before the restart the service was declared healthy and the expected restart never came — the test then sat until its 15s ceiling. The probe now keys off the service's own run log, so its answer no longer depends on how often it is called.
- **CI has no job timeout**, which turns a deadlocked test into an hour of queued runners. Added `timeout-minutes: 20`, and `cargo test --all` became `cargo test --workspace --all-features` so the gate covers what it claims to.

## Tests

331 total (was 311): 11 unit tests for the two templates, the stop-timeout rule, quoting/escaping, file names and install hints; a new `tests/generate.rs` with 8 integration tests; and one for the `killpg` errno classification. The previously flaky health test passed 5/5 locally after the fix.

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings` and `cargo test --workspace --all-features` are green locally.
