### PR TITLE
Fix the install snippet on macOS arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -33,7 +33,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Cargo registry + build artefacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             target: x86_64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -67,7 +67,7 @@ jobs:
         if: matrix.target != 'x86_64-apple-darwin'
         run: ./target/${{ matrix.target }}/release/servicrab --version
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}
           path: |
@@ -82,11 +82,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/README.md
+++ b/README.md
@@ -38,10 +38,14 @@ Linux and macOS) on the
 `.sha256` next to it:
 
 ```sh
-tag=$(curl -fsSL https://api.github.com/repos/gaborini/servicrab/releases/latest | grep -m1 tag_name | cut -d\" -f4)
-target=$(uname -m)-$([ "$(uname -s)" = Darwin ] && echo apple-darwin || echo unknown-linux-gnu)
-curl -fsSL "https://github.com/gaborini/servicrab/releases/download/${tag}/servicrab-${tag#v}-${target}.tar.gz" | tar -xz
-sudo install "servicrab-${tag#v}-${target}/servicrab" /usr/local/bin/
+tag=$(curl -fsSL https://api.github.com/repos/gaborini/servicrab/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
+arch=$(uname -m); [ "$arch" = arm64 ] && arch=aarch64
+os=unknown-linux-gnu; [ "$(uname -s)" = Darwin ] && os=apple-darwin
+dir="servicrab-${tag#v}-${arch}-${os}"
+
+curl -fsSL "https://github.com/gaborini/servicrab/releases/download/${tag}/${dir}.tar.gz" | tar -xz
+sudo install "${dir}/servicrab" /usr/local/bin/
+servicrab --version
 ```
 
 ### From crates.io


### PR DESCRIPTION
Cutting `v0.1.0` (the release workflow ran green, four platforms, eight assets) turned up one bug in the docs it shipped with: `uname -m` reports `arm64` on macOS while the Rust target triple says `aarch64`, so the documented install one-liner 404'd on exactly the machines most likely to run it.

The snippet now normalises the arch, builds the directory name once, and ends with `servicrab --version` so a user sees immediately whether it worked. Verified end-to-end against the published `v0.1.0` assets on macOS arm64, including the `.sha256`.

Also bumps the workflow actions off the Node 20 versions that now warn on every run (`checkout@v7`, `upload-artifact@v7`, `download-artifact@v8`, `cache@v6`).