### PR TITLE
Add conditions to `depends_on`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Docker-Compose-style conditions on `depends_on`, spelled with the table form:
+
+  ```toml
+  [services.api.depends_on]
+  db = { condition = "service_healthy" }
+  migrate = { condition = "service_completed_successfully" }
+  ```
+
+  `service_completed_successfully` is the one that was missing: it is the only
+  condition that looks at the exit status, so a dependent is no longer started
+  against a half-migrated database when the migration exits non-zero. The other
+  two conditions keep treating a one-shot that has exited as available whatever
+  its status, because a condition a finished process can never meet again would
+  deadlock the stack.
+
+  The list form and its behaviour are unchanged, and leaving the condition out
+  is deliberately *not* the same as `service_started`: it still means "healthy
+  if the dependency declares a health check, up otherwise", so adding a health
+  check keeps gating everything that depends on that service. Spelling out
+  `service_started` is now the way to opt out of that for one edge.
+
+  Conditions that can never be met are rejected at load time: `service_healthy`
+  on a service with no `[health]` block, and `service_completed_successfully` on
+  a service with `restart = "always"`, which never stays exited.
 - `servicrab start --wait` returns only once every service is ready — running,
   and health-checked if it declares a health check — with `--timeout` to bound
   the wait (60s by default). A one-shot service that has already exited counts
@@ -39,6 +63,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `servicrab list --json` reports each dependency as an object rather than a
+  bare name, so the condition being waited for is machine-readable:
+  `"depends_on": [{"service": "db", "condition": "service_healthy"}]`. The
+  condition is the effective one, resolved for entries that omit it. The human
+  output names it too.
 - The daemon socket is now created with mode `0600`. It was left to the process
   umask, which is `022` on most systems but `002` on distributions that give
   each user a private group — and connecting to the socket is enough to start

--- a/README.md
+++ b/README.md
@@ -324,13 +324,19 @@ set, or when `TERM=dumb`.
 ### Start and stop ordering
 
 Services start in the configuration's deterministic topological order, and a
-service is only spawned once every service it depends on is **available**:
+service is only spawned once every service it depends on is **available**. What
+"available" means is per dependency, and by default depends on the dependency
+itself:
 
-- a service without a health check is available as soon as its process is up;
-- a service **with** a health check is available only after its first
+- a dependency without a health check is available as soon as its process is up;
+- a dependency **with** a health check is available only after its first
   successful probe;
-- a one-shot dependency (a migration, a build step) that exited cleanly counts
-  as available too.
+- a one-shot dependency (a migration, a build step) that has exited counts as
+  available too — otherwise a stack containing one could never come up.
+
+Spell the condition out to override that (see
+[Dependency conditions](#dependency-conditions)), which is also the only way to
+have the exit status of a one-shot checked.
 
 Shutdown happens in reverse: dependents are stopped (and fully reaped) before
 the services they depend on, each with its own `shutdown_signal` and
@@ -403,6 +409,53 @@ command = ["./scripts/queue-ok.sh"]      # healthy when it exits with code 0
 
 Failures during `start_period` never count, which gives slow starters time to
 come up without burning their retry budget.
+
+---
+
+## Dependency conditions
+
+`depends_on = ["db"]` says *what* to wait for but not *when* the wait is over.
+The table form says both:
+
+```toml
+[services.api]
+command = ["./api"]
+
+[services.api.depends_on]
+db = { condition = "service_healthy" }
+migrate = { condition = "service_completed_successfully" }
+cache = { condition = "service_started" }
+```
+
+| Condition | Available once |
+|---|---|
+| `service_started` | the process is up; the exit status is never consulted |
+| `service_healthy` | a health probe has passed |
+| `service_completed_successfully` | the service has exited with status `0` |
+
+Both forms may be mixed across services, but not within one service: a service
+either lists names or uses the table.
+
+**Leaving the condition out is not the same as `service_started`.** An entry
+without a condition waits for a probe when the dependency has a `[health]`
+block, and for the process otherwise — so adding a health check to a service
+automatically starts gating everything that depends on it.
+
+`service_completed_successfully` is the one that exists for **migrations and
+seed steps**: it is the only condition that looks at the exit status, so it is
+the only one that stops a dependent from starting against a half-migrated
+database. Under the other two conditions a one-shot that has exited counts as
+available whatever its exit status, because a condition a finished process can
+never meet again would deadlock the stack.
+
+Conditions that can never be met are rejected at load time rather than at
+2 a.m.: `service_healthy` on a service with no `[health]` block, and
+`service_completed_successfully` on a service with `restart = "always"`, which
+never stays exited.
+
+A dependency that can no longer meet its condition — including a one-shot that
+exited non-zero where success was required — leaves its dependents **skipped**,
+exactly as an unavailable dependency does.
 
 ---
 
@@ -613,9 +666,12 @@ servicrab start api --wait             # wait for one service inside a running d
 A service counts as ready when it is running and — if it declares a health
 check — that check has passed. A one-shot service that has already exited counts
 as ready too: a migration that finished is not something to keep waiting for.
-This is the same definition the supervisor uses to decide when a dependent may
-start, so `--wait` returns exactly when the last dependent would have been
-released.
+That is the default a dependent waits for as well, so with the default
+conditions `--wait` returns exactly when the last dependent would have been
+released. A `depends_on` entry that spells out
+[a condition](#dependency-conditions) is not reflected here: `--wait` asks
+whether each service is ready, not whether it satisfies a particular dependent,
+so it does not check the exit status of a one-shot.
 
 The exit code is the point:
 

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -176,9 +176,12 @@ mod imp {
 
     /// What a status snapshot says about one service's readiness.
     ///
-    /// The same three answers the supervisor's own dependency gating uses, so
-    /// `--wait` returns exactly when a dependent would have been allowed to
-    /// start.
+    /// The same three answers the supervisor's own dependency gating uses under
+    /// its *default* condition, so `--wait` returns when a dependent that did
+    /// not spell out a condition would have been allowed to start.  A spelled
+    /// out `service_completed_successfully` is not reflected: this asks whether
+    /// a service is ready, not whether it satisfies a particular dependent, and
+    /// a status snapshot carries no exit status to check.
     #[derive(Debug, PartialEq, Eq)]
     enum Readiness {
         /// Up, and health-checked if it promised a health check.

--- a/crates/servicrab-cli/src/commands/init.rs
+++ b/crates/servicrab-cli/src/commands/init.rs
@@ -47,7 +47,10 @@ name = "my-project"
 #   cwd           Working directory (default: config file's directory)
 #   env           Per-service environment variables
 #   env_file      Dotenv file(s) loaded before `env`, e.g. ".env" or a list
-#   depends_on    Services that must start before this one, e.g. ["db"]
+#   depends_on    Services that must be ready before this one, e.g. ["db"], or
+#                 with a condition: { db = { condition = "service_healthy" } }
+#                 Conditions: service_started | service_healthy |
+#                 service_completed_successfully (the last one is for migrations)
 #   autostart     Whether to start automatically (default: true)
 #   restart       never | on-failure | always  (default: never)
 #   restart_delay         Minimum backoff before first restart (default: 1s)
@@ -79,7 +82,8 @@ name = "my-project"
 #   on_unhealthy  restart | ignore (default: restart)
 #
 # Services that depend on a health-checked service wait for its first
-# successful probe instead of just for its process to be up.
+# successful probe instead of just for its process to be up, unless their
+# depends_on entry says otherwise.
 
 [services.api]
 command = ["echo", "Replace me with your API server command"]

--- a/crates/servicrab-cli/src/commands/list.rs
+++ b/crates/servicrab-cli/src/commands/list.rs
@@ -35,11 +35,22 @@ struct ServiceJson<'a> {
     name: &'a str,
     command: Vec<&'a str>,
     cwd: String,
-    depends_on: Vec<&'a str>,
+    depends_on: Vec<DependencyJson<'a>>,
     autostart: bool,
     restart: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     health: Option<String>,
+}
+
+/// One dependency, with the condition resolved.
+///
+/// Resolved rather than as written, because a consumer of `--json` wants to
+/// know what will be waited for without having to reimplement the rule for an
+/// omitted condition.
+#[derive(Serialize)]
+struct DependencyJson<'a> {
+    service: &'a str,
+    condition: String,
 }
 
 fn print_json(services: &std::collections::BTreeMap<ServiceName, Service>) {
@@ -52,7 +63,7 @@ fn print_json(services: &std::collections::BTreeMap<ServiceName, Service>) {
                 name: svc.name.as_str(),
                 command: cmd,
                 cwd: svc.cwd.display().to_string(),
-                depends_on: svc.depends_on.iter().map(|n| n.as_str()).collect(),
+                depends_on: dependencies(svc, services),
                 autostart: svc.autostart,
                 restart: match svc.restart {
                     servicrab_core::RestartPolicy::Never => "never",
@@ -68,6 +79,26 @@ fn print_json(services: &std::collections::BTreeMap<ServiceName, Service>) {
         "{}",
         serde_json::to_string_pretty(&list).expect("JSON serialization")
     );
+}
+
+/// The dependencies of one service, each with its effective condition.
+fn dependencies<'a>(
+    service: &'a Service,
+    services: &'a std::collections::BTreeMap<ServiceName, Service>,
+) -> Vec<DependencyJson<'a>> {
+    service
+        .depends_on
+        .iter()
+        .map(|dep| DependencyJson {
+            service: dep.service.as_str(),
+            condition: match services.get(&dep.service) {
+                Some(target) => dep.condition_for(target).to_string(),
+                // Unreachable for a loaded config: validation rejects a
+                // dependency on a service that does not exist.
+                None => "unknown".to_string(),
+            },
+        })
+        .collect()
 }
 
 // ── Human-readable table ───────────────────────────────────────────────────
@@ -101,7 +132,10 @@ fn print_table(services: &std::collections::BTreeMap<ServiceName, Service>, proj
             cmd_preview
         );
         if !svc.depends_on.is_empty() {
-            let deps: Vec<&str> = svc.depends_on.iter().map(|n| n.as_str()).collect();
+            let deps: Vec<String> = dependencies(svc, services)
+                .into_iter()
+                .map(|dep| format!("{} ({})", dep.service, dep.condition))
+                .collect();
             println!("  depends on: {}", deps.join(", "));
         }
         if let Some(health) = &svc.health {

--- a/crates/servicrab-cli/tests/cli.rs
+++ b/crates/servicrab-cli/tests/cli.rs
@@ -199,6 +199,56 @@ fn list_json_output() {
 }
 
 #[test]
+fn list_reports_the_effective_dependency_condition() {
+    let toml = r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["echo", "api"]
+depends_on = ["db", "migrate"]
+[services.migrate]
+command = ["echo", "migrate"]
+[services.db]
+command = ["echo", "db"]
+[services.db.health]
+tcp = "127.0.0.1:1"
+"#;
+    let (_dir, path) = temp_dir_with_config(toml);
+
+    let output = cmd()
+        .arg("list")
+        .arg("--config")
+        .arg(&path)
+        .arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8(output).unwrap()).expect("valid JSON");
+    let api = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|svc| svc["name"] == "api")
+        .expect("api in the listing");
+
+    // Neither entry spells a condition out, so both are resolved from the
+    // dependency: the health-checked one gates on a probe, the other does not.
+    assert_eq!(
+        api["depends_on"],
+        serde_json::json!([
+            { "service": "db", "condition": "service_healthy" },
+            { "service": "migrate", "condition": "service_started" },
+        ]),
+        "{json:#}"
+    );
+}
+
+#[test]
 fn list_failure_on_invalid_config() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("servicrab.toml");

--- a/crates/servicrab-cli/tests/health.rs
+++ b/crates/servicrab-cli/tests/health.rs
@@ -183,6 +183,58 @@ retries = 2
     );
 }
 
+/// The other half of the test above: `service_started` is the way to opt out of
+/// health gating for one edge — a log shipper needs the database process to
+/// exist, not to be serving queries — so the same never-healthy dependency does
+/// not hold this dependent back.
+#[test]
+fn service_started_ignores_the_dependencys_health_check() {
+    let dir = TempDir::new().unwrap();
+    let started = dir.path().join("api.started");
+
+    script(dir.path(), "db.sh", "sleep 30");
+    script(dir.path(), "probe.sh", "exit 1");
+    script(
+        dir.path(),
+        "api.sh",
+        &format!("echo started > {}", started.display()),
+    );
+
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{api}"]
+depends_on = {{ db = {{ condition = "service_started" }} }}
+
+[services.db]
+command = ["{db}"]
+restart = "never"
+
+[services.db.health]
+command = ["{probe}"]
+interval = "100ms"
+retries = 2
+"#,
+            api = dir.path().join("api.sh").display(),
+            db = dir.path().join("db.sh").display(),
+            probe = dir.path().join("probe.sh").display(),
+        ),
+    );
+
+    let (_code, _stdout, stderr) = up(&cfg, &[]);
+    assert!(
+        started.exists(),
+        "the dependent should not wait for a health check it opted out of: {stderr}"
+    );
+}
+
 #[test]
 fn an_unhealthy_service_is_restarted() {
     let dir = TempDir::new().unwrap();

--- a/crates/servicrab-cli/tests/up.rs
+++ b/crates/servicrab-cli/tests/up.rs
@@ -416,6 +416,126 @@ depends_on = ["db"]
     );
 }
 
+/// The condition a migration or seed step needs: the dependent starts only
+/// after the one-shot has exited, and only if it exited cleanly.
+#[test]
+fn service_completed_successfully_waits_for_the_one_shot_to_exit() {
+    let dir = TempDir::new().unwrap();
+    // The migration stays alive for a moment, so a supervisor that waited only
+    // for the process to *start* would run api while this is still going.
+    script(dir.path(), "migrate.sh", "sleep 0.5");
+    script(dir.path(), "api.sh", "true");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{}"]
+depends_on = {{ migrate = {{ condition = "service_completed_successfully" }} }}
+
+[services.migrate]
+command = ["{}"]
+"#,
+            dir.path().join("api.sh").display(),
+            dir.path().join("migrate.sh").display()
+        ),
+    );
+
+    let (code, stdout, stderr) = up(&cfg, &["--json"]);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+
+    // As in the start-order test above, the verdict comes from the supervisor's
+    // own event stream: the migration's exit must precede api's start.
+    let order: Vec<String> = stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter_map(|event| {
+            let service = event["service"].as_str()?;
+            let kind = event["event"]["kind"].as_str()?;
+            Some(format!("{service}/{kind}"))
+        })
+        .filter(|event| event == "migrate/exited" || event == "api/started")
+        .collect();
+    assert_eq!(order, vec!["migrate/exited", "api/started"], "{stdout}");
+}
+
+#[test]
+fn service_completed_successfully_skips_the_dependent_when_the_one_shot_fails() {
+    let dir = TempDir::new().unwrap();
+    script(dir.path(), "migrate.sh", "exit 1");
+    script(dir.path(), "api.sh", "echo api-started");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{}"]
+depends_on = {{ migrate = {{ condition = "service_completed_successfully" }} }}
+
+[services.migrate]
+command = ["{}"]
+"#,
+            dir.path().join("api.sh").display(),
+            dir.path().join("migrate.sh").display()
+        ),
+    );
+
+    let (code, stdout, stderr) = up(&cfg, &[]);
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(!stdout.contains("api-started"), "stdout: {stdout}");
+    assert!(
+        stderr.contains("never became available"),
+        "stderr: {stderr}"
+    );
+}
+
+/// The counterpart of the test above, and the reason the condition exists: the
+/// short `depends_on` form waits for the dependency to have *started* and never
+/// looks at how it ended, so the same failing migration lets api run.
+#[test]
+fn the_short_dependency_form_does_not_look_at_the_exit_status() {
+    let dir = TempDir::new().unwrap();
+    script(dir.path(), "migrate.sh", "exit 1");
+    script(dir.path(), "api.sh", "echo api-started");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{}"]
+depends_on = ["migrate"]
+
+[services.migrate]
+command = ["{}"]
+"#,
+            dir.path().join("api.sh").display(),
+            dir.path().join("migrate.sh").display()
+        ),
+    );
+
+    let (code, stdout, stderr) = up(&cfg, &[]);
+    assert!(stdout.contains("api-started"), "stdout: {stdout}");
+    // And the run as a whole passes: a service that exits on its own is not a
+    // stack failure, which is precisely why the exit status of a migration goes
+    // unnoticed unless something waits for it.
+    assert_eq!(code, 0, "{stdout}{stderr}");
+}
+
 #[test]
 fn ctrl_c_stops_the_whole_stack() {
     let dir = TempDir::new().unwrap();

--- a/crates/servicrab-core/src/config.rs
+++ b/crates/servicrab-core/src/config.rs
@@ -106,6 +106,64 @@ impl std::fmt::Display for ShutdownSignal {
     }
 }
 
+/// What a dependent waits for before it starts.
+///
+/// The names are the ones Docker Compose uses, because that is where anyone
+/// writing this field has met the idea before.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyCondition {
+    /// The dependency's process is up.  Its exit status is not consulted: a
+    /// one-shot that has already run counts as started.
+    ServiceStarted,
+    /// A health probe of the dependency has passed.
+    ServiceHealthy,
+    /// The dependency has exited with status 0.
+    ServiceCompletedSuccessfully,
+}
+
+impl std::fmt::Display for DependencyCondition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DependencyCondition::ServiceStarted => write!(f, "service_started"),
+            DependencyCondition::ServiceHealthy => write!(f, "service_healthy"),
+            DependencyCondition::ServiceCompletedSuccessfully => {
+                write!(f, "service_completed_successfully")
+            }
+        }
+    }
+}
+
+/// One validated `depends_on` entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Dependency {
+    /// The service to wait for.
+    pub service: ServiceName,
+    /// What to wait for, when the config spelled it out.
+    ///
+    /// Left as declared rather than resolved to a concrete condition, because
+    /// `PartialEq` on [`Service`] is the hot-reload restart trigger: resolving
+    /// it here would restart a dependent whenever its *dependency* gained a
+    /// health check, which changes nothing about the dependent's own process.
+    /// Use [`Dependency::condition_for`] to get the effective condition.
+    pub condition: Option<DependencyCondition>,
+}
+
+impl Dependency {
+    /// The condition to actually wait for, given the dependency it points at.
+    ///
+    /// An unspecified condition means "healthy if it promised a health check,
+    /// up otherwise" — the rule servicrab used before conditions existed, kept
+    /// so that adding a health check to a service still gates its dependents.
+    pub fn condition_for(&self, dependency: &Service) -> DependencyCondition {
+        self.condition.unwrap_or(if dependency.health.is_some() {
+            DependencyCondition::ServiceHealthy
+        } else {
+            DependencyCondition::ServiceStarted
+        })
+    }
+}
+
 // ── Project ────────────────────────────────────────────────────────────────
 
 /// Validated file-logging settings.
@@ -295,8 +353,8 @@ pub struct Service {
     /// Absolute paths of the service-level `env_file` entries, in declaration
     /// order.
     pub env_files: Vec<PathBuf>,
-    /// Validated list of service names that must start before this one.
-    pub depends_on: Vec<ServiceName>,
+    /// Validated dependencies that must be ready before this one starts.
+    pub depends_on: Vec<Dependency>,
     /// Whether the supervisor should start this service automatically.
     pub autostart: bool,
     /// Restart policy.

--- a/crates/servicrab-core/src/error.rs
+++ b/crates/servicrab-core/src/error.rs
@@ -93,6 +93,24 @@ pub enum ConfigError {
     #[error("dependency cycle detected: {cycle}")]
     DependencyCycle { cycle: String },
 
+    /// An unrecognised `depends_on` condition.
+    #[error("service {service:?}: unknown condition {value:?} for dependency {dep:?}; expected one of: service_started, service_healthy, service_completed_successfully")]
+    InvalidDependencyCondition {
+        service: String,
+        dep: String,
+        value: String,
+    },
+
+    /// `service_healthy` was asked of a service that has no health check, so
+    /// the condition could never be met.
+    #[error("service {service:?}: dependency {dep:?} has condition \"service_healthy\" but no [health] block, so it can never become healthy")]
+    DependencyNotHealthChecked { service: String, dep: String },
+
+    /// `service_completed_successfully` was asked of a service that is
+    /// restarted forever, so it never stays exited.
+    #[error("service {service:?}: dependency {dep:?} has condition \"service_completed_successfully\" but restart = \"always\", so it never stays exited")]
+    DependencyNeverCompletes { service: String, dep: String },
+
     /// A duration string could not be parsed.
     #[error("service {service:?}: invalid duration {value:?} for field `{field}`: {reason}")]
     InvalidDuration {

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -29,8 +29,9 @@ pub mod validation;
 
 // Convenience re-exports.
 pub use config::{
-    Config, HealthCheck, HealthProbe, LogSettings, Project, ProjectName, RestartPolicy, Service,
-    ServiceName, ShutdownSignal, UnhealthyAction, WatchSettings,
+    Config, Dependency, DependencyCondition, HealthCheck, HealthProbe, LogSettings, Project,
+    ProjectName, RestartPolicy, Service, ServiceName, ShutdownSignal, UnhealthyAction,
+    WatchSettings,
 };
 pub use envfile::EnvFileError;
 pub use error::{ConfigError, ConfigWarning, RuntimeError};

--- a/crates/servicrab-core/src/raw.rs
+++ b/crates/servicrab-core/src/raw.rs
@@ -95,6 +95,88 @@ pub struct RawServiceLogs {
     pub enabled: bool,
 }
 
+/// The two accepted spellings of `depends_on`.
+///
+/// The list form is the short one and says nothing about *what* it waits for;
+/// the table form spells out a condition per dependency, which is the only way
+/// to ask for something other than the default.
+#[derive(Debug)]
+pub enum RawDependsOn {
+    /// `depends_on = ["db"]`
+    Names(Vec<String>),
+    /// `depends_on = { db = { condition = "service_healthy" } }`
+    Detailed(BTreeMap<String, RawDependency>),
+}
+
+// Hand-written rather than `#[serde(untagged)]`, which is what the other
+// either-or field in this file uses.  Untagged buffers the input and reports
+// only "data did not match any variant" when both arms fail, which would turn a
+// typo inside the table — the whole reason `deny_unknown_fields` is on
+// `RawDependency` — into a message that names neither the field nor the
+// service.  Dispatching on the shape keeps the inner error intact.
+impl<'de> Deserialize<'de> for RawDependsOn {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct DependsOnVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for DependsOnVisitor {
+            type Value = RawDependsOn;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a list of service names, or a table of dependency conditions")
+            }
+
+            fn visit_seq<A>(self, seq: A) -> Result<RawDependsOn, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                Deserialize::deserialize(serde::de::value::SeqAccessDeserializer::new(seq))
+                    .map(RawDependsOn::Names)
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<RawDependsOn, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                Deserialize::deserialize(serde::de::value::MapAccessDeserializer::new(map))
+                    .map(RawDependsOn::Detailed)
+            }
+        }
+
+        deserializer.deserialize_any(DependsOnVisitor)
+    }
+}
+
+impl RawDependsOn {
+    /// The declared dependencies as (name, condition) pairs.
+    ///
+    /// The list form keeps its declaration order — which is what makes a
+    /// duplicate entry visible — while the table form is sorted by name, as
+    /// TOML tables cannot repeat a key anyway.
+    pub fn entries(&self) -> Vec<(&str, Option<&str>)> {
+        match self {
+            RawDependsOn::Names(names) => names.iter().map(|n| (n.as_str(), None)).collect(),
+            RawDependsOn::Detailed(map) => map
+                .iter()
+                .map(|(name, dep)| (name.as_str(), dep.condition.as_deref()))
+                .collect(),
+        }
+    }
+}
+
+/// Raw settings for one entry of the table form of `depends_on`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawDependency {
+    /// What "ready" means for this dependency: `service_started`,
+    /// `service_healthy` or `service_completed_successfully`.  Validated by
+    /// the validation layer.
+    #[serde(default)]
+    pub condition: Option<String>,
+}
+
 /// Raw service configuration (`[services.<name>]`).
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -115,9 +197,9 @@ pub struct RawService {
     #[serde(default)]
     pub env_file: Option<RawEnvFile>,
 
-    /// Services that must be started before this one.
+    /// Services that must be ready before this one starts.
     #[serde(default)]
-    pub depends_on: Vec<String>,
+    pub depends_on: Option<RawDependsOn>,
 
     /// Whether to start this service automatically.  Defaults to `true`.
     #[serde(default = "default_true")]

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -8,8 +8,9 @@
 //! * `ForegroundRunner` wraps it with signal handling for `run`.
 //! * `stack::StackSupervisor` runs many services concurrently for `up`.
 //!
-//! A dependent waits for its dependency to be *running*, or to be *healthy*
-//! when that dependency declares a health check.
+//! What a dependent waits for is set per `depends_on` entry by its
+//! [`crate::config::DependencyCondition`], defaulting to *healthy* when the
+//! dependency declares a health check and to *running* otherwise.
 //!
 //! Only Linux and macOS are supported.  On other platforms every entry point
 //! returns [`crate::error::RuntimeError::UnsupportedPlatform`].

--- a/crates/servicrab-core/src/runtime/plan.rs
+++ b/crates/servicrab-core/src/runtime/plan.rs
@@ -84,7 +84,7 @@ fn collect_with_dependencies(
     // dependencies, so this recursion always terminates.
     if let Some(service) = config.services.get(name) {
         for dep in &service.depends_on {
-            collect_with_dependencies(config, dep, selected);
+            collect_with_dependencies(config, &dep.service, selected);
         }
     }
 }

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -5,9 +5,12 @@
 //! down in reverse dependency order so that dependents stop before the services
 //! they rely on.
 //!
-//! A service is considered "available" for its dependents as soon as its
-//! process is running.  Real readiness probes are a later milestone; until then
-//! a dependent may still need to retry its own connection attempts.
+//! What makes a service "available" for its dependents is per edge: each
+//! `depends_on` entry carries a [`DependencyCondition`], and an entry that does
+//! not spell one out waits for a health probe when the dependency has a health
+//! check and for the process to be up otherwise.  Either way, "up" is not a
+//! promise that the service is *usable*, so a dependent may still need to retry
+//! its own connection attempts.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -16,7 +19,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
-use crate::config::{Config, Service, ServiceName};
+use crate::config::{Config, DependencyCondition, Service, ServiceName};
 use crate::error::RuntimeError;
 use crate::lifecycle::{ExitReason, ServiceState, ShutdownReason};
 use crate::runtime::event::{event_channel, EventKind, EventSender, EventSink, ServiceEvent};
@@ -155,8 +158,8 @@ pub fn control_channel() -> (ControlTx, ControlRx) {
 /// Everything the supervisor needs to run — and re-run — one service.
 struct Slot {
     service: Arc<Service>,
-    deps: Vec<(ServiceName, watch::Receiver<Readiness>)>,
-    readiness: Arc<watch::Sender<Readiness>>,
+    deps: Vec<DependencyEdge>,
+    readiness: Arc<watch::Sender<DependencyStatus>>,
     /// Present exactly while a supervision task is alive.
     stop: Option<crate::runtime::ShutdownTx>,
     handle: Option<JoinHandle<()>>,
@@ -177,9 +180,9 @@ impl Slot {
         options: RunOptions,
         reports: mpsc::UnboundedSender<ServiceReport>,
     ) {
-        // A previous run may have left the signal at `Gone`; dependents that
-        // are still waiting must not act on that stale verdict.
-        let _ = self.readiness.send(Readiness::Pending);
+        // A previous run may have left the status at something a dependent
+        // would read as a verdict; it must not act on that stale news.
+        let _ = self.readiness.send(DependencyStatus::new());
 
         let (stop_tx, stop_rx) = shutdown_channel();
         self.stop = Some(stop_tx);
@@ -554,7 +557,7 @@ impl RunState {
     /// Dependencies are wired up separately, once every slot exists: a
     /// service must be able to subscribe to slots added after it.
     fn insert_slot(&mut self, name: &ServiceName, service: Arc<Service>) {
-        let (state_tx, state_rx) = watch::channel(Readiness::Pending);
+        let (state_tx, state_rx) = watch::channel(DependencyStatus::new());
         drop(state_rx);
         self.slots.insert(
             name.clone(),
@@ -571,9 +574,9 @@ impl RunState {
         );
     }
 
-    /// Point every slot at the readiness of the dependencies it currently has.
+    /// Point every slot at the status of the dependencies it currently has.
     fn rewire_dependencies(&mut self) {
-        let readiness: BTreeMap<ServiceName, Arc<watch::Sender<Readiness>>> = self
+        let readiness: BTreeMap<ServiceName, Arc<watch::Sender<DependencyStatus>>> = self
             .slots
             .iter()
             .map(|(name, slot)| (name.clone(), slot.readiness.clone()))
@@ -587,9 +590,17 @@ impl RunState {
                 .depends_on
                 .iter()
                 .filter_map(|dep| {
-                    readiness
-                        .get(dep)
-                        .map(|sender| (dep.clone(), sender.subscribe()))
+                    // An unspecified condition resolves against the dependency
+                    // as it is configured *now*, so a health check added by a
+                    // reload starts gating this edge without the dependent
+                    // itself having changed.
+                    let target = self.config.services.get(&dep.service)?;
+                    let sender = readiness.get(&dep.service)?;
+                    Some(DependencyEdge {
+                        name: dep.service.clone(),
+                        condition: dep.condition_for(target),
+                        status: sender.subscribe(),
+                    })
                 })
                 .collect();
         }
@@ -723,12 +734,87 @@ pub enum Readiness {
     Gone,
 }
 
+/// What a service's own event stream says about it so far.
+///
+/// This is broadcast rather than a [`Readiness`] verdict because one service
+/// can be depended on under different conditions at the same time — a web app
+/// may want the database *healthy* while a log shipper only needs it *up* — so
+/// the verdict has to be computed per dependent, from a shared set of facts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DependencyStatus {
+    /// The last lifecycle state observed.
+    state: ServiceState,
+    /// Whether a probe has passed for the process that is running now.
+    healthy: bool,
+    /// Whether the current run is known to be unhealthy.
+    unhealthy: bool,
+    /// Whether the last run that ended exited with status 0.
+    exited_ok: bool,
+    /// Set when the service will not run at all: it was itself skipped over an
+    /// unavailable dependency, or the stack shut down before its turn.  No
+    /// lifecycle state describes that, and no condition can be met after it.
+    gone: bool,
+}
+
+impl DependencyStatus {
+    /// The status of a service that has not been started yet.
+    fn new() -> Self {
+        Self {
+            state: ServiceState::Pending,
+            healthy: false,
+            unhealthy: false,
+            exited_ok: false,
+            gone: false,
+        }
+    }
+
+    /// Whether a dependent waiting for `condition` may start.
+    fn readiness(&self, condition: DependencyCondition) -> Readiness {
+        if self.gone {
+            return Readiness::Gone;
+        }
+        match self.state {
+            ServiceState::Exited => match condition {
+                // The only condition that consults the exit status.  The other
+                // two treat a one-shot that has done its job — a migration, a
+                // build step — as available, which is what keeps a stack whose
+                // dependency legitimately exits from deadlocking.
+                DependencyCondition::ServiceCompletedSuccessfully if self.exited_ok => {
+                    Readiness::Ready
+                }
+                DependencyCondition::ServiceCompletedSuccessfully => Readiness::Gone,
+                // Unless it was stopped precisely because it was unhealthy.
+                _ if !self.unhealthy => Readiness::Ready,
+                _ => Readiness::Gone,
+            },
+            ServiceState::Failed | ServiceState::Stopped => Readiness::Gone,
+            ServiceState::Running => match condition {
+                DependencyCondition::ServiceStarted => Readiness::Ready,
+                DependencyCondition::ServiceHealthy if self.healthy => Readiness::Ready,
+                // An unhealthy service may yet be restarted into shape, and a
+                // one-shot that has not exited yet may yet exit cleanly, so
+                // both are a wait rather than a verdict.
+                _ => Readiness::Pending,
+            },
+            _ => Readiness::Pending,
+        }
+    }
+}
+
+/// One dependency edge: who to wait for, for what, and where to watch it.
+#[derive(Clone)]
+struct DependencyEdge {
+    name: ServiceName,
+    condition: DependencyCondition,
+    status: watch::Receiver<DependencyStatus>,
+}
+
 /// Supervise one service: wait for its dependencies, then run it.
 #[allow(clippy::too_many_arguments)]
 async fn supervise_service(
     service: Arc<Service>,
-    deps: Vec<(ServiceName, watch::Receiver<Readiness>)>,
-    readiness: Arc<watch::Sender<Readiness>>,
+    deps: Vec<DependencyEdge>,
+    readiness: Arc<watch::Sender<DependencyStatus>>,
     mut stop: ShutdownRx,
     events: EventSender,
     options: RunOptions,
@@ -745,7 +831,7 @@ async fn supervise_service(
                     dependency: dependency.clone(),
                 },
             ));
-            let _ = readiness.send(Readiness::Gone);
+            readiness.send_modify(|status| status.gone = true);
             let _ = reports.send(ServiceReport {
                 service: name,
                 result: ServiceResult::Skipped { dependency },
@@ -753,7 +839,7 @@ async fn supervise_service(
             return;
         }
         DependencyWait::Shutdown(reason) => {
-            let _ = readiness.send(Readiness::Gone);
+            readiness.send_modify(|status| status.gone = true);
             let _ = reports.send(ServiceReport {
                 service: name,
                 result: ServiceResult::Finished(RunOutcome::Stopped { reason }),
@@ -767,9 +853,7 @@ async fn supervise_service(
     let (tx, mut rx) = event_channel();
     let relay = {
         let global = events.clone();
-        // A service with a health check is only ready once a probe passes;
-        // without one, "the process is up" is the best signal available.
-        let mut tracker = ReadinessTracker::new(service.health.is_some());
+        let mut tracker = ReadinessTracker::new();
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
                 if let Some(next) = tracker.observe(&event.kind) {
@@ -808,86 +892,66 @@ async fn supervise_service(
     });
 }
 
-/// Derives the readiness signal dependents wait on from a service's events.
+/// Folds a service's events into the status its dependents watch.
 struct ReadinessTracker {
-    /// Whether the service promised a health check, in which case being up is
-    /// not enough to be ready.
-    gate_on_health: bool,
-    /// Whether the current process run is known to be unhealthy.
-    unhealthy: bool,
+    status: DependencyStatus,
 }
 
 impl ReadinessTracker {
-    fn new(gate_on_health: bool) -> Self {
+    fn new() -> Self {
         Self {
-            gate_on_health,
-            unhealthy: false,
+            status: DependencyStatus::new(),
         }
     }
 
-    /// Map one runtime event to the readiness it implies, if any.
-    fn observe(&mut self, kind: &EventKind) -> Option<Readiness> {
+    /// Fold one runtime event in, returning the new status when it changed.
+    fn observe(&mut self, kind: &EventKind) -> Option<DependencyStatus> {
+        let before = self.status;
         match kind {
-            // A passing health probe always means ready.
             EventKind::Healthy => {
-                self.unhealthy = false;
-                Some(Readiness::Ready)
+                self.status.healthy = true;
+                self.status.unhealthy = false;
             }
-            // A failing one takes readiness away again, so a dependent that
-            // has not started yet keeps waiting for the service to recover.
             EventKind::Unhealthy { .. } => {
-                self.unhealthy = true;
-                Some(Readiness::Pending)
+                self.status.healthy = false;
+                self.status.unhealthy = true;
             }
-            EventKind::Exited {
-                reason: ExitReason::Unhealthy,
-                ..
-            } => {
-                self.unhealthy = true;
-                None
+            EventKind::Exited { reason, .. } => {
+                self.status.exited_ok = reason.is_success();
+                if matches!(reason, ExitReason::Unhealthy) {
+                    self.status.unhealthy = true;
+                }
             }
-            EventKind::State(state) => match state {
+            EventKind::State(state) => {
+                self.status.state = *state;
                 // A restart gets a clean slate: the new process has to prove
                 // itself healthy again.
-                ServiceState::Starting => {
-                    self.unhealthy = false;
-                    None
+                if matches!(state, ServiceState::Starting) {
+                    self.status.healthy = false;
+                    self.status.unhealthy = false;
                 }
-                // The process is up: enough on its own, unless the service
-                // promised a health check that has not passed yet.
-                ServiceState::Running if !self.gate_on_health => Some(Readiness::Ready),
-                // A one-shot dependency (a migration, a build step) that
-                // already did its job counts as available — unless it was
-                // stopped precisely because it was unhealthy.
-                ServiceState::Exited if !self.unhealthy => Some(Readiness::Ready),
-                ServiceState::Exited | ServiceState::Failed | ServiceState::Stopped => {
-                    Some(Readiness::Gone)
-                }
-                _ => None,
-            },
-            _ => None,
+            }
+            _ => {}
         }
+        (self.status != before).then_some(self.status)
     }
 }
 
 /// Wait until every dependency is available (or will never be).
-async fn wait_for_dependencies(
-    deps: &[(ServiceName, watch::Receiver<Readiness>)],
-    stop: &mut ShutdownRx,
-) -> DependencyWait {
-    for (name, receiver) in deps {
-        let mut receiver = receiver.clone();
+async fn wait_for_dependencies(deps: &[DependencyEdge], stop: &mut ShutdownRx) -> DependencyWait {
+    for edge in deps {
+        let mut status = edge.status.clone();
         loop {
-            match *receiver.borrow_and_update() {
+            match status.borrow_and_update().readiness(edge.condition) {
                 Readiness::Ready => break,
-                Readiness::Gone => return DependencyWait::Blocked(name.clone()),
+                Readiness::Gone => return DependencyWait::Blocked(edge.name.clone()),
                 Readiness::Pending => {}
             }
 
             tokio::select! {
-                changed = receiver.changed() => {
+                changed = status.changed() => {
                     if changed.is_err() {
-                        return DependencyWait::Blocked(name.clone());
+                        return DependencyWait::Blocked(edge.name.clone());
                     }
                 }
                 reason = wait_for_shutdown(stop) => return DependencyWait::Shutdown(reason),
@@ -1072,7 +1136,7 @@ command = ["sleep", "60"]
         let deps: Vec<ServiceName> = state.slots[&name("api")]
             .deps
             .iter()
-            .map(|(dep, _)| dep.clone())
+            .map(|edge| edge.name.clone())
             .collect();
         assert_eq!(deps, vec![name("worker")]);
     }
@@ -1116,14 +1180,53 @@ command = ["sleep", "60"]
         assert_eq!(bad.failures().count(), 1);
     }
 
+    /// What a dependent waiting for `condition` sees after the dependency has
+    /// emitted `events`.
+    fn verdict(events: &[EventKind], condition: DependencyCondition) -> Readiness {
+        let mut tracker = ReadinessTracker::new();
+        for event in events {
+            tracker.observe(event);
+        }
+        tracker.status.readiness(condition)
+    }
+
+    /// The events a service emits as it comes up.
+    fn started() -> Vec<EventKind> {
+        vec![
+            EventKind::State(ServiceState::Starting),
+            EventKind::State(ServiceState::Running),
+        ]
+    }
+
+    /// The events a service emits as it exits with `code` and is not restarted.
+    fn exited(code: i32) -> Vec<EventKind> {
+        let mut events = started();
+        events.push(EventKind::Exited {
+            reason: ExitReason::Code(code),
+            uptime: Duration::from_secs(1),
+        });
+        events.push(EventKind::State(ServiceState::Exited));
+        events
+    }
+
+    fn edge(
+        condition: DependencyCondition,
+        status: watch::Receiver<DependencyStatus>,
+    ) -> Vec<DependencyEdge> {
+        vec![DependencyEdge {
+            name: name("db"),
+            condition,
+            status,
+        }]
+    }
+
     #[tokio::test]
     async fn dependencies_are_awaited_until_ready() {
-        let (tx, rx) = watch::channel(Readiness::Pending);
+        let (tx, rx) = watch::channel(DependencyStatus::new());
         let (_stop_tx, mut stop_rx) = shutdown_channel();
-        let deps = vec![(name("db"), rx)];
+        let deps = edge(DependencyCondition::ServiceStarted, rx);
 
         let waiter = tokio::spawn(async move {
-            let (_stop_tx2, _) = shutdown_channel();
             matches!(
                 wait_for_dependencies(&deps, &mut stop_rx).await,
                 DependencyWait::Ready
@@ -1131,18 +1234,32 @@ command = ["sleep", "60"]
         });
 
         tokio::task::yield_now().await;
-        tx.send(Readiness::Ready).expect("receiver alive");
+        tx.send_modify(|status| status.state = ServiceState::Running);
 
         assert!(waiter.await.expect("task"));
     }
 
     #[tokio::test]
     async fn a_failed_dependency_blocks_the_dependent() {
-        let (tx, rx) = watch::channel(Readiness::Pending);
+        let (tx, rx) = watch::channel(DependencyStatus::new());
         let (_stop_tx, mut stop_rx) = shutdown_channel();
-        let deps = vec![(name("db"), rx)];
+        let deps = edge(DependencyCondition::ServiceStarted, rx);
 
-        tx.send(Readiness::Gone).expect("receiver alive");
+        tx.send_modify(|status| status.state = ServiceState::Failed);
+
+        assert!(matches!(
+            wait_for_dependencies(&deps, &mut stop_rx).await,
+            DependencyWait::Blocked(blocked) if blocked.as_str() == "db"
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_skipped_dependency_blocks_the_dependent() {
+        let (tx, rx) = watch::channel(DependencyStatus::new());
+        let (_stop_tx, mut stop_rx) = shutdown_channel();
+        let deps = edge(DependencyCondition::ServiceStarted, rx);
+
+        tx.send_modify(|status| status.gone = true);
 
         assert!(matches!(
             wait_for_dependencies(&deps, &mut stop_rx).await,
@@ -1151,89 +1268,120 @@ command = ["sleep", "60"]
     }
 
     #[test]
-    fn readiness_follows_the_process_when_there_is_no_health_check() {
-        let mut tracker = ReadinessTracker::new(false);
+    fn service_started_only_needs_the_process_to_be_up() {
+        use DependencyCondition::ServiceStarted;
+
+        assert_eq!(verdict(&started(), ServiceStarted), Readiness::Ready);
         assert_eq!(
-            tracker.observe(&EventKind::State(ServiceState::Running)),
-            Some(Readiness::Ready)
+            verdict(&[EventKind::State(ServiceState::Starting)], ServiceStarted),
+            Readiness::Pending
         );
+        // The exit status is deliberately not consulted: it started.
+        assert_eq!(verdict(&exited(1), ServiceStarted), Readiness::Ready);
         assert_eq!(
-            tracker.observe(&EventKind::State(ServiceState::Backoff)),
-            None
-        );
-        assert_eq!(
-            tracker.observe(&EventKind::State(ServiceState::Failed)),
-            Some(Readiness::Gone)
+            verdict(&[EventKind::State(ServiceState::Failed)], ServiceStarted),
+            Readiness::Gone
         );
     }
 
     #[test]
-    fn a_health_checked_service_is_only_ready_once_a_probe_passes() {
-        let mut tracker = ReadinessTracker::new(true);
-        assert_eq!(
-            tracker.observe(&EventKind::State(ServiceState::Running)),
-            None
-        );
-        assert_eq!(tracker.observe(&EventKind::Healthy), Some(Readiness::Ready));
-        assert_eq!(
-            tracker.observe(&EventKind::Unhealthy {
-                message: "boom".to_string()
-            }),
-            Some(Readiness::Pending)
-        );
+    fn service_healthy_waits_for_a_passing_probe() {
+        use DependencyCondition::ServiceHealthy;
+
+        assert_eq!(verdict(&started(), ServiceHealthy), Readiness::Pending);
+
+        let mut healthy = started();
+        healthy.push(EventKind::Healthy);
+        assert_eq!(verdict(&healthy, ServiceHealthy), Readiness::Ready);
+
+        // A failing probe takes readiness away again rather than settling the
+        // question: a restart may yet put the service right.
+        let mut unhealthy = healthy.clone();
+        unhealthy.push(EventKind::Unhealthy {
+            message: "boom".to_string(),
+        });
+        assert_eq!(verdict(&unhealthy, ServiceHealthy), Readiness::Pending);
     }
 
     #[test]
-    fn a_one_shot_dependency_counts_as_ready_once_it_exits() {
-        for gate in [false, true] {
-            let mut tracker = ReadinessTracker::new(gate);
-            assert_eq!(
-                tracker.observe(&EventKind::State(ServiceState::Exited)),
-                Some(Readiness::Ready)
-            );
+    fn a_one_shot_dependency_counts_as_started_and_as_healthy_once_it_exits() {
+        // Neither condition can ever be met again by a process that is gone, so
+        // insisting on them would deadlock every stack with a migration step in
+        // it.  `service_completed_successfully` is the condition for callers who
+        // want the exit status checked.
+        for condition in [
+            DependencyCondition::ServiceStarted,
+            DependencyCondition::ServiceHealthy,
+        ] {
+            assert_eq!(verdict(&exited(0), condition), Readiness::Ready);
         }
     }
 
     #[test]
-    fn a_service_stopped_for_being_unhealthy_never_becomes_available() {
-        let mut tracker = ReadinessTracker::new(true);
+    fn service_completed_successfully_waits_for_a_clean_exit() {
+        use DependencyCondition::ServiceCompletedSuccessfully;
+
         assert_eq!(
-            tracker.observe(&EventKind::Unhealthy {
-                message: "boom".to_string()
-            }),
-            Some(Readiness::Pending)
+            verdict(&started(), ServiceCompletedSuccessfully),
+            Readiness::Pending
         );
         assert_eq!(
-            tracker.observe(&EventKind::Exited {
-                reason: ExitReason::Unhealthy,
-                uptime: Duration::from_secs(1),
-            }),
-            None
+            verdict(&exited(0), ServiceCompletedSuccessfully),
+            Readiness::Ready
         );
         assert_eq!(
-            tracker.observe(&EventKind::State(ServiceState::Exited)),
-            Some(Readiness::Gone)
+            verdict(&exited(1), ServiceCompletedSuccessfully),
+            Readiness::Gone
         );
     }
 
     #[test]
+    fn a_service_stopped_for_being_unhealthy_never_becomes_available() {
+        let events = vec![
+            EventKind::State(ServiceState::Running),
+            EventKind::Unhealthy {
+                message: "boom".to_string(),
+            },
+            EventKind::Exited {
+                reason: ExitReason::Unhealthy,
+                uptime: Duration::from_secs(1),
+            },
+            EventKind::State(ServiceState::Exited),
+        ];
+
+        for condition in [
+            DependencyCondition::ServiceStarted,
+            DependencyCondition::ServiceHealthy,
+        ] {
+            assert_eq!(verdict(&events, condition), Readiness::Gone);
+        }
+    }
+
+    #[test]
     fn a_restart_resets_the_unhealthy_verdict() {
-        let mut tracker = ReadinessTracker::new(true);
-        tracker.observe(&EventKind::Unhealthy {
+        let mut events = started();
+        events.push(EventKind::Unhealthy {
             message: "boom".to_string(),
         });
+        events.push(EventKind::State(ServiceState::Starting));
+        events.push(EventKind::State(ServiceState::Running));
         assert_eq!(
-            tracker.observe(&EventKind::State(ServiceState::Starting)),
-            None
+            verdict(&events, DependencyCondition::ServiceHealthy),
+            Readiness::Pending
         );
-        assert_eq!(tracker.observe(&EventKind::Healthy), Some(Readiness::Ready));
+
+        events.push(EventKind::Healthy);
+        assert_eq!(
+            verdict(&events, DependencyCondition::ServiceHealthy),
+            Readiness::Ready
+        );
     }
 
     #[tokio::test]
     async fn shutdown_interrupts_the_dependency_wait() {
-        let (_tx, rx) = watch::channel(Readiness::Pending);
+        let (_tx, rx) = watch::channel(DependencyStatus::new());
         let (stop_tx, mut stop_rx) = shutdown_channel();
-        let deps = vec![(name("db"), rx)];
+        let deps = edge(DependencyCondition::ServiceStarted, rx);
 
         stop_tx
             .send(Some(ShutdownReason::UserInterrupt))

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -8,12 +8,15 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::config::{
-    Config, HealthCheck, HealthProbe, LogSettings, Project, ProjectName, RestartPolicy, Service,
-    ServiceName, ShutdownSignal, UnhealthyAction, WatchSettings,
+    Config, Dependency, DependencyCondition, HealthCheck, HealthProbe, LogSettings, Project,
+    ProjectName, RestartPolicy, Service, ServiceName, ShutdownSignal, UnhealthyAction,
+    WatchSettings,
 };
 use crate::error::{ConfigError, ConfigWarning};
 use crate::graph::topological_sort;
-use crate::raw::{RawConfig, RawEnvFile, RawHealthCheck, RawRestartPolicy, RawWatch};
+use crate::raw::{
+    RawConfig, RawDependsOn, RawEnvFile, RawHealthCheck, RawRestartPolicy, RawService, RawWatch,
+};
 
 /// The only supported schema version.
 const SUPPORTED_VERSION: u32 = 1;
@@ -238,11 +241,17 @@ pub fn validate_raw(
         merged_env.extend(svc_file_env);
         merged_env.extend(svc_env);
 
-        // Collect depends_on as ServiceNames (cross-service validation deferred)
-        let depends_on: Vec<ServiceName> = raw_svc
-            .depends_on
-            .iter()
-            .map(|d| ServiceName(d.clone()))
+        // Collect depends_on (cross-service validation deferred to step 7).
+        // An unparseable condition is dropped rather than reported here: step 7
+        // walks the raw services, so it also sees the ones this loop skipped
+        // over an invalid command, and it is the single place that reports
+        // dependency problems.
+        let depends_on: Vec<Dependency> = dependency_entries(raw_svc)
+            .into_iter()
+            .map(|(dep, condition)| Dependency {
+                service: ServiceName(dep.to_string()),
+                condition: condition.and_then(parse_dependency_condition),
+            })
             .collect();
 
         let args = raw_svc.command[1..].to_vec();
@@ -275,21 +284,53 @@ pub fn validate_raw(
     // ── 7. Cross-service dependency validation ────────────────────────────
     for (raw_name, raw_svc) in &raw.services {
         let mut seen: BTreeSet<&str> = BTreeSet::new();
-        for dep in &raw_svc.depends_on {
-            if dep == raw_name {
+        for (dep, condition) in dependency_entries(raw_svc) {
+            if dep == raw_name.as_str() {
                 errors.push(ConfigError::SelfDependency {
                     service: raw_name.clone(),
                 });
-            } else if !raw.services.contains_key(dep.as_str()) {
+                continue;
+            }
+            let Some(target) = raw.services.get(dep) else {
                 errors.push(ConfigError::UnknownDependency {
                     service: raw_name.clone(),
-                    dep: dep.clone(),
+                    dep: dep.to_string(),
                 });
-            } else if !seen.insert(dep.as_str()) {
+                continue;
+            };
+            if !seen.insert(dep) {
                 errors.push(ConfigError::DuplicateDependency {
                     service: raw_name.clone(),
-                    dep: dep.clone(),
+                    dep: dep.to_string(),
                 });
+                continue;
+            }
+
+            // A condition the dependency can never satisfy is a deadlock
+            // waiting to happen — the dependent would sit there until someone
+            // interrupts the stack — so it is rejected at load time.
+            let Some(condition) = condition else { continue };
+            match parse_dependency_condition(condition) {
+                None => errors.push(ConfigError::InvalidDependencyCondition {
+                    service: raw_name.clone(),
+                    dep: dep.to_string(),
+                    value: condition.to_string(),
+                }),
+                Some(DependencyCondition::ServiceHealthy) if target.health.is_none() => {
+                    errors.push(ConfigError::DependencyNotHealthChecked {
+                        service: raw_name.clone(),
+                        dep: dep.to_string(),
+                    });
+                }
+                Some(DependencyCondition::ServiceCompletedSuccessfully)
+                    if target.restart == RawRestartPolicy::Always =>
+                {
+                    errors.push(ConfigError::DependencyNeverCompletes {
+                        service: raw_name.clone(),
+                        dep: dep.to_string(),
+                    });
+                }
+                Some(_) => {}
             }
         }
     }
@@ -302,7 +343,10 @@ pub fn validate_raw(
     // ── 9. Topological sort (may also emit DependencyCycle) ───────────────
     let dep_graph: BTreeMap<ServiceName, Vec<ServiceName>> = services
         .iter()
-        .map(|(name, svc)| (name.clone(), svc.depends_on.clone()))
+        .map(|(name, svc)| {
+            let deps = svc.depends_on.iter().map(|d| d.service.clone()).collect();
+            (name.clone(), deps)
+        })
         .collect();
 
     let start_order = match topological_sort(&dep_graph) {
@@ -324,6 +368,27 @@ pub fn validate_raw(
     };
 
     Ok((config, warnings))
+}
+
+// ── Dependencies ───────────────────────────────────────────────────────────
+
+/// The `depends_on` entries of one raw service, whichever form it used.
+fn dependency_entries(service: &RawService) -> Vec<(&str, Option<&str>)> {
+    service
+        .depends_on
+        .as_ref()
+        .map(RawDependsOn::entries)
+        .unwrap_or_default()
+}
+
+/// Parse a `depends_on` condition token, or `None` if it is not one.
+fn parse_dependency_condition(value: &str) -> Option<DependencyCondition> {
+    match value {
+        "service_started" => Some(DependencyCondition::ServiceStarted),
+        "service_healthy" => Some(DependencyCondition::ServiceHealthy),
+        "service_completed_successfully" => Some(DependencyCondition::ServiceCompletedSuccessfully),
+        _ => None,
+    }
 }
 
 // ── Name validation ────────────────────────────────────────────────────────
@@ -1659,7 +1724,7 @@ command = ["echo"]
                         cwd: None,
                         env: Default::default(),
                         env_file: None,
-                        depends_on: vec![],
+                        depends_on: None,
                         autostart: true,
                         restart: Default::default(),
                         restart_delay: None,
@@ -2088,6 +2153,138 @@ shutdown_timeout = "30s"
         load_from_str(toml).expect("valid dependency should pass");
     }
 
+    // ── Dependency conditions ──────────────────────────────────────────────
+
+    /// Two services where `b` depends on `a` under `condition`, and `a` carries
+    /// whatever `a_extra` adds.
+    fn with_condition(condition: &str, a_extra: &str) -> String {
+        format!(
+            r#"
+version = 1
+[project]
+name = "p"
+[services.a]
+command = ["echo"]
+{a_extra}
+[services.b]
+command = ["echo"]
+depends_on = {{ a = {{ condition = "{condition}" }} }}
+"#
+        )
+    }
+
+    #[test]
+    fn a_declared_condition_survives_validation() {
+        let (cfg, _) =
+            load_from_str(&with_condition("service_completed_successfully", "")).unwrap();
+        let b = &cfg.services[&ServiceName("b".to_string())];
+
+        assert_eq!(b.depends_on.len(), 1);
+        assert_eq!(b.depends_on[0].service.as_str(), "a");
+        assert_eq!(
+            b.depends_on[0].condition,
+            Some(DependencyCondition::ServiceCompletedSuccessfully)
+        );
+    }
+
+    #[test]
+    fn the_short_form_leaves_the_condition_to_the_dependency() {
+        let toml = r#"
+version = 1
+[project]
+name = "p"
+[services.a]
+command = ["echo"]
+[services.plain]
+command = ["echo"]
+depends_on = ["a"]
+[services.checked]
+command = ["echo"]
+depends_on = ["a"]
+[services.checked.health]
+tcp = "127.0.0.1:1"
+"#;
+        let (cfg, _) = load_from_str(toml).unwrap();
+        let plain = &cfg.services[&ServiceName("plain".to_string())];
+        let checked = &cfg.services[&ServiceName("checked".to_string())];
+
+        // Nothing is resolved at load time, so that adding a health check to a
+        // dependency does not count as a change to its dependents.
+        assert_eq!(plain.depends_on[0].condition, None);
+        assert_eq!(
+            plain.depends_on[0].condition_for(&cfg.services[&ServiceName("a".to_string())]),
+            DependencyCondition::ServiceStarted
+        );
+        assert_eq!(
+            plain.depends_on[0].condition_for(checked),
+            DependencyCondition::ServiceHealthy
+        );
+    }
+
+    #[test]
+    fn an_unknown_condition_errors() {
+        let err = expect_one_error(&with_condition("service_started_maybe", ""));
+        assert!(
+            matches!(&err, ConfigError::InvalidDependencyCondition { dep, value, .. }
+                if dep == "a" && value == "service_started_maybe"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn service_healthy_needs_the_dependency_to_have_a_health_check() {
+        let err = expect_one_error(&with_condition("service_healthy", ""));
+        assert!(
+            matches!(&err, ConfigError::DependencyNotHealthChecked { service, dep }
+                if service == "b" && dep == "a"),
+            "{err:?}"
+        );
+
+        load_from_str(&with_condition(
+            "service_healthy",
+            "[services.a.health]\ntcp = \"127.0.0.1:1\"",
+        ))
+        .expect("a health-checked dependency should pass");
+    }
+
+    #[test]
+    fn service_completed_successfully_rejects_a_dependency_that_always_restarts() {
+        let err = expect_one_error(&with_condition(
+            "service_completed_successfully",
+            r#"restart = "always""#,
+        ));
+        assert!(
+            matches!(&err, ConfigError::DependencyNeverCompletes { service, dep }
+                if service == "b" && dep == "a"),
+            "{err:?}"
+        );
+
+        // `on-failure` is fine: it retries until the run succeeds, which is
+        // exactly what waiting for a successful completion wants.
+        load_from_str(&with_condition(
+            "service_completed_successfully",
+            r#"restart = "on-failure""#,
+        ))
+        .expect("a retried dependency should pass");
+    }
+
+    #[test]
+    fn the_table_form_is_checked_like_the_list_form() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\ndepends_on={ ghost = {} }\n";
+        let err = expect_one_error(toml);
+        assert!(
+            matches!(&err, ConfigError::UnknownDependency { dep, .. } if dep == "ghost"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_typo_inside_the_table_form_names_the_field() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.a]\ncommand=[\"echo\"]\n[services.b]\ncommand=[\"echo\"]\ndepends_on={ a = { conditon = \"service_started\" } }\n";
+        let err = toml::from_str::<RawConfig>(toml).expect_err("unknown field must be rejected");
+        assert!(err.to_string().contains("conditon"), "{err}");
+    }
+
     // ── Topological order ──────────────────────────────────────────────────
 
     #[test]
@@ -2172,7 +2369,7 @@ restart_delay = "2s"
                 cwd: None,
                 env: env.into_iter().collect(),
                 env_file: None,
-                depends_on: vec![],
+                depends_on: None,
                 autostart: true,
                 restart: Default::default(),
                 restart_delay: None,


### PR DESCRIPTION
## Summary

A dependent could say *what* it waits for but not *when* the wait is over, and the missing case was the one every project has: a migration. A one-shot that exited released its dependents whatever its exit status, so a failing migration started the API against a half-migrated database.

`depends_on` now also takes the Compose table form, with a condition per entry:

```toml
[services.api.depends_on]
db = { condition = "service_healthy" }
migrate = { condition = "service_completed_successfully" }
cache = { condition = "service_started" }
```

| Condition | Available once |
|---|---|
| `service_started` | the process is up; the exit status is never consulted |
| `service_healthy` | a health probe has passed |
| `service_completed_successfully` | the service has exited with status `0` |

## Decisions worth reviewing

**An omitted condition is deliberately not `service_started`.** It keeps meaning "healthy if the dependency declares a health check, up otherwise", so adding a health check still starts gating everything downstream. `Dependency` stores the condition *as declared* rather than resolved: `Service`'s `PartialEq` is the hot-reload restart trigger, and resolving it at load time would have restarted a dependent whenever its *dependency* gained a health check — which changes nothing about the dependent's own process. The edge is resolved when it is wired up, so a reload still picks the change up.

**Only `service_completed_successfully` consults the exit status.** Under the other two, a one-shot that has exited still counts as available: a finished process can never become healthy again, so insisting would deadlock any stack with a migration in it. This is what keeps every existing config behaving exactly as it did — no test needed changing.

**Unsatisfiable conditions are load-time errors**, not 2am debugging: `service_healthy` on a service with no `[health]` block, and `service_completed_successfully` on one with `restart = "always"` (it never stays exited).

**The readiness signal changed shape.** One verdict cannot serve two dependents that want different things from the same service, so what is broadcast is now the facts — state, health, exit status — and each dependent computes its own verdict.

**The deserializer is hand-written** rather than `#[serde(untagged)]`, which is what the other either-or field in `raw.rs` uses. Untagged buffers the input and reports only "data did not match any variant", which would turn a typo inside the table — the whole reason `deny_unknown_fields` is there — into a message naming neither the field nor the service. Dispatching on the shape keeps the inner error:

```
✗ bad.toml has 1 error(s):
  • failed to parse bad.toml: TOML parse error at line 9, column 12
  |
9 | worker = { conditon = "service_started" }
  |            ^^^^^^^^
unknown field `conditon`, expected `condition`
```

## Breaking

`list --json` reports each dependency as an object carrying the effective condition instead of a bare name, so the thing being waited for is machine-readable. Noted under Changed in the changelog.

## Test plan

- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked` — 371 pass
- [x] Unit tests for all three conditions, including the one-shot and unhealthy-exit corners, plus the skipped-dependency path
- [x] Validation tests for each new error, and one asserting the typo message names the field
- [x] `up` integration tests: a one-shot that must complete (asserted from the event stream, not from timing), the same one failing and skipping its dependent, and the short form deliberately ignoring the exit status
- [x] `health` integration test: `service_started` opting out of a health check that never passes — the mirror of the existing "never becomes healthy" test
- [x] Manual check of the three load-time error messages and of `list` output