### PR TITLE
Release engineering: packaging metadata, changelog, tagged binary releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,18 @@ jobs:
 
       - name: Run tests
         run: cargo test --workspace --all-features
+
+  package:
+    name: package (crates.io dry run)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # Catches missing manifest metadata and files left out of the package
+      # long before a release tag depends on them.
+      - name: Package every crate
+        run: cargo package --workspace --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+name: Release
+
+# Tag a commit on main with `v<version>` (matching the workspace version) and
+# push the tag; this builds the binaries and publishes a GitHub release.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (must already exist)"
+        required: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --locked --target ${{ matrix.target }} --bin servicrab
+
+      - name: Package
+        id: package
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          name="servicrab-${version}-${{ matrix.target }}"
+          mkdir -p "dist/${name}"
+          cp "target/${{ matrix.target }}/release/servicrab" "dist/${name}/"
+          cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "dist/${name}/"
+          tar -czf "dist/${name}.tar.gz" -C dist "${name}"
+          shasum -a 256 "dist/${name}.tar.gz" | sed "s| dist/| |" > "dist/${name}.tar.gz.sha256"
+          echo "archive=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-test the binary
+        # Cross-built macOS x86_64 cannot run on an arm runner.
+        if: matrix.target != 'x86_64-apple-darwin'
+        run: ./target/${{ matrix.target }}/release/servicrab --version
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+          if-no-files-found: error
+
+  release:
+    name: Publish the GitHub release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          notes=$(awk -v tag="${TAG#v}" '
+            $0 ~ "^## \\[" tag "\\]" { printing = 1; next }
+            printing && /^## \[/ { exit }
+            printing { print }
+          ' CHANGELOG.md)
+          if [ -z "${notes//[[:space:]]/}" ]; then
+            notes="See CHANGELOG.md."
+          fi
+          gh release create "$TAG" dist/* \
+            --title "$TAG" \
+            --notes "$notes"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-07-30
+
+The first release. Supervision runs on Linux and macOS; on other platforms the
+config commands work and the runtime reports `UnsupportedPlatform`.
+
+### Configuration
+
+- `servicrab.toml` with a validated schema: project metadata, services,
+  dependencies, environments, health checks, log settings and watch rules.
+  Unknown keys are rejected rather than silently ignored.
+- `servicrab init` writes an annotated example config; `servicrab check`
+  validates one; `servicrab list` prints the services and their policies.
+- Per-project and per-service `env_file` layering on top of the process
+  environment.
+- Dependency declarations with a deterministic topological start order and
+  cycle detection.
+
+### Running services
+
+- `servicrab run <SERVICE>` supervises one service in the foreground.
+- `servicrab up [SERVICE...]` supervises a whole stack: dependency-ordered
+  start, interleaved and colour-prefixed output, reverse-order shutdown,
+  `--abort-on-failure`.
+- `servicrab watch` restarts services when their watched files change, with
+  ignore rules and debouncing.
+- Restart policies `never`, `on-failure` and `always`, with exponential
+  backoff, a restart ceiling, and a stability window.
+- Per-service process groups: shutdown signals the whole group and escalates
+  to `SIGKILL` after `shutdown_timeout`, so no orphans are left behind.
+- Health checks (`command`, `http`, `tcp`) with readiness gating for
+  dependents and automatic restart of unhealthy services.
+
+### Logs
+
+- Opt-in capture to `<dir>/<service>.log` with size-based rotation, and a
+  per-service opt-out.
+- `servicrab logs [SERVICE...] [-f] [-n N]` reads and follows them.
+
+### Background daemon
+
+- `servicrab start` / `status` / `stop` / `restart` / `down` / `daemon`,
+  one detached daemon per project.
+- A documented newline-delimited JSON protocol over a Unix socket, published
+  as the `servicrab-protocol` crate.
+- `servicrab reload` applies config changes to a running stack without
+  touching the services that did not change; an invalid config is refused and
+  leaves the stack running.
+- `servicrab events` follows the daemon's live event stream, as text or JSON,
+  optionally filtered by service.
+
+### Platform integration
+
+- `servicrab generate systemd|launchd` writes a unit that runs the stack, with
+  `systemctl reload` wired to `servicrab reload`.
+- `servicrab completions <SHELL>` for bash, zsh, fish, PowerShell and elvish.
+- `servicrab up --json` and `servicrab watch --json` emit the same event lines
+  the daemon streams, for scripts and wrappers.
+
+[Unreleased]: https://github.com/gaborini/servicrab/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/gaborini/servicrab/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,24 @@ Docs: update README roadmap
 
 ---
 
+## Releasing
+
+1. Update `version` in the workspace `Cargo.toml` and move the `Unreleased`
+   entries in `CHANGELOG.md` under the new version heading.
+2. Merge that to `main` and check CI is green.
+3. Tag it and push the tag:
+
+   ```sh
+   git tag -a v0.2.0 -m "v0.2.0"
+   git push origin v0.2.0
+   ```
+
+The `Release` workflow builds `x86_64` and `aarch64` binaries for Linux and
+macOS, attaches them (with `.sha256` files) to a GitHub release, and takes the
+release notes from the matching `CHANGELOG.md` section.
+
+---
+
 ## Reporting issues
 
 Please include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,17 @@ edition = "2021"
 authors = ["servicrab contributors"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/gaborini/servicrab"
+homepage = "https://github.com/gaborini/servicrab"
+keywords = ["process", "supervisor", "daemon", "cli", "devtools"]
+categories = ["command-line-utilities", "development-tools"]
 rust-version = "1.75"
+
+# Release builds ship to other machines: strip them, and let the optimiser see
+# the whole crate graph.  The extra build time only lands on `--release`.
+[profile.release]
+strip = "symbols"
+lto = "thin"
+codegen-units = 1
 
 [workspace.dependencies]
 # Async runtime
@@ -42,5 +52,5 @@ thiserror = "2"
 anyhow = "1"
 
 # Internal crates
-servicrab-core = { path = "crates/servicrab-core" }
-servicrab-protocol = { path = "crates/servicrab-protocol" }
+servicrab-core = { path = "crates/servicrab-core", version = "0.1.0" }
+servicrab-protocol = { path = "crates/servicrab-protocol", version = "0.1.0" }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 
 ## Installation
 
+### Prebuilt binaries
+
+Every release ships a tarball per platform (`x86_64` and `aarch64` for both
+Linux and macOS) on the
+[releases page](https://github.com/gaborini/servicrab/releases), each with a
+`.sha256` next to it:
+
+```sh
+tag=$(curl -fsSL https://api.github.com/repos/gaborini/servicrab/releases/latest | grep -m1 tag_name | cut -d\" -f4)
+target=$(uname -m)-$([ "$(uname -s)" = Darwin ] && echo apple-darwin || echo unknown-linux-gnu)
+curl -fsSL "https://github.com/gaborini/servicrab/releases/download/${tag}/servicrab-${tag#v}-${target}.tar.gz" | tar -xz
+sudo install "servicrab-${tag#v}-${target}/servicrab" /usr/local/bin/
+```
+
+### From crates.io
+
+```sh
+cargo install servicrab
+```
+
 ### From source
 
 ```sh
@@ -787,11 +807,16 @@ cargo test -p servicrab-core config::tests
 - [x] `servicrab watch` — restart on file changes, with ignore rules and debouncing
 - [x] Config hot-reload (`servicrab reload`)
 
-### Phase 4 (current) — Platform integration
+### Phase 4 — Platform integration ✅
 - [x] systemd unit generation (`servicrab generate systemd`)
 - [x] launchd plist generation (`servicrab generate launchd`)
 - [x] Live event streaming over the socket (`servicrab events`, `subscribe`)
 - [x] `--json` event stream for `up` and `watch`
+
+### Phase 5 (current) — Release engineering
+- [x] Publishable crate metadata and a `CHANGELOG.md`
+- [x] Tagged releases with prebuilt Linux and macOS binaries (x86_64 + aarch64)
+- [ ] Published to crates.io
 
 ---
 

--- a/crates/servicrab-cli/Cargo.toml
+++ b/crates/servicrab-cli/Cargo.toml
@@ -6,7 +6,11 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 rust-version.workspace = true
+readme = "README.md"
 
 [[bin]]
 name = "servicrab"

--- a/crates/servicrab-cli/README.md
+++ b/crates/servicrab-cli/README.md
@@ -1,0 +1,41 @@
+# servicrab
+
+A lightweight cross-platform process supervisor for local development stacks,
+homelabs, and small servers — one `servicrab.toml`, one binary, no daemon
+required.
+
+```toml
+version = 1
+
+[project]
+name = "myapp"
+
+[services.api]
+command = ["cargo", "run", "--bin", "api"]
+restart = "on-failure"
+
+[services.web]
+command = ["npm", "run", "dev"]
+depends_on = ["api"]
+```
+
+```console
+$ servicrab up
+servicrab up myapp → api, web
+api | listening on :8080
+web | ready on :3000
+```
+
+- Dependency-ordered start, reverse-order shutdown, per-service process groups
+- Restart policies (`never`, `on-failure`, `always`) with exponential backoff
+- Health checks (`command`, `http`, `tcp`) with readiness gating
+- Log files with rotation, plus `servicrab logs -f`
+- A background daemon with a documented JSON-over-Unix-socket API, live event
+  streaming, and config hot-reload
+- systemd unit and launchd plist generation
+
+Supervision runs on Linux and macOS. See the
+[project README](https://github.com/gaborini/servicrab#readme) for the full
+documentation.
+
+Dual-licensed under MIT OR Apache-2.0.

--- a/crates/servicrab-core/Cargo.toml
+++ b/crates/servicrab-core/Cargo.toml
@@ -6,7 +6,11 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 rust-version.workspace = true
+readme = "README.md"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/servicrab-core/README.md
+++ b/crates/servicrab-core/README.md
@@ -1,0 +1,18 @@
+# servicrab-core
+
+Configuration models, validation, and the service lifecycle runtime behind
+[servicrab](https://github.com/gaborini/servicrab) — a lightweight process
+supervisor for local development stacks, homelabs, and small servers.
+
+This crate parses and validates `servicrab.toml`, resolves the dependency
+graph, and supervises processes (process groups, restart policies with
+exponential backoff, health probes, log capture, file watching). It never
+formats output: it publishes structured events and lets the CLI render them.
+
+The process runtime is Linux and macOS only; on other platforms the runtime
+entry points return `UnsupportedPlatform`.
+
+Most people want the [`servicrab`](https://crates.io/crates/servicrab) CLI
+instead of this crate.
+
+Dual-licensed under MIT OR Apache-2.0.

--- a/crates/servicrab-protocol/Cargo.toml
+++ b/crates/servicrab-protocol/Cargo.toml
@@ -6,7 +6,11 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 rust-version.workspace = true
+readme = "README.md"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/servicrab-protocol/README.md
+++ b/crates/servicrab-protocol/README.md
@@ -1,0 +1,15 @@
+# servicrab-protocol
+
+The wire types spoken by the [servicrab](https://github.com/gaborini/servicrab)
+daemon: newline-delimited JSON over a Unix socket, one request per line, one
+response per line.
+
+```json
+{"type":"status"}
+{"type":"status","services":[{"name":"api","state":"running","pid":5512,"restarts":0,"health":"healthy"}]}
+```
+
+The crate depends on neither the runtime nor Tokio, so any client can link it
+to drive a daemon, follow its event stream, or generate bindings from it.
+
+Dual-licensed under MIT OR Apache-2.0.


### PR DESCRIPTION
Every item on the feature roadmap is now merged, so this turns the repo into something people can install.

**Manifests** — `homepage`, `keywords`, `categories` and a per-crate `README.md` for the crates.io pages, and versions on the internal path dependencies so the three crates can be published in dependency order. A new `package` job runs `cargo package --workspace --locked` on every PR, so a missing file or stale manifest fails on the PR that caused it instead of on a release tag.

**Release workflow** — pushing a `v*` tag builds `x86_64` and `aarch64` binaries for Linux and macOS (four targets, native runners for three of them), packages each with the README, changelog and both licences, writes a `.sha256` alongside, and opens a GitHub release whose notes are extracted from the matching `CHANGELOG.md` section. Also runnable via `workflow_dispatch` for an existing tag.

**Release profile** — `strip = "symbols"`, thin LTO, one codegen unit. Only `--release` pays for it.

**Docs** — `CHANGELOG.md` (Keep a Changelog, with the whole 0.1.0 feature set written up), install instructions for prebuilt binaries and `cargo install`, and a release checklist in `CONTRIBUTING.md`. Roadmap gains a Phase 5, with "published to crates.io" left unticked since that needs the owner's token.

Verified locally: `cargo package --workspace` succeeds for all three crates, the changelog-extraction `awk` produces the right notes for `v0.1.0`, both workflows parse, and the full suite is green (349 tests).