### PR TITLE
docs: make the MSRV true and drop the stale phase TODOs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,33 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features
 
+  msrv:
+    name: msrv (minimum supported Rust version)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      # An MSRV nobody checks is a guess.  Read it from the manifest so the
+      # job cannot drift away from what the crates promise.
+      - name: Read rust-version from the workspace manifest
+        id: msrv
+        run: |
+          set -euo pipefail
+          version=$(grep -m1 '^rust-version' Cargo.toml | cut -d'"' -f2)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Workspace MSRV: ${version}"
+
+      - name: Install the MSRV toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      # --locked matters: the promise is about the versions we ship in
+      # Cargo.lock, not about whatever resolves today.
+      - name: Check the workspace on the MSRV
+        run: cargo check --workspace --all-features --all-targets --locked
+
   package:
     name: package (crates.io dry run)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The declared minimum supported Rust version is now **1.85**, up from the
+  previously documented 1.75. The old number was never true: the dependency
+  tree in `Cargo.lock` contains crates that require edition 2024, so a 1.75
+  toolchain failed before compiling a single line. Nothing in servicrab itself
+  changed — only the promise now matches reality.
+
+### Added
+
+- A CI job that checks the workspace on the declared MSRV with `--locked`, so
+  the minimum supported version is verified on every push instead of being an
+  unchecked claim in the manifest.
+
 ## [0.1.0] - 2026-07-30
 
 The first release. Supervision runs on Linux and macOS; on other platforms the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,32 @@ Be respectful and constructive. We follow the [Rust Code of Conduct](https://www
    ```sh
    git checkout -b feat/my-feature
    ```
-4. **Make changes**, then run the checks locally before pushing:
+4. **Make changes**, then run the checks locally before pushing. These are the
+   same commands CI runs, so a clean sweep here means a green pipeline:
    ```sh
    cargo fmt --all
-   cargo clippy --all-targets --all-features -- -D warnings
-   cargo test --all
+   cargo clippy --workspace --all-targets --all-features -- -D warnings
+   cargo test --workspace --all-features
    ```
 5. **Open a pull request** against the `main` branch.
+
+---
+
+## Minimum supported Rust version
+
+Servicrab builds on Rust **1.85** and newer. A CI job checks the workspace on
+exactly that toolchain with `--locked`, so an accidental use of a newer feature
+fails the pipeline rather than a user's build.
+
+Raising the MSRV is allowed when there is a reason for it, but it is a
+deliberate change: bump `rust-version` in the workspace `Cargo.toml` (the CI job
+reads the number from there), mention it in the changelog, and say why in the
+pull request. To reproduce the job locally:
+
+```sh
+rustup toolchain install 1.85
+cargo +1.85 check --workspace --all-features --all-targets --locked
+```
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,10 @@ repository = "https://github.com/gaborini/servicrab"
 homepage = "https://github.com/gaborini/servicrab"
 keywords = ["process", "supervisor", "daemon", "cli", "devtools"]
 categories = ["command-line-utilities", "development-tools"]
-rust-version = "1.75"
+# Minimum supported Rust version.  Verified by a dedicated CI job — do not
+# raise it without checking the dependency tree, and do not lower it without
+# proving the lockfile still builds.
+rust-version = "1.85"
 
 # Release builds ship to other machines: strip them, and let the optimiser see
 # the whole crate graph.  The extra build time only lands on `--release`.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ cargo install servicrab
 
 ### From source
 
+Building from source needs Rust **1.85** or newer (the minimum supported
+version, enforced by CI):
+
 ```sh
 git clone https://github.com/gaborini/servicrab
 cd servicrab
@@ -756,14 +759,21 @@ servicrab/
 cargo fmt --all
 
 # Lint (warnings are errors in CI)
-cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 # Test
-cargo test --all
+cargo test --workspace --all-features
 
 # Run a specific test
 cargo test -p servicrab-core config::tests
+
+# Check against the minimum supported Rust version
+rustup toolchain install 1.85
+cargo +1.85 check --workspace --all-features --all-targets --locked
 ```
+
+The commands above are exactly what CI runs, so a clean local sweep means a
+green pipeline.
 
 ---
 

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -13,14 +13,12 @@
 //!   (Linux/macOS)
 //!
 //! - `servicrab logs [SERVICE...]` — read the captured log files
+//! - `servicrab start` / `stop` / `restart` / `reload` / `status` / `down` /
+//!   `daemon` — background daemon control (Linux/macOS)
+//! - `servicrab events [SERVICE...]` — follow the daemon's event stream
+//!   (Linux/macOS)
+//! - `servicrab generate <systemd|launchd>` — write an init-system unit
 //! - `servicrab completions <SHELL>` — print a shell completion script
-//! - `servicrab start` / `status` / `stop` / `restart` / `down` — background
-//!   daemon control (Linux/macOS)
-//!
-//! ## Future phases (TODOs)
-//!
-//! - TODO(phase-2): Live event streaming over the daemon socket.
-//! - TODO(phase-3): Config hot-reload (`servicrab reload`).
 
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -4,8 +4,8 @@
 //! # Architecture
 //!
 //! This crate is intentionally dependency-light so that it can be shared by
-//! both the CLI and (in a future phase) the daemon without pulling in the full
-//! async runtime.  All I/O is delegated to callers.
+//! the CLI, its daemon, and any other client without pulling in the full async
+//! runtime.  All I/O is delegated to callers.
 //!
 //! ## Usage
 //!
@@ -13,13 +13,9 @@
 //! 2. Call [`load::load`] to read, parse, and validate the file.
 //! 3. Use the resulting [`config::Config`] as the runtime configuration.
 //!
-//! ## Future phases (TODOs)
+//! ## Not implemented yet
 //!
-//! - TODO(phase-2): Add `HealthCheck` configuration (HTTP probe, command
-//!   probe, interval, retries).
-//! - TODO(phase-2): Add a process-table abstraction for the background daemon.
-//! - TODO(phase-3): Support `include` directives to split large configs
-//!   across multiple files.
+//! - `include` directives, to split a large config across several files.
 
 pub mod config;
 pub mod envfile;

--- a/crates/servicrab-core/src/lifecycle.rs
+++ b/crates/servicrab-core/src/lifecycle.rs
@@ -4,12 +4,8 @@
 //! durations and process outcomes as inputs and returns decisions.  The actual
 //! process handling lives in [`crate::runtime`].
 //!
-//! ## Future phases (TODOs)
-//!
-//! - TODO(phase-2): Track PID and start timestamp inside the running state once
-//!   the daemon needs to report a process table.
-//! - TODO(phase-3): Add a `Degraded` state for services that pass their health
-//!   check but report warnings.
+//! Per-process bookkeeping the daemon reports (pid, uptime, restart count)
+//! lives in [`crate::runtime::status`], not in these types.
 
 use std::time::Duration;
 

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -8,14 +8,11 @@
 //! * `ForegroundRunner` wraps it with signal handling for `run`.
 //! * `stack::StackSupervisor` runs many services concurrently for `up`.
 //!
+//! A dependent waits for its dependency to be *running*, or to be *healthy*
+//! when that dependency declares a health check.
+//!
 //! Only Linux and macOS are supported.  On other platforms every entry point
 //! returns [`crate::error::RuntimeError::UnsupportedPlatform`].
-//!
-//! ## Future phases (TODOs)
-//!
-//! - TODO(phase-3): Replace "dependency is running" with "dependency is
-//!   healthy" once health probes exist.
-//! - TODO(phase-2): Persist captured output to log files for the daemon.
 
 use tokio::sync::watch;
 

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -194,7 +194,7 @@ pub fn validate_raw(
             .as_ref()
             .and_then(|raw_health| validate_health(raw_health, raw_name, &mut errors));
 
-        let log_to_file = raw_svc.logs.as_ref().map_or(true, |logs| logs.enabled);
+        let log_to_file = raw_svc.logs.as_ref().is_none_or(|logs| logs.enabled);
 
         let watch = raw_svc
             .watch


### PR DESCRIPTION
Two things in the tree were saying something untrue about the project, and both are the kind a new reader takes at face value.

## The MSRV was fiction

`Cargo.toml` promised `rust-version = "1.75"`. That was never testable, because CI only ever ran `stable`. It turns out it was also wrong:

```
$ cargo +1.75 check --workspace
error: failed to parse manifest at .../clap_lex-1.1.0/Cargo.toml
  feature `edition2024` is required
```

A 1.75 toolchain dies at manifest-parse time, before touching a single line of servicrab. Walking the locked dependency tree gives a floor of **1.85.0** — `clap`, `clap_complete`, `clap_lex`, `assert_cmd`, `indexmap`, `hashbrown` and `getrandom` all require it.

So this PR declares 1.85, verified empirically rather than derived from metadata:

```
$ cargo +1.85 check --workspace --all-features --all-targets --locked   # clean
$ cargo +1.85 test  --workspace --all-features --locked                 # 349 passed
```

Declaring the truth is the right fix here. Chasing 1.75 would mean pinning half the dependency tree to old versions indefinitely, and servicrab ships as a binary CLI — nobody embeds these crates into an old toolchain.

## An unchecked promise drifts back into fiction

CI gets a third job that runs the workspace on the declared MSRV with `--locked`, so the number is enforced rather than decorative. The job **reads `rust-version` out of the manifest** instead of hardcoding a copy, so the job and the promise cannot disagree:

```yaml
version=$(grep -m1 '^rust-version' Cargo.toml | cut -d'"' -f2)
```

`--locked` matters: the promise is about the versions we actually ship in `Cargo.lock`, not about whatever happens to resolve today.

## The `TODO(phase-N)` comments lied

Nine of them, advertising as missing seven features that have shipped: health checks, event streaming, config hot-reload, log files, the daemon, dependency readiness gating, restart bookkeeping. They are replaced by what is true — one honest "not implemented yet" note for `include` directives, and pointers to where the behaviour actually lives now. The CLI module doc also listed a subcommand set predating `reload`, `events`, `generate` and `daemon`.

## Two smaller things that fell out

- Clippy is MSRV-aware. At 1.75 it suppressed `unnecessary_map_or` because `Option::is_none_or` only stabilised in 1.82; at 1.85 it started firing. Applied the suggestion in `validation.rs` — same behaviour, and a nice independent confirmation that the bump is real.
- `README.md` and `CONTRIBUTING.md` told contributors to run `cargo test --all` while CI runs `cargo test --workspace --all-features`. Different command, different coverage. Both now match CI, so a clean local sweep means a green pipeline. `CONTRIBUTING.md` also gained a short MSRV section explaining how to reproduce the job and what raising the floor requires.

## Checks

`fmt`, `clippy -D warnings`, and the full 349-test suite pass on stable; `check` and the full suite also pass on 1.85 itself.

No functional change to servicrab.