### PR TITLE
Add `servicrab start --wait`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `servicrab start --wait` returns only once every service is ready — running,
+  and health-checked if it declares a health check — with `--timeout` to bound
+  the wait (60s by default). A one-shot service that has already exited counts
+  as ready, which is the same definition the supervisor uses to release a
+  dependent. The exit code says whether it worked, so a CI script can stop
+  guessing with `sleep`. The daemon is left running on failure, because a stack
+  that came up wrong is easier to diagnose alive.
 - `servicrab man` prints the man page in roff, or writes one page per command
   into a directory with `--output`. Release tarballs now ship the generated
   pages under `man/`. The pages come from the same command definitions as

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - `servicrab watch` — restart a service as soon as its sources change, with ignore rules and debouncing
 - Log files: opt-in per-service capture with size-based rotation, plus `servicrab logs [-f]` to read and follow them
 - Background daemon: `servicrab start` / `status` / `stop` / `restart` / `down`, with a documented JSON-over-Unix-socket protocol (Linux/macOS)
+- `servicrab start --wait` — block until every service is ready (health checks included), with an exit code that says whether it worked
 - `servicrab reload` — apply config changes to a running stack without stopping the services you did not touch
 - `servicrab events` — follow a running stack live: logs, state changes, restarts and health verdicts, as text or JSON
 - `servicrab generate systemd|launchd` — hand the stack over to the init system, with `systemctl reload` wired to `servicrab reload`
@@ -164,7 +165,7 @@ if you want shell semantics.
 | `servicrab up [SERVICE...] [--config PATH] [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure] [--json]` | Supervise a whole stack in the foreground |
 | `servicrab watch [SERVICE...] [--config PATH] [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure] [--json]` | Like `up`, and restart services when their watched files change |
 | `servicrab logs [SERVICE...] [--config PATH] [-f] [-n N] [--no-prefix]` | Show (and follow) the captured log files |
-| `servicrab start [--config PATH] [--no-restart]` | Start the stack in the background |
+| `servicrab start [SERVICE...] [--config PATH] [--no-restart] [--wait] [--timeout DUR]` | Start the stack in the background, optionally waiting until it is ready |
 | `servicrab status [--config PATH] [--json]` | Show what the background daemon is doing |
 | `servicrab stop <SERVICE...> [--config PATH]` | Stop individual services in the running daemon |
 | `servicrab restart <SERVICE...> [--config PATH]` | Restart individual services |
@@ -596,6 +597,41 @@ db       running      41231     4m30s         0  healthy
 api      running      41244     4m12s         1  -
 worker   backoff          -         -         3  -
   worker: stopped (exit code 1), last status: exit code 1
+```
+
+### Waiting for the stack to be ready
+
+`start` returns as soon as the daemon is up, which is not the same as the stack
+being usable. `--wait` returns when it actually is:
+
+```bash
+servicrab start --wait                 # ... 60s by default
+servicrab start --wait --timeout 2m    # give it longer
+servicrab start api --wait             # wait for one service inside a running daemon
+```
+
+A service counts as ready when it is running and — if it declares a health
+check — that check has passed. A one-shot service that has already exited counts
+as ready too: a migration that finished is not something to keep waiting for.
+This is the same definition the supervisor uses to decide when a dependent may
+start, so `--wait` returns exactly when the last dependent would have been
+released.
+
+The exit code is the point:
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Every service is ready |
+| `1` | A service gave up (failed, or stopped unhealthy), or the timeout ran out |
+
+Either way the daemon is left running — a stack that came up wrong is easier to
+diagnose alive, with `status`, `logs` and `events`. Which makes this a usable CI
+step:
+
+```bash
+servicrab start --wait --timeout 90s || { servicrab status; servicrab logs -n 100; exit 1; }
+./run-integration-tests
+servicrab down
 ```
 
 The daemon keeps its runtime state next to the config file, in

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -14,6 +14,25 @@ use crate::daemon::DaemonPaths;
 const START_TIMEOUT: Duration = Duration::from_secs(15);
 /// How long to wait for a stopping daemon to disappear.
 const STOP_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long `--wait` waits for readiness when `--timeout` is not given.
+///
+/// Generous on purpose: this has to cover a health check's `start_period` plus
+/// a probe interval or two, and a wait that gives up too early is worse than
+/// one that takes a moment.
+const WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+/// How often `--wait` asks the daemon for a status snapshot.
+const WAIT_POLL: Duration = Duration::from_millis(100);
+
+/// Options for `servicrab start`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StartOptions {
+    /// Never restart services, whatever their configured policy says.
+    pub no_restart: bool,
+    /// Return only once every started service is ready.
+    pub wait: bool,
+    /// How long to wait for that; [`WAIT_TIMEOUT`] when absent.
+    pub timeout: Option<Duration>,
+}
 
 /// Load the config the daemon commands all need.
 pub(crate) fn setup(config: Option<&Path>) -> Result<(Config, PathBuf, DaemonPaths), String> {
@@ -62,10 +81,15 @@ mod imp {
     pub fn start(
         config: Option<&Path>,
         services: &[String],
-        no_restart: bool,
+        options: StartOptions,
     ) -> Result<i32, String> {
         if !services.is_empty() {
-            return control(config, services, |name| Request::StartService { name });
+            let code = control(config, services, |name| Request::StartService { name })?;
+            if code != 0 || !options.wait {
+                return Ok(code);
+            }
+            let (_, _, paths) = setup(config)?;
+            return wait_for_ready(&paths.socket, services, options.timeout);
         }
 
         let (cfg, config_path, paths) = setup(config)?;
@@ -97,7 +121,7 @@ mod imp {
             .stdin(std::process::Stdio::null())
             .stdout(log)
             .stderr(errors);
-        if no_restart {
+        if options.no_restart {
             command.arg("--no-restart");
         }
         // A new session detaches the daemon from this terminal, so Ctrl+C here
@@ -143,7 +167,136 @@ mod imp {
                 )
             )
         );
+
+        if options.wait {
+            return wait_for_ready(&paths.socket, &[], options.timeout);
+        }
         Ok(0)
+    }
+
+    /// What a status snapshot says about one service's readiness.
+    ///
+    /// The same three answers the supervisor's own dependency gating uses, so
+    /// `--wait` returns exactly when a dependent would have been allowed to
+    /// start.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Readiness {
+        /// Up, and health-checked if it promised a health check.
+        Ready,
+        /// Not there yet, but still on its way.
+        Waiting,
+        /// It will not become ready without someone intervening.
+        Gone(String),
+    }
+
+    fn readiness(service: &ServiceInfo) -> Readiness {
+        use servicrab_protocol::{Health, ServiceState};
+
+        match service.state {
+            ServiceState::Running => match service.health {
+                Health::None | Health::Healthy => Readiness::Ready,
+                // An unhealthy service may still be restarted back into shape,
+                // so this is a wait rather than a verdict.  A verdict this
+                // client does not know about is one to wait out, not to read as
+                // readiness.
+                Health::Starting | Health::Unhealthy | _ => Readiness::Waiting,
+            },
+            // A one-shot service — a migration, a build step — has done its job.
+            // Unless it was stopped precisely because it was unhealthy.
+            ServiceState::Exited if service.health != Health::Unhealthy => Readiness::Ready,
+            ServiceState::Exited => Readiness::Gone("exited unhealthy".to_string()),
+            ServiceState::Failed => Readiness::Gone(
+                service
+                    .message
+                    .clone()
+                    .unwrap_or_else(|| "failed".to_string()),
+            ),
+            ServiceState::Stopped => Readiness::Gone("stopped".to_string()),
+            ServiceState::Pending
+            | ServiceState::Starting
+            | ServiceState::Backoff
+            | ServiceState::Stopping
+            // Same reasoning for a state added by a newer daemon: wait, and let
+            // the timeout be the one to give up.
+            | _ => Readiness::Waiting,
+        }
+    }
+
+    /// Poll the daemon until every service in `only` (or all of them) is ready.
+    ///
+    /// The daemon is left running either way: a stack that came up wrong is
+    /// easier to diagnose alive, with `status`, `logs` and `events`.
+    fn wait_for_ready(
+        socket: &Path,
+        only: &[String],
+        timeout: Option<Duration>,
+    ) -> Result<i32, String> {
+        let timeout = timeout.unwrap_or(WAIT_TIMEOUT);
+        let deadline = std::time::Instant::now() + timeout;
+        let color = style::color_enabled();
+
+        loop {
+            let services = match client::send(socket, &Request::Status) {
+                Ok(Response::Status { services }) => services,
+                Ok(Response::Error { message }) => return Err(message),
+                Ok(other) => return Err(format!("unexpected response from the daemon: {other:?}")),
+                Err(client::ClientError::NotRunning) => {
+                    return Err("the daemon stopped while waiting for the stack".to_string())
+                }
+                Err(err) => return Err(err.to_string()),
+            };
+
+            let watched: Vec<&ServiceInfo> = services
+                .iter()
+                .filter(|service| only.is_empty() || only.contains(&service.name))
+                .collect();
+
+            let mut waiting: Vec<&str> = Vec::new();
+            let mut gone: Vec<(&str, String)> = Vec::new();
+            for service in &watched {
+                match readiness(service) {
+                    Readiness::Ready => {}
+                    Readiness::Waiting => waiting.push(&service.name),
+                    Readiness::Gone(why) => gone.push((&service.name, why)),
+                }
+            }
+
+            if !gone.is_empty() {
+                for (name, why) in &gone {
+                    eprintln!("{} {name}: {why}", style::paint(color, RED, "✗"));
+                }
+                return Ok(1);
+            }
+
+            if waiting.is_empty() {
+                println!(
+                    "{} {} service(s) ready",
+                    style::paint(color, GREEN, "✓"),
+                    watched.len()
+                );
+                return Ok(0);
+            }
+
+            if std::time::Instant::now() >= deadline {
+                eprintln!(
+                    "{} timed out after {}: still waiting for {}",
+                    style::paint(color, RED, "✗"),
+                    humantime::format_duration(timeout),
+                    waiting.join(", ")
+                );
+                eprintln!(
+                    "{}",
+                    style::paint(
+                        color,
+                        DIM,
+                        "  the daemon is still running — see `servicrab status` and `servicrab logs`"
+                    )
+                );
+                return Ok(1);
+            }
+
+            std::thread::sleep(WAIT_POLL);
+        }
     }
 
     /// Stop individual services without touching the rest of the stack.
@@ -389,7 +542,7 @@ mod imp {
     pub fn start(
         _config: Option<&Path>,
         _services: &[String],
-        _no_restart: bool,
+        _options: StartOptions,
     ) -> Result<i32, String> {
         Err(UNSUPPORTED.to_string())
     }

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -13,8 +13,9 @@
 //!   (Linux/macOS)
 //!
 //! - `servicrab logs [SERVICE...]` — read the captured log files
-//! - `servicrab start` / `stop` / `restart` / `reload` / `status` / `down` /
-//!   `daemon` — background daemon control (Linux/macOS)
+//! - `servicrab start [--wait [--timeout DUR]]` / `stop` / `restart` /
+//!   `reload` / `status` / `down` / `daemon` — background daemon control
+//!   (Linux/macOS)
 //! - `servicrab events [SERVICE...]` — follow the daemon's event stream
 //!   (Linux/macOS)
 //! - `servicrab generate <systemd|launchd>` — write an init-system unit
@@ -28,6 +29,12 @@ mod commands;
 mod daemon;
 mod style;
 mod wire;
+
+/// Parse a `--timeout` value, using the same duration syntax as the config
+/// file (`30s`, `2m`, `1m30s`).
+fn parse_duration(text: &str) -> Result<std::time::Duration, String> {
+    humantime::parse_duration(text).map_err(|e| format!("invalid duration {text:?}: {e}"))
+}
 
 #[derive(Parser, Debug)]
 #[command(
@@ -203,6 +210,16 @@ enum Commands {
         /// Never restart services, whatever their configured policy says.
         #[arg(long, default_value_t = false)]
         no_restart: bool,
+
+        /// Return only once every started service is ready — running, and
+        /// health-checked if it declares a health check.  Exits non-zero if a
+        /// service fails or the timeout runs out.
+        #[arg(long, default_value_t = false)]
+        wait: bool,
+
+        /// How long --wait waits before giving up, e.g. `90s` or `2m`.
+        #[arg(long, requires = "wait", value_parser = parse_duration)]
+        timeout: Option<std::time::Duration>,
     },
 
     /// Stop individual services without stopping the daemon.
@@ -422,7 +439,17 @@ fn main() {
             services,
             config,
             no_restart,
-        } => commands::daemon::start(config.as_deref(), &services, no_restart),
+            wait,
+            timeout,
+        } => commands::daemon::start(
+            config.as_deref(),
+            &services,
+            commands::daemon::StartOptions {
+                no_restart,
+                wait,
+                timeout,
+            },
+        ),
         Commands::Stop { services, config } => commands::daemon::stop(config.as_deref(), &services),
         Commands::Restart { services, config } => {
             commands::daemon::restart(config.as_deref(), &services)

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -48,6 +48,21 @@ fn cli(args: &[&str], config_path: &Path) -> (i32, String, String) {
     )
 }
 
+/// Start a servicrab subcommand without waiting for it, for the tests that need
+/// to act while it is still running.
+fn spawn_cli(args: &[&str], config_path: &Path) -> Child {
+    Command::new(binary())
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to run servicrab")
+}
+
 /// A long-lived service that exits cleanly on SIGTERM.
 fn resident(dir: &Path, name: &str) -> PathBuf {
     script(
@@ -64,8 +79,22 @@ struct Daemon {
 
 impl Daemon {
     fn start(config: &Path) -> Self {
-        let (code, stdout, stderr) = cli(&["start"], config);
+        Self::start_with(config, &[])
+    }
+
+    fn start_with(config: &Path, args: &[&str]) -> Self {
+        let mut argv = vec!["start"];
+        argv.extend_from_slice(args);
+        let (code, stdout, stderr) = cli(&argv, config);
         assert_eq!(code, 0, "start failed: {stdout}{stderr}");
+        Self {
+            config: config.to_path_buf(),
+        }
+    }
+
+    /// Only the cleanup half: for tests that run `start` themselves because
+    /// they are about how it fails.
+    fn guard(config: &Path) -> Self {
         Self {
             config: config.to_path_buf(),
         }
@@ -176,6 +205,174 @@ restart = "always"
     let (code, stdout, _) = cli(&["status"], &cfg);
     assert_eq!(code, 1);
     assert!(stdout.contains("no daemon is running"), "{stdout}");
+}
+
+// ── start --wait ───────────────────────────────────────────────────────────
+
+/// A stack whose service can only pass its health check once the test says so.
+///
+/// The gate is a file this test creates, not a sleep: whether the service is
+/// ready is then a fact the test controls rather than a race it hopes to win on
+/// a loaded machine. Returns `(config path, gate path)`.
+fn gated_by_a_marker(dir: &Path) -> (PathBuf, PathBuf) {
+    let gate = dir.join("open-the-gate");
+    script(
+        dir,
+        "db.sh",
+        "trap 'exit 0' TERM INT\nwhile true; do sleep 0.1; done",
+    );
+    script(dir, "probe.sh", &format!("test -f {}", gate.display()));
+    let cfg = config(
+        dir,
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.db]
+command = ["{db}"]
+restart = "always"
+[services.db.health]
+command = ["{probe}"]
+interval = "100ms"
+start_period = "30s"
+"#,
+            db = dir.join("db.sh").display(),
+            probe = dir.join("probe.sh").display()
+        ),
+    );
+    (cfg, gate)
+}
+
+#[test]
+fn start_wait_returns_only_once_the_health_check_is_green() {
+    let dir = TempDir::new().unwrap();
+    let (cfg, gate) = gated_by_a_marker(dir.path());
+    let daemon = Daemon::guard(&cfg);
+
+    let mut start = spawn_cli(&["start", "--wait", "--timeout", "20s"], &cfg);
+
+    // The probe cannot pass while the gate is closed, so an exit here is the
+    // supervisor claiming a readiness it cannot have observed.
+    daemon.wait_for_status("db to be running", |status| status.contains("running"));
+    assert!(
+        start.try_wait().unwrap().is_none(),
+        "--wait returned before the health check could pass"
+    );
+
+    fs::write(&gate, "go").unwrap();
+    assert_eq!(wait_bounded(&mut start), 0);
+
+    let (code, stdout, _) = cli(&["status"], &cfg);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("healthy"), "not healthy:\n{stdout}");
+}
+
+/// The counterpart: plain `start` returns while the stack is still starting.
+/// This is the difference the flag exists for, and it keeps the test above from
+/// being a tautology.
+#[test]
+fn start_without_wait_returns_before_the_health_check_is_green() {
+    let dir = TempDir::new().unwrap();
+    let (cfg, _gate) = gated_by_a_marker(dir.path());
+
+    let _daemon = Daemon::start(&cfg);
+
+    let (_, stdout, _) = cli(&["status"], &cfg);
+    assert!(
+        !stdout.contains("healthy"),
+        "the gate is closed, so the probe cannot have passed:\n{stdout}"
+    );
+}
+
+#[test]
+fn start_wait_gives_up_when_a_service_never_becomes_healthy() {
+    let dir = TempDir::new().unwrap();
+    let svc = resident(dir.path(), "api.sh");
+    script(dir.path(), "probe.sh", "exit 1");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{api}"]
+restart = "never"
+[services.api.health]
+command = ["{probe}"]
+interval = "100ms"
+start_period = "10s"
+retries = 100
+"#,
+            api = svc.display(),
+            probe = dir.path().join("probe.sh").display()
+        ),
+    );
+
+    // The daemon outlives the failed wait on purpose, so `down` still has work.
+    let _daemon = Daemon::guard(&cfg);
+    let (code, stdout, stderr) = cli(&["start", "--wait", "--timeout", "1s"], &cfg);
+
+    assert_eq!(code, 1, "{stdout}{stderr}");
+    assert!(stderr.contains("timed out"), "{stderr}");
+    assert!(stderr.contains("api"), "{stderr}");
+
+    // A stack that came up wrong is easier to diagnose alive.
+    let (code, stdout, _) = cli(&["status"], &cfg);
+    assert_eq!(code, 0, "the daemon should still be running:\n{stdout}");
+}
+
+#[test]
+fn start_wait_reports_a_service_that_gave_up() {
+    let dir = TempDir::new().unwrap();
+    let svc = script(dir.path(), "api.sh", "exit 3");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "on-failure"
+max_restarts = 1
+restart_delay = "50ms"
+"#,
+            svc.display()
+        ),
+    );
+
+    let _daemon = Daemon::guard(&cfg);
+    let (code, stdout, stderr) = cli(&["start", "--wait", "--timeout", "10s"], &cfg);
+
+    assert_eq!(code, 1, "{stdout}{stderr}");
+    assert!(stderr.contains("api"), "{stderr}");
+}
+
+#[test]
+fn timeout_without_wait_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let svc = resident(dir.path(), "api.sh");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+"#,
+            svc.display()
+        ),
+    );
+
+    let (code, _, stderr) = cli(&["start", "--timeout", "5s"], &cfg);
+    assert_eq!(code, 2, "{stderr}");
+    assert!(stderr.contains("--wait"), "{stderr}");
 }
 
 /// Connecting to the socket is enough to start and stop every service in the


### PR DESCRIPTION
> **Stacked on #19.** Base is `chore/repo-infrastructure`, so this diff only shows
> the `--wait` work; GitHub will retarget it to `main` once #19 merges.

`start` returned as soon as the daemon was up, which is not the same as the stack
being usable — so any script or CI job that needed a working stack had to guess
with `sleep`. This is the most common ask in the backlog and the event stream was
already there to sit on.

## What it does

```bash
servicrab start --wait                 # 60s by default
servicrab start --wait --timeout 2m
servicrab start api --wait             # one service inside a running daemon
```

The exit code is the point: `0` when every service is ready, `1` when a service
gave up or the timeout ran out.

## What "ready" means

Running, and health-checked if the service declares a health check. A one-shot
service that has already exited counts as ready — a migration that finished is
not something to keep waiting for.

That is deliberately the *same* definition the supervisor's own dependency gating
uses (`ReadinessTracker` in `stack.rs`), so `--wait` returns exactly when the last
dependent would have been released. Two consequences worth stating:

- **Unhealthy is a wait, not a verdict.** A restart may bring the service back,
  so `--wait` keeps waiting and lets the timeout be the thing that gives up.
- **`Failed` and `Stopped` are verdicts** and end the wait immediately with the
  service's own message — there is no point waiting out 60s for a service that
  exhausted its restart budget.

Unknown future `ServiceState`/`Health` values (both protocol enums are
`#[non_exhaustive]`) are treated as "keep waiting", so an older client talking to
a newer daemon times out rather than reporting a readiness it cannot interpret.

## On failure the daemon stays up

A stack that came up wrong is easier to diagnose alive, which also makes it a
usable CI step:

```bash
servicrab start --wait --timeout 90s || { servicrab status; servicrab logs -n 100; exit 1; }
```

## Tests

Both behaviour tests are gated on a **marker file the test creates**, not on a
sleep, so whether the probe can pass is a fact the test controls rather than a
race that depends on machine load:

- `start_wait_returns_only_once_the_health_check_is_green` — asserts `--wait` is
  still blocked while the gate is closed (an early exit would be the supervisor
  claiming a readiness it could not have observed), then opens the gate and
  requires exit 0 and a `healthy` status.
- `start_without_wait_returns_before_the_health_check_is_green` — the counterpart,
  so the test above is not a tautology.
- `start_wait_gives_up_when_a_service_never_becomes_healthy` — exit 1, the
  message names the service, and the daemon is still answering afterwards.
- `start_wait_reports_a_service_that_gave_up` — a service that exhausts its
  restart budget ends the wait early.
- `timeout_without_wait_is_rejected` — `--timeout` requires `--wait` (clap exit 2).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked` — 357 pass (352 before)
- [x] `daemon` suite stressed 8x, no failures
- [x] README (`Waiting for the stack to be ready`, command reference) and CHANGELOG updated
- [x] The man page and shell completions pick the flag up automatically