### PR TITLE
Live event streaming over the daemon socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - Log files: opt-in per-service capture with size-based rotation, plus `servicrab logs [-f]` to read and follow them
 - Background daemon: `servicrab start` / `status` / `stop` / `restart` / `down`, with a documented JSON-over-Unix-socket protocol (Linux/macOS)
 - `servicrab reload` — apply config changes to a running stack without stopping the services you did not touch
+- `servicrab events` — follow a running stack live: logs, state changes, restarts and health verdicts, as text or JSON
 - `servicrab generate systemd|launchd` — hand the stack over to the init system, with `systemctl reload` wired to `servicrab reload`
 - Restart policies: `never`, `on-failure`, `always`, with exponential backoff
 - Environment: per-service variables, working directories, and dotenv-style `env_file` layering
@@ -134,6 +135,7 @@ if you want shell semantics.
 | `servicrab stop <SERVICE...> [--config PATH]` | Stop individual services in the running daemon |
 | `servicrab restart <SERVICE...> [--config PATH]` | Restart individual services |
 | `servicrab reload [--config PATH]` | Re-read the config and apply the difference to the running daemon |
+| `servicrab events [SERVICE...] [--config PATH] [--json] [--no-prefix] [--timestamps] [--no-logs]` | Follow the daemon's live event stream |
 | `servicrab down [--config PATH]` | Stop the daemon and every service it supervises |
 | `servicrab daemon [--config PATH] [--no-restart]` | Run the daemon in the foreground (for systemd/launchd/containers) |
 | `servicrab generate <systemd\|launchd> [--config PATH] [--scope system\|user] [-o PATH] [--user NAME]` | Generate an init-system unit that runs the stack |
@@ -575,10 +577,48 @@ echo '{"type":"status"}' | nc -U .servicrab/daemon.sock
 | `{"type":"stop_service","name":"api"}` | `{"type":"ok","message":"api stopped"}` |
 | `{"type":"restart_service","name":"api"}` | `{"type":"ok","message":"api restarted"}` |
 | `{"type":"reload"}` | `{"type":"ok","message":"reloaded demo: 1 added, 1 changed, 0 removed"}` |
+| `{"type":"subscribe"}` | `{"type":"ok"}`, then a `{"type":"event",…}` line per event |
 
 `stop_service` and `restart_service` only answer once the service has actually
 stopped (and, for a restart, been replaced), so scripts can rely on the reply
 instead of polling.
+
+### Live event streaming
+
+`subscribe` is the one request that turns a connection one-way: the daemon
+answers `ok` and then keeps writing events until the client goes away. It takes
+two optional fields — `services` (an allow-list; empty means all of them) and
+`logs` (set it to `false` to leave captured output out).
+
+```bash
+$ echo '{"type":"subscribe","services":["api"]}' | nc -U .servicrab/daemon.sock
+{"type":"ok"}
+{"type":"event","service":"api","event":{"kind":"log","stream":"stdout","line":"listening on :8080"}}
+{"type":"event","service":"api","event":{"kind":"state","state":"stopping"}}
+```
+
+`servicrab events` is the CLI on top of it, rendered like `up`:
+
+```console
+$ servicrab events
+servicrab events demo → all services
+api    | listening on :8080
+worker | picked up job 41
+api    | ▶ started (pgid 5512)
+```
+
+| Flag | Effect |
+| --- | --- |
+| `SERVICE...` | Only follow these services |
+| `--json` | Print the raw protocol lines, one JSON object per line |
+| `--no-logs` | Lifecycle events only — no captured stdout/stderr |
+| `--no-prefix` | Drop the service-name column |
+| `-t`, `--timestamps` | Prefix every line with a UTC timestamp |
+
+The stream is a live feed, not a backlog: a subscriber sees what happens from
+the moment it attaches (use `servicrab logs` for history). A client too slow to
+keep up gets a `{"type":"lagged","skipped":N}` notice instead of silently
+missing events, and the command exits cleanly when the daemon stops.
 
 ### Config hot-reload
 
@@ -725,7 +765,7 @@ cargo test -p servicrab-core config::tests
 - [x] `servicrab start` / `status` / `down` / `daemon`
 - [x] Status snapshot: state, pid, uptime, restarts, health
 - [x] Per-service `start` / `stop` / `restart` through the daemon
-- [ ] Live event streaming over the socket
+- [x] Live event streaming over the socket
 
 ### Phase 3 — Stack management ✅
 - [x] `.env` file support per project and per service
@@ -736,7 +776,7 @@ cargo test -p servicrab-core config::tests
 ### Phase 4 (current) — Platform integration
 - [x] systemd unit generation (`servicrab generate systemd`)
 - [x] launchd plist generation (`servicrab generate launchd`)
-- [ ] Live event streaming over the socket
+- [x] Live event streaming over the socket (`servicrab events`, `subscribe`)
 - [ ] `--json` event stream for `up`
 
 ---

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -16,7 +16,7 @@ const START_TIMEOUT: Duration = Duration::from_secs(15);
 const STOP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Load the config the daemon commands all need.
-fn setup(config: Option<&Path>) -> Result<(Config, PathBuf, DaemonPaths), String> {
+pub(crate) fn setup(config: Option<&Path>) -> Result<(Config, PathBuf, DaemonPaths), String> {
     let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
 
     let (cfg, warnings) = load(&path).map_err(|errors| {

--- a/crates/servicrab-cli/src/commands/events.rs
+++ b/crates/servicrab-cli/src/commands/events.rs
@@ -1,0 +1,325 @@
+//! `servicrab events [SERVICE...]` — follow a running daemon's event stream.
+//!
+//! This is `up`'s renderer without the supervision: the daemon owns the
+//! processes, and this command only attaches to the fan-out socket and prints
+//! what arrives until the user interrupts it.
+
+use std::path::Path;
+
+/// Command-line options for `events`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EventsOptions {
+    /// Print one JSON object per line instead of rendering for a terminal.
+    pub json: bool,
+    /// Do not prefix output lines with the service name.
+    pub no_prefix: bool,
+    /// Prefix output lines with a UTC timestamp.
+    pub timestamps: bool,
+    /// Leave captured stdout/stderr out of the stream.
+    pub no_logs: bool,
+}
+
+#[cfg(unix)]
+mod imp {
+    use super::*;
+
+    use std::collections::BTreeMap;
+    use std::io::Write;
+
+    use servicrab_protocol::{Event, Request, Response, Stream};
+
+    use crate::daemon::client;
+    use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
+
+    /// Attach to the daemon and render its events.
+    pub fn events(
+        services: &[String],
+        config: Option<&Path>,
+        options: EventsOptions,
+    ) -> Result<i32, String> {
+        let (cfg, _, paths) = crate::commands::daemon::setup(config)?;
+
+        for name in services {
+            if !cfg.services.keys().any(|known| known.as_str() == name) {
+                return Err(format!("unknown service: {name}"));
+            }
+        }
+
+        let request = Request::Subscribe {
+            services: services.to_vec(),
+            logs: !options.no_logs,
+        };
+
+        let mut printer = Printer::new(services, options);
+        if !options.json {
+            printer.banner(cfg.project.name.as_str(), services);
+        }
+
+        match client::subscribe(&paths.socket, &request, |raw, response| {
+            if options.json {
+                let mut out = std::io::stdout().lock();
+                let _ = writeln!(out, "{raw}");
+                let _ = out.flush();
+                return true;
+            }
+            printer.response(&response);
+            true
+        }) {
+            Ok(()) => Ok(0),
+            Err(client::ClientError::NotRunning) => Err(format!(
+                "no daemon is running for {} — start one with `servicrab start`",
+                cfg.project.name
+            )),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
+    /// Renders streamed events for a terminal.
+    struct Printer {
+        colors: BTreeMap<String, &'static str>,
+        width: usize,
+        color: bool,
+        options: EventsOptions,
+    }
+
+    impl Printer {
+        fn new(services: &[String], options: EventsOptions) -> Self {
+            let color = style::color_enabled();
+            let width = services.iter().map(String::len).max().unwrap_or(0);
+            let colors = services
+                .iter()
+                .enumerate()
+                .map(|(index, name)| (name.clone(), SERVICE_COLORS[index % SERVICE_COLORS.len()]))
+                .collect();
+            Self {
+                colors,
+                width,
+                color,
+                options,
+            }
+        }
+
+        fn banner(&self, project: &str, services: &[String]) {
+            let scope = if services.is_empty() {
+                "all services".to_string()
+            } else {
+                services.join(", ")
+            };
+            eprintln!(
+                "{} {project} → {scope}",
+                style::paint(self.color, BOLD, "servicrab events")
+            );
+        }
+
+        /// `api    | ` (or an empty string when prefixes are disabled).
+        ///
+        /// Colours are handed out as services first show up, so a stream that
+        /// was not filtered still gets stable, distinct prefixes.
+        fn prefix(&mut self, service: &str) -> String {
+            if self.options.no_prefix {
+                return String::new();
+            }
+            let next = SERVICE_COLORS[self.colors.len() % SERVICE_COLORS.len()];
+            let color = *self
+                .colors
+                .entry(service.to_string())
+                .or_insert_with(|| next);
+            self.width = self.width.max(service.len());
+            let label = format!("{:width$}", service, width = self.width);
+            format!("{} {} ", style::paint(self.color, color, &label), "|")
+        }
+
+        fn timestamp(&self) -> String {
+            if !self.options.timestamps {
+                return String::new();
+            }
+            let now = style::utc_hms(std::time::SystemTime::now());
+            format!("{} ", style::paint(self.color, DIM, &now))
+        }
+
+        fn response(&mut self, response: &Response) {
+            match response {
+                Response::Event { service, event } => self.event(service, event),
+                Response::Lagged { skipped } => {
+                    self.note(&format!("dropped {skipped} event(s): too slow to keep up"))
+                }
+                Response::Error { message } => self.note(message),
+                _ => {}
+            }
+        }
+
+        fn event(&mut self, service: &str, event: &Event) {
+            match event {
+                Event::Log { stream, line } => self.log(service, *stream, line),
+                Event::Started { pgid } => {
+                    self.status(service, "▶", &format!("started (pgid {pgid})"))
+                }
+                Event::Exited {
+                    reason, uptime_ms, ..
+                } => self.status(
+                    service,
+                    "■",
+                    &format!("{reason} after {}", humanize(*uptime_ms)),
+                ),
+                Event::Backoff { delay_ms, attempt } => self.status(
+                    service,
+                    "↻",
+                    &format!("restarting in {} (attempt {attempt})", humanize(*delay_ms)),
+                ),
+                Event::Stopping { reason } => {
+                    self.status(service, "◼", &format!("stopping: {reason}"))
+                }
+                Event::Skipped { dependency } => self.status(
+                    service,
+                    "⊘",
+                    &format!("skipped: dependency {dependency} never became available"),
+                ),
+                Event::Failed { message } => self.status(service, "✗", message),
+                Event::Healthy => self.status(service, "✔", "healthy"),
+                Event::HealthProbeFailed {
+                    message,
+                    consecutive,
+                    retries,
+                } => self.status(
+                    service,
+                    "!",
+                    &format!("health probe failed ({consecutive}/{retries}): {message}"),
+                ),
+                Event::Unhealthy { message } => {
+                    self.status(service, "✗", &format!("unhealthy: {message}"))
+                }
+                Event::WatchTriggered { path, changed } => {
+                    let name = Path::new(path)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| path.clone());
+                    let detail = if *changed == 1 {
+                        format!("{name} changed")
+                    } else {
+                        format!("{name} and {} more changed", changed - 1)
+                    };
+                    self.status(service, "↻", &format!("{detail}; restarting"))
+                }
+                Event::WatchFailed { message } => {
+                    self.status(service, "!", &format!("watch: {message}"))
+                }
+                Event::WatchTruncated { limit } => self.status(
+                    service,
+                    "!",
+                    &format!(
+                        "watch: more than {limit} files; narrow `paths` or add `ignore` entries"
+                    ),
+                ),
+                // Unlike `up`, a client that just attached has no idea what
+                // the services are doing, so state changes are worth showing.
+                Event::State { state } => self.status(service, "·", &state.to_string()),
+                Event::Finished { summary } => self.status(service, "□", summary),
+                _ => {}
+            }
+        }
+
+        fn log(&mut self, service: &str, stream: Stream, line: &str) {
+            let text = format!("{}{}{}", self.timestamp(), self.prefix(service), line);
+            match stream {
+                Stream::Stderr => {
+                    let mut err = std::io::stderr().lock();
+                    let _ = writeln!(err, "{text}");
+                    let _ = err.flush();
+                }
+                _ => {
+                    let mut out = std::io::stdout().lock();
+                    let _ = writeln!(out, "{text}");
+                    let _ = out.flush();
+                }
+            }
+        }
+
+        fn status(&mut self, service: &str, symbol: &str, message: &str) {
+            let text = format!(
+                "{}{}{}",
+                self.timestamp(),
+                self.prefix(service),
+                style::paint(self.color, DIM, &format!("{symbol} {message}"))
+            );
+            let mut err = std::io::stderr().lock();
+            let _ = writeln!(err, "{text}");
+            let _ = err.flush();
+        }
+
+        /// Report something about the stream itself, not about a service.
+        fn note(&self, message: &str) {
+            eprintln!("{}⚠  {message}{}", if self.color { DIM } else { "" }, {
+                if self.color {
+                    RESET
+                } else {
+                    ""
+                }
+            });
+        }
+    }
+
+    /// Render a millisecond duration the way a human would say it.
+    fn humanize(millis: u64) -> String {
+        let secs = millis / 1000;
+        if secs >= 60 {
+            return format!("{}m{}s", secs / 60, secs % 60);
+        }
+        if secs > 0 {
+            return format!("{secs}s");
+        }
+        format!("{millis}ms")
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn durations_read_naturally() {
+            assert_eq!(humanize(250), "250ms");
+            assert_eq!(humanize(1_500), "1s");
+            assert_eq!(humanize(90_000), "1m30s");
+        }
+
+        #[test]
+        fn prefixes_are_padded_and_stable() {
+            let mut printer = Printer::new(&[], EventsOptions::default());
+            let first = printer.prefix("api");
+            let second = printer.prefix("worker");
+            assert!(first.contains("api"));
+            assert!(second.contains("worker"));
+            // The second, longer name widens the column for later lines.
+            assert!(printer.prefix("api").contains("api   "));
+            // A name keeps the colour it was first given.
+            assert_eq!(printer.colors["api"], SERVICE_COLORS[0]);
+            assert_eq!(printer.colors["worker"], SERVICE_COLORS[1]);
+        }
+
+        #[test]
+        fn prefixes_can_be_disabled() {
+            let mut printer = Printer::new(
+                &[],
+                EventsOptions {
+                    no_prefix: true,
+                    ..EventsOptions::default()
+                },
+            );
+            assert_eq!(printer.prefix("api"), "");
+        }
+    }
+}
+
+#[cfg(not(unix))]
+mod imp {
+    use super::*;
+
+    pub fn events(
+        _services: &[String],
+        _config: Option<&Path>,
+        _options: EventsOptions,
+    ) -> Result<i32, String> {
+        Err("the background daemon is only supported on Linux and macOS".to_string())
+    }
+}
+
+pub use imp::events;

--- a/crates/servicrab-cli/src/commands/mod.rs
+++ b/crates/servicrab-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@
 pub mod check;
 pub mod completions;
 pub mod daemon;
+pub mod events;
 pub mod generate;
 pub mod init;
 pub mod list;

--- a/crates/servicrab-cli/src/daemon/client.rs
+++ b/crates/servicrab-cli/src/daemon/client.rs
@@ -34,13 +34,7 @@ impl std::fmt::Display for ClientError {
 
 /// Send one request and read the response.
 pub fn send(socket: &Path, request: &Request) -> Result<Response, ClientError> {
-    let mut stream = UnixStream::connect(socket).map_err(|err| match err.kind() {
-        // A socket file left behind by a crashed daemon refuses connections.
-        std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused => {
-            ClientError::NotRunning
-        }
-        _ => ClientError::Failed(format!("could not connect to {}: {err}", socket.display())),
-    })?;
+    let mut stream = connect(socket)?;
 
     let _ = stream.set_read_timeout(Some(TIMEOUT));
     let _ = stream.set_write_timeout(Some(TIMEOUT));
@@ -62,6 +56,72 @@ pub fn send(socket: &Path, request: &Request) -> Result<Response, ClientError> {
     }
 
     decode(&reply).map_err(|e| ClientError::Failed(e.to_string()))
+}
+
+/// Send a subscribe request and hand every streamed response to `on_event`.
+///
+/// The stream has no timeout: it lasts until the daemon exits, the callback
+/// returns `false`, or the user interrupts the command.
+pub fn subscribe<F>(socket: &Path, request: &Request, mut on_event: F) -> Result<(), ClientError>
+where
+    F: FnMut(&str, Response) -> bool,
+{
+    let mut stream = connect(socket)?;
+    let _ = stream.set_write_timeout(Some(TIMEOUT));
+
+    let line = encode(request).map_err(|e| ClientError::Failed(e.to_string()))?;
+    stream
+        .write_all(line.as_bytes())
+        .and_then(|()| stream.flush())
+        .map_err(|e| ClientError::Failed(format!("could not send the request: {e}")))?;
+
+    let mut reader = BufReader::new(&stream);
+    let mut first = String::new();
+    reader
+        .read_line(&mut first)
+        .map_err(|e| ClientError::Failed(format!("could not read the response: {e}")))?;
+    match decode::<Response>(&first) {
+        Ok(Response::Ok { .. }) => {}
+        Ok(Response::Error { message }) => return Err(ClientError::Failed(message)),
+        Ok(other) => {
+            return Err(ClientError::Failed(format!(
+                "unexpected response from the daemon: {other:?}"
+            )))
+        }
+        Err(err) => return Err(ClientError::Failed(err.to_string())),
+    }
+
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            // The daemon closed the socket, which is how a shutdown looks.
+            Ok(0) => return Ok(()),
+            Ok(_) => {}
+            Err(err) => {
+                return Err(ClientError::Failed(format!(
+                    "the event stream broke: {err}"
+                )))
+            }
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = decode::<Response>(&line).map_err(|e| ClientError::Failed(e.to_string()))?;
+        if !on_event(line.trim_end(), response) {
+            return Ok(());
+        }
+    }
+}
+
+/// Open the socket, mapping "nothing is listening" to [`ClientError::NotRunning`].
+fn connect(socket: &Path) -> Result<UnixStream, ClientError> {
+    UnixStream::connect(socket).map_err(|err| match err.kind() {
+        // A socket file left behind by a crashed daemon refuses connections.
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused => {
+            ClientError::NotRunning
+        }
+        _ => ClientError::Failed(format!("could not connect to {}: {err}", socket.display())),
+    })
 }
 
 /// Whether a daemon is listening and answering.

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -14,12 +14,16 @@ use servicrab_core::{
     event_channel, load, plan_stack, Config, EventKind, EventReceiver, EventSender, LogRouter,
     ServiceName, ServiceState, ShutdownReason, SignalWatcher, StatusRegistry,
 };
-use servicrab_protocol::{decode, encode, Request, Response};
+use servicrab_protocol::{decode, encode, Event, Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::task::JoinHandle;
 
 use super::paths::DaemonPaths;
+
+/// How many events a slow subscriber may fall behind before it is told that
+/// it missed some.  Log lines dominate the stream, so this is generous.
+const STREAM_BACKLOG: usize = 4096;
 
 /// How long the daemon waits for the log collector to drain on shutdown.
 const COLLECTOR_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
@@ -50,6 +54,8 @@ struct Session {
     /// daemon stops, which is what lets the collector task finish: it ends
     /// when the last event sender is gone.
     events: Mutex<Option<EventSender>>,
+    /// Fan-out of the runtime event stream to subscribed clients.
+    stream: tokio::sync::broadcast::Sender<servicrab_core::ServiceEvent>,
     /// File watchers, replaced wholesale on reload.
     watchers: Mutex<Vec<JoinHandle<()>>>,
     /// Serializes reloads: two clients must not diff against each other.
@@ -165,7 +171,13 @@ pub fn serve(
 
         let (events_tx, events_rx) = event_channel();
         let (control_tx, control_rx) = control_channel();
-        let collector = tokio::spawn(collect(events_rx, Arc::clone(&registry), logs));
+        let (stream_tx, _) = tokio::sync::broadcast::channel(STREAM_BACKLOG);
+        let collector = tokio::spawn(collect(
+            events_rx,
+            Arc::clone(&registry),
+            logs,
+            stream_tx.clone(),
+        ));
 
         let session = Arc::new(Session {
             registry: Arc::clone(&registry),
@@ -175,6 +187,7 @@ pub fn serve(
             project: project.clone(),
             config_path: config_path.to_path_buf(),
             events: Mutex::new(Some(events_tx.clone())),
+            stream: stream_tx,
             watchers: Mutex::new(Vec::new()),
             reloading: tokio::sync::Mutex::new(()),
         });
@@ -216,11 +229,13 @@ pub fn serve(
     Ok(0)
 }
 
-/// Keep the status registry current and copy output to the log files.
+/// Keep the status registry current, copy output to the log files, and hand
+/// every event to whoever is subscribed.
 async fn collect(
     mut events: EventReceiver,
     registry: Arc<Mutex<StatusRegistry>>,
     mut logs: Option<LogRouter>,
+    stream: tokio::sync::broadcast::Sender<servicrab_core::ServiceEvent>,
 ) {
     while let Some(event) = events.recv().await {
         if let (Some(router), EventKind::Log { line, .. }) = (logs.as_mut(), &event.kind) {
@@ -231,6 +246,8 @@ async fn collect(
         if let Ok(mut registry) = registry.lock() {
             registry.apply(&event);
         }
+        // Nobody subscribed is the normal case, and not an error.
+        let _ = stream.send(event);
     }
 }
 
@@ -257,20 +274,170 @@ async fn handle_client(stream: UnixStream, session: Arc<Session>) {
         if line.trim().is_empty() {
             continue;
         }
-        let response = match decode::<Request>(&line) {
-            Ok(request) => respond(request, &session).await,
-            Err(err) => Response::Error {
-                message: err.to_string(),
-            },
+        let request = match decode::<Request>(&line) {
+            Ok(request) => request,
+            Err(err) => {
+                if !write(
+                    &mut write_half,
+                    &Response::Error {
+                        message: err.to_string(),
+                    },
+                )
+                .await
+                {
+                    break;
+                }
+                continue;
+            }
         };
 
-        let Ok(payload) = encode(&response) else {
-            break;
-        };
-        if write_half.write_all(payload.as_bytes()).await.is_err() {
+        // Subscribing turns the connection one-way: the client stops asking
+        // and only reads until it goes away.
+        if let Request::Subscribe { services, logs } = request {
+            let filter = Filter::new(services, logs);
+            let receiver = session.stream.subscribe();
+            if write(&mut write_half, &Response::Ok { message: None }).await {
+                stream_events(receiver, filter, write_half).await;
+            }
+            return;
+        }
+
+        let response = respond(request, &session).await;
+
+        if !write(&mut write_half, &response).await {
             break;
         }
-        let _ = write_half.flush().await;
+    }
+}
+
+/// Write one response, reporting whether the client is still there.
+async fn write(sink: &mut tokio::net::unix::OwnedWriteHalf, response: &Response) -> bool {
+    let Ok(payload) = encode(response) else {
+        return false;
+    };
+    if sink.write_all(payload.as_bytes()).await.is_err() {
+        return false;
+    }
+    sink.flush().await.is_ok()
+}
+
+/// Which events a subscriber asked for.
+struct Filter {
+    services: Vec<String>,
+    logs: bool,
+}
+
+impl Filter {
+    fn new(services: Vec<String>, logs: bool) -> Self {
+        Self { services, logs }
+    }
+
+    fn wants(&self, event: &servicrab_core::ServiceEvent) -> bool {
+        if !self.logs && matches!(event.kind, EventKind::Log { .. }) {
+            return false;
+        }
+        self.services.is_empty()
+            || self
+                .services
+                .iter()
+                .any(|name| name == event.service.as_str())
+    }
+}
+
+/// Forward runtime events to one subscribed client until it disconnects.
+async fn stream_events(
+    mut events: tokio::sync::broadcast::Receiver<servicrab_core::ServiceEvent>,
+    filter: Filter,
+    mut sink: tokio::net::unix::OwnedWriteHalf,
+) {
+    loop {
+        let response = match events.recv().await {
+            Ok(event) => {
+                if !filter.wants(&event) {
+                    continue;
+                }
+                Response::Event {
+                    service: event.service.to_string(),
+                    event: to_wire_event(&event.kind),
+                }
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                Response::Lagged { skipped }
+            }
+            // The collector is gone, so the daemon is shutting down.
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+        };
+        if !write(&mut sink, &response).await {
+            return;
+        }
+    }
+}
+
+/// Translate a runtime event into its wire form.
+fn to_wire_event(kind: &EventKind) -> Event {
+    use servicrab_core::ExitReason;
+
+    match kind {
+        EventKind::State(state) => Event::State {
+            state: to_wire_state(*state),
+        },
+        EventKind::Started { pgid } => Event::Started { pgid: *pgid },
+        EventKind::Log { stream, line } => Event::Log {
+            stream: match stream {
+                servicrab_core::Stream::Stdout => servicrab_protocol::Stream::Stdout,
+                servicrab_core::Stream::Stderr => servicrab_protocol::Stream::Stderr,
+            },
+            line: line.clone(),
+        },
+        EventKind::Exited { reason, uptime } => Event::Exited {
+            reason: reason.to_string(),
+            code: match reason {
+                ExitReason::Code(code) => Some(*code),
+                _ => None,
+            },
+            signal: match reason {
+                ExitReason::Signal(signal) => Some(*signal),
+                _ => None,
+            },
+            uptime_ms: uptime.as_millis() as u64,
+        },
+        EventKind::Backoff { delay, attempt } => Event::Backoff {
+            delay_ms: delay.as_millis() as u64,
+            attempt: *attempt,
+        },
+        EventKind::Skipped { dependency } => Event::Skipped {
+            dependency: dependency.to_string(),
+        },
+        EventKind::Stopping { reason } => Event::Stopping {
+            reason: reason.to_string(),
+        },
+        EventKind::Finished { summary } => Event::Finished {
+            summary: summary.clone(),
+        },
+        EventKind::Healthy => Event::Healthy,
+        EventKind::HealthProbeFailed {
+            message,
+            consecutive,
+            retries,
+        } => Event::HealthProbeFailed {
+            message: message.clone(),
+            consecutive: *consecutive,
+            retries: *retries,
+        },
+        EventKind::Unhealthy { message } => Event::Unhealthy {
+            message: message.clone(),
+        },
+        EventKind::WatchTriggered { path, changed } => Event::WatchTriggered {
+            path: path.display().to_string(),
+            changed: *changed,
+        },
+        EventKind::WatchFailed { message } => Event::WatchFailed {
+            message: message.clone(),
+        },
+        EventKind::WatchTruncated { limit } => Event::WatchTruncated { limit: *limit },
+        EventKind::Failed { message } => Event::Failed {
+            message: message.clone(),
+        },
     }
 }
 
@@ -470,21 +637,25 @@ async fn command(
 }
 
 /// Convert a runtime status into its wire representation.
-fn to_wire(status: &servicrab_core::ServiceStatus) -> servicrab_protocol::ServiceInfo {
+fn to_wire_state(state: ServiceState) -> servicrab_protocol::ServiceState {
     use servicrab_protocol::ServiceState as Wire;
 
+    match state {
+        ServiceState::Pending => Wire::Pending,
+        ServiceState::Starting => Wire::Starting,
+        ServiceState::Running => Wire::Running,
+        ServiceState::Backoff => Wire::Backoff,
+        ServiceState::Stopping => Wire::Stopping,
+        ServiceState::Stopped => Wire::Stopped,
+        ServiceState::Exited => Wire::Exited,
+        ServiceState::Failed => Wire::Failed,
+    }
+}
+
+fn to_wire(status: &servicrab_core::ServiceStatus) -> servicrab_protocol::ServiceInfo {
     servicrab_protocol::ServiceInfo {
         name: status.name.to_string(),
-        state: match status.state {
-            ServiceState::Pending => Wire::Pending,
-            ServiceState::Starting => Wire::Starting,
-            ServiceState::Running => Wire::Running,
-            ServiceState::Backoff => Wire::Backoff,
-            ServiceState::Stopping => Wire::Stopping,
-            ServiceState::Stopped => Wire::Stopped,
-            ServiceState::Exited => Wire::Exited,
-            ServiceState::Failed => Wire::Failed,
-        },
+        state: to_wire_state(status.state),
         pid: status.pid,
         uptime_secs: status.uptime.map(|d| d.as_secs()),
         restarts: status.restarts,

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -230,6 +230,33 @@ enum Commands {
         config: Option<std::path::PathBuf>,
     },
 
+    /// Follow the running daemon's live event stream.  Linux and macOS only.
+    Events {
+        /// Only follow these services.  Defaults to all of them.
+        services: Vec<String>,
+
+        /// Path to the configuration file.  If omitted, discovers
+        /// servicrab.toml by walking up from the current directory.
+        #[arg(long, short = 'c')]
+        config: Option<std::path::PathBuf>,
+
+        /// Print one JSON object per line instead of rendering for a terminal.
+        #[arg(long)]
+        json: bool,
+
+        /// Do not prefix lines with the service name.
+        #[arg(long)]
+        no_prefix: bool,
+
+        /// Prefix lines with a UTC timestamp.
+        #[arg(long, short = 't')]
+        timestamps: bool,
+
+        /// Leave captured stdout/stderr out of the stream.
+        #[arg(long)]
+        no_logs: bool,
+    },
+
     /// Show what the background daemon is doing.  Linux and macOS only.
     Status {
         /// Path to the configuration file.  If omitted, discovers
@@ -379,6 +406,23 @@ fn main() {
             commands::daemon::restart(config.as_deref(), &services)
         }
         Commands::Reload { config } => commands::daemon::reload(config.as_deref()),
+        Commands::Events {
+            services,
+            config,
+            json,
+            no_prefix,
+            timestamps,
+            no_logs,
+        } => commands::events::events(
+            &services,
+            config.as_deref(),
+            commands::events::EventsOptions {
+                json,
+                no_prefix,
+                timestamps,
+                no_logs,
+            },
+        ),
         Commands::Status { config, json } => commands::daemon::status(config.as_deref(), json),
         Commands::Down { config } => commands::daemon::down(config.as_deref()),
         Commands::Daemon { config, no_restart } => {

--- a/crates/servicrab-cli/tests/events.rs
+++ b/crates/servicrab-cli/tests/events.rs
@@ -1,0 +1,319 @@
+//! Integration tests for `servicrab events` (live stream over the socket).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Upper bound for any wait in this file; keeps a hung test from stalling CI.
+const CEILING: Duration = Duration::from_secs(20);
+
+fn script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+/// A service that keeps printing a marker until it is told to stop.
+fn chatty(dir: &Path, name: &str, marker: &str) -> PathBuf {
+    script(
+        dir,
+        name,
+        &format!("trap 'exit 0' TERM INT\nwhile true; do echo {marker}; sleep 0.2; done"),
+    )
+}
+
+fn write_config(dir: &Path, toml: &str) -> PathBuf {
+    let path = dir.join("servicrab.toml");
+    fs::write(&path, toml).unwrap();
+    path
+}
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+fn cli(args: &[&str], config_path: &Path) -> (i32, String, String) {
+    let output = Command::new(binary())
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Stops the daemon when the test ends, however it ends.
+struct Daemon {
+    config: PathBuf,
+}
+
+impl Daemon {
+    fn start(config: &Path) -> Self {
+        let (code, stdout, stderr) = cli(&["start"], config);
+        assert_eq!(code, 0, "start failed: {stdout}{stderr}");
+        Self {
+            config: config.to_path_buf(),
+        }
+    }
+
+    fn status(&self) -> String {
+        let (_, stdout, _) = cli(&["status"], &self.config);
+        stdout
+    }
+
+    /// Poll `status` until `predicate` holds.
+    fn wait_for_status(&self, what: &str, predicate: impl Fn(&str) -> bool) {
+        let deadline = Instant::now() + CEILING;
+        loop {
+            let status = self.status();
+            if predicate(&status) {
+                return;
+            }
+            if Instant::now() >= deadline {
+                panic!("timed out waiting for {what}; last status:\n{status}");
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    fn down(&self) {
+        let _ = cli(&["down"], &self.config);
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = Command::new(binary())
+            .arg("down")
+            .arg("--config")
+            .arg(&self.config)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+/// A running `servicrab events` process whose output is collected in the
+/// background, so a test can wait for a line to show up.
+struct Subscriber {
+    child: Child,
+    lines: Arc<Mutex<Vec<String>>>,
+}
+
+impl Subscriber {
+    fn start(config: &Path, args: &[&str]) -> Self {
+        let mut child = Command::new(binary())
+            .arg("events")
+            .args(args)
+            .arg("--config")
+            .arg(config)
+            .env_remove("RUST_LOG")
+            .env("NO_COLOR", "1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to run servicrab events");
+
+        let stdout = child.stdout.take().expect("piped stdout");
+        let lines = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&lines);
+        std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                sink.lock().unwrap().push(line);
+            }
+        });
+
+        Self { child, lines }
+    }
+
+    fn collected(&self) -> Vec<String> {
+        self.lines.lock().unwrap().clone()
+    }
+
+    /// Wait until at least one collected line satisfies `predicate`.
+    fn wait_for(&self, what: &str, predicate: impl Fn(&str) -> bool) -> String {
+        let deadline = Instant::now() + CEILING;
+        loop {
+            if let Some(line) = self.collected().iter().find(|l| predicate(l)) {
+                return line.clone();
+            }
+            if Instant::now() >= deadline {
+                panic!(
+                    "timed out waiting for {what}; collected so far:\n{}",
+                    self.collected().join("\n")
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Wait for the process to exit on its own.
+    fn wait_for_exit(&mut self) -> i32 {
+        let deadline = Instant::now() + CEILING;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => return status.code().unwrap_or(-1),
+                Ok(None) => {}
+                Err(err) => panic!("could not wait for the subscriber: {err}"),
+            }
+            if Instant::now() >= deadline {
+                panic!("the event stream did not end when the daemon stopped");
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for Subscriber {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn two_service_config(api: &Path, worker: &Path) -> String {
+    format!(
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+[services.worker]
+command = ["{}"]
+restart = "always"
+"#,
+        api.display(),
+        worker.display()
+    )
+}
+
+/// Start a daemon with two chatty services and wait until both are running.
+fn running_stack(dir: &TempDir) -> (PathBuf, Daemon) {
+    let api = chatty(dir.path(), "api.sh", "api-line");
+    let worker = chatty(dir.path(), "worker.sh", "worker-line");
+    let cfg = write_config(dir.path(), &two_service_config(&api, &worker));
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        s.matches("running").count() == 2
+    });
+    (cfg, daemon)
+}
+
+#[test]
+fn a_subscriber_sees_captured_output() {
+    let dir = TempDir::new().unwrap();
+    let (cfg, _daemon) = running_stack(&dir);
+
+    let events = Subscriber::start(&cfg, &["--json"]);
+    let line = events.wait_for("an api log line", |l| {
+        l.contains("\"kind\":\"log\"") && l.contains("api-line")
+    });
+    assert!(line.contains("\"service\":\"api\""), "{line}");
+}
+
+#[test]
+fn a_subscriber_can_follow_one_service() {
+    let dir = TempDir::new().unwrap();
+    let (cfg, _daemon) = running_stack(&dir);
+
+    let events = Subscriber::start(&cfg, &["--json", "worker"]);
+    events.wait_for("a worker log line", |l| l.contains("worker-line"));
+    assert!(
+        events.collected().iter().all(|l| !l.contains("api-line")),
+        "the filter let another service through:\n{}",
+        events.collected().join("\n")
+    );
+}
+
+#[test]
+fn logs_can_be_left_out_of_the_stream() {
+    let dir = TempDir::new().unwrap();
+    let (cfg, _daemon) = running_stack(&dir);
+
+    let events = Subscriber::start(&cfg, &["--json", "--no-logs"]);
+    // Give the subscription time to attach before making something happen.
+    std::thread::sleep(Duration::from_millis(300));
+    let (code, stdout, stderr) = cli(&["restart", "worker"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+
+    events.wait_for("the worker to come back up", |l| {
+        l.contains("\"service\":\"worker\"") && l.contains("\"kind\":\"started\"")
+    });
+    assert!(
+        events.collected().iter().all(|l| !l.contains("\"log\"")),
+        "log lines leaked into a --no-logs stream:\n{}",
+        events.collected().join("\n")
+    );
+}
+
+#[test]
+fn the_human_stream_prefixes_lines_with_the_service() {
+    let dir = TempDir::new().unwrap();
+    let (cfg, _daemon) = running_stack(&dir);
+
+    let events = Subscriber::start(&cfg, &["api"]);
+    let line = events.wait_for("a prefixed api line", |l| l.contains("api-line"));
+    assert!(line.starts_with("api "), "{line:?}");
+    assert!(line.contains('|'), "{line:?}");
+}
+
+#[test]
+fn prefixes_can_be_turned_off() {
+    let dir = TempDir::new().unwrap();
+    let (cfg, _daemon) = running_stack(&dir);
+
+    let events = Subscriber::start(&cfg, &["api", "--no-prefix"]);
+    let line = events.wait_for("an unprefixed api line", |l| l.contains("api-line"));
+    assert_eq!(line, "api-line");
+}
+
+#[test]
+fn the_stream_ends_when_the_daemon_stops() {
+    let dir = TempDir::new().unwrap();
+    let (cfg, daemon) = running_stack(&dir);
+
+    let mut events = Subscriber::start(&cfg, &["--json"]);
+    events.wait_for("any event", |l| l.contains("\"type\":\"event\""));
+    daemon.down();
+
+    assert_eq!(events.wait_for_exit(), 0);
+}
+
+#[test]
+fn an_unknown_service_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let (cfg, _daemon) = running_stack(&dir);
+
+    let (code, _, stderr) = cli(&["events", "nope"], &cfg);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("unknown service"), "{stderr}");
+}
+
+#[test]
+fn events_without_a_daemon_says_so() {
+    let dir = TempDir::new().unwrap();
+    let api = chatty(dir.path(), "api.sh", "api-line");
+    let worker = chatty(dir.path(), "worker.sh", "worker-line");
+    let cfg = write_config(dir.path(), &two_service_config(&api, &worker));
+
+    let (code, _, stderr) = cli(&["events"], &cfg);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("no daemon is running"), "{stderr}");
+}

--- a/crates/servicrab-protocol/src/frame.rs
+++ b/crates/servicrab-protocol/src/frame.rs
@@ -58,6 +58,68 @@ mod tests {
     }
 
     #[test]
+    fn subscribe_defaults_to_every_service_and_logs() {
+        let request: Request = decode("{\"type\":\"subscribe\"}\n").unwrap();
+        assert_eq!(
+            request,
+            Request::Subscribe {
+                services: Vec::new(),
+                logs: true,
+            }
+        );
+    }
+
+    #[test]
+    fn a_subscribe_request_survives_a_round_trip() {
+        let request = Request::Subscribe {
+            services: vec!["api".to_string()],
+            logs: false,
+        };
+        let line = encode(&request).unwrap();
+        assert!(line.contains("\"services\":[\"api\"]"));
+        assert_eq!(decode::<Request>(&line).unwrap(), request);
+    }
+
+    #[test]
+    fn a_streamed_event_survives_a_round_trip() {
+        let response = Response::Event {
+            service: "api".to_string(),
+            event: crate::Event::Log {
+                stream: crate::Stream::Stderr,
+                line: "boom".to_string(),
+            },
+        };
+        let line = encode(&response).unwrap();
+        assert!(line.contains("\"kind\":\"log\""));
+        assert_eq!(decode::<Response>(&line).unwrap(), response);
+    }
+
+    #[test]
+    fn event_payloads_omit_absent_exit_details() {
+        let response = Response::Event {
+            service: "api".to_string(),
+            event: crate::Event::Exited {
+                reason: "exited with code 0".to_string(),
+                code: Some(0),
+                signal: None,
+                uptime_ms: 1234,
+            },
+        };
+        let line = encode(&response).unwrap();
+        assert!(line.contains("\"code\":0"));
+        assert!(!line.contains("signal"));
+        assert_eq!(decode::<Response>(&line).unwrap(), response);
+    }
+
+    #[test]
+    fn a_lag_notice_survives_a_round_trip() {
+        let response = Response::Lagged { skipped: 7 };
+        let line = encode(&response).unwrap();
+        assert!(line.contains("\"type\":\"lagged\""));
+        assert_eq!(decode::<Response>(&line).unwrap(), response);
+    }
+
+    #[test]
     fn garbage_is_reported_not_panicked_on() {
         assert!(decode::<Request>("not json").is_err());
         assert!(decode::<Request>("{\"type\":\"fly\"}").is_err());

--- a/crates/servicrab-protocol/src/lib.rs
+++ b/crates/servicrab-protocol/src/lib.rs
@@ -18,4 +18,4 @@ pub mod response;
 
 pub use frame::{decode, encode, FrameError};
 pub use request::Request;
-pub use response::{Health, Response, ServiceInfo, ServiceState};
+pub use response::{Event, Health, Response, ServiceInfo, ServiceState, Stream};

--- a/crates/servicrab-protocol/src/request.rs
+++ b/crates/servicrab-protocol/src/request.rs
@@ -36,4 +36,24 @@ pub enum Request {
 
     /// Re-read the configuration file and apply the difference.
     Reload,
+
+    /// Follow the daemon's event stream.
+    ///
+    /// The daemon answers `ok` and then keeps writing
+    /// [`crate::Response::Event`] lines until the client disconnects, so this
+    /// is the only request that turns a connection one-way.
+    Subscribe {
+        /// Only report these services; empty means all of them.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        services: Vec<String>,
+
+        /// Whether captured stdout/stderr lines are part of the stream.
+        #[serde(default = "yes")]
+        logs: bool,
+    },
+}
+
+/// Serde default for flags that are on unless a client says otherwise.
+fn yes() -> bool {
+    true
 }

--- a/crates/servicrab-protocol/src/response.rs
+++ b/crates/servicrab-protocol/src/response.rs
@@ -93,6 +93,127 @@ pub struct ServiceInfo {
     pub message: Option<String>,
 }
 
+/// Which standard stream a captured log line came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Stream {
+    /// The service's standard output.
+    Stdout,
+    /// The service's standard error.
+    Stderr,
+}
+
+impl std::fmt::Display for Stream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Stream::Stdout => f.write_str("stdout"),
+            Stream::Stderr => f.write_str("stderr"),
+        }
+    }
+}
+
+/// Something that happened to a service, as streamed by the daemon.
+///
+/// This mirrors the runtime's event enum, but the protocol crate stays
+/// independent of the runtime: durations are plain milliseconds and paths are
+/// strings, so any client can read them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Event {
+    /// The service moved to a new lifecycle state.
+    State {
+        /// The state it moved to.
+        state: ServiceState,
+    },
+    /// The service's process was spawned.
+    Started {
+        /// Process-group id (equal to the direct child's pid).
+        pgid: i32,
+    },
+    /// A line was read from the service's captured output.
+    Log {
+        /// Which stream the line came from.
+        stream: Stream,
+        /// The line, without its trailing newline.
+        line: String,
+    },
+    /// The service's process stopped.
+    Exited {
+        /// Human-readable description of why the process stopped.
+        reason: String,
+        /// Exit code, when the process exited on its own.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<i32>,
+        /// Signal number, when the process was killed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signal: Option<i32>,
+        /// How long it stayed alive.
+        uptime_ms: u64,
+    },
+    /// The service is waiting before being restarted.
+    Backoff {
+        /// How long the supervisor will wait.
+        delay_ms: u64,
+        /// 1-based restart attempt number.
+        attempt: u32,
+    },
+    /// The service was never started because a dependency never came up.
+    Skipped {
+        /// The dependency that blocked the start.
+        dependency: String,
+    },
+    /// The supervisor is shutting the service down.
+    Stopping {
+        /// Why the shutdown was requested.
+        reason: String,
+    },
+    /// The service stopped for good, and no restart will happen.
+    Finished {
+        /// A human-readable description of the final outcome.
+        summary: String,
+    },
+    /// The service passed its health check and is considered ready.
+    Healthy,
+    /// A health probe failed.
+    HealthProbeFailed {
+        /// Why the probe failed.
+        message: String,
+        /// How many consecutive failures have been seen so far.
+        consecutive: u32,
+        /// How many consecutive failures are tolerated.
+        retries: u32,
+    },
+    /// The service exhausted its health-check retry budget.
+    Unhealthy {
+        /// Why the last probe failed.
+        message: String,
+    },
+    /// A watched path changed and a restart was requested.
+    WatchTriggered {
+        /// The first changed path, in sort order.
+        path: String,
+        /// How many paths changed in this batch.
+        changed: usize,
+    },
+    /// A watch-triggered restart was refused by the supervisor.
+    WatchFailed {
+        /// Why the restart did not happen.
+        message: String,
+    },
+    /// The watched tree is larger than the scan limit.
+    WatchTruncated {
+        /// How many files the watcher is willing to scan.
+        limit: usize,
+    },
+    /// The service failed fatally.
+    Failed {
+        /// A human-readable description of the failure.
+        message: String,
+    },
+}
+
 /// A response returned by the servicrab daemon to a client.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -117,6 +238,20 @@ pub enum Response {
     Status {
         /// One entry per service, in start order.
         services: Vec<ServiceInfo>,
+    },
+
+    /// One streamed runtime event, sent after [`crate::Request::Subscribe`].
+    Event {
+        /// The service the event belongs to.
+        service: String,
+        /// What happened.
+        event: Event,
+    },
+
+    /// Events were dropped because the client could not keep up.
+    Lagged {
+        /// How many events were skipped.
+        skipped: u64,
     },
 
     /// The requested operation failed.


### PR DESCRIPTION
The daemon already kept a structured event stream internally (it feeds the status registry and the log files); this exposes it to clients.

## Protocol

`{"type":"subscribe"}` is the one request that turns a connection one-way: the daemon answers `ok` and then keeps writing event lines until the client goes away. Two optional fields: `services` (allow-list, empty = all) and `logs` (`false` leaves captured output out).

```
{"type":"ok"}
{"type":"event","service":"api","event":{"kind":"log","stream":"stdout","line":"listening on :8080"}}
{"type":"event","service":"api","event":{"kind":"state","state":"stopping"}}
```

The wire `Event` mirrors `EventKind` but keeps `servicrab-protocol` independent of the runtime: durations are milliseconds, paths are strings, exit reasons carry both a human string and the raw code/signal. A subscriber that cannot keep up gets `{"type":"lagged","skipped":N}` instead of silently missing events.

## Daemon

A `broadcast` fan-out published by the existing collector task, plus a per-client streaming loop that ends when the client disconnects or the collector shuts down. The sender lives in the collector task, so it does not keep the daemon alive at shutdown.

## CLI

`servicrab events [SERVICE...] [--json] [--no-logs] [--no-prefix] [--timestamps]`, rendered like `up`. Colours are handed out as services first show up, so an unfiltered stream still gets stable, distinct prefixes. Unlike `up`, state changes are shown — a client that just attached has no idea what the stack is doing.

## Tests

347 total (up from 331): 5 protocol round-trip tests, 3 renderer unit tests, and a new `tests/events.rs` with 8 integration tests (captured output arrives, filtering by service, `--no-logs`, prefixes on/off, the stream ends cleanly when the daemon stops, unknown service and no-daemon errors).

README: feature bullet, command table, socket-protocol table, a "Live event streaming" section, roadmap boxes ticked.