### PR TITLE
Add `include`, to split a config across files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `include`, so a stack of a dozen services does not have to live in one file:
+
+  ```toml
+  version = 1
+  include = ["services/db.toml", "services/api.toml"]
+  ```
+
+  An included file holds `[services.<name>]` tables and may include further
+  files; `version` and `[project]` stay in the config every command is pointed
+  at, not least because the project name decides where the daemon keeps its
+  socket.
+
+  Relative paths in an included file belong to that file — its own `include`
+  entries, and the `cwd` and `env_file` of the services it declares — so a
+  fragment can be moved together with the code it describes.
+
+  Merging is not overriding: two files declaring the same service, an `include`
+  cycle, the same file included twice, and `version` or `[project]` in an
+  included file are all configuration errors, reported with the file names
+  involved. `include` paths are not `${VAR}`-substituted, because which files
+  make up a config should not depend on who ran it.
 - `${VAR}` substitution in every value of `servicrab.toml`, so a committed
   config can serve checkouts that disagree about where things live:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 
 ## Features (v0.1)
 
-- Declare your entire local stack in a single `servicrab.toml`
+- Declare your entire local stack in one `servicrab.toml`, or split it across
+  files with `include`
+- `${VAR}` substitution in every config value, strict about unset variables
 - `servicrab init` — scaffold a config in seconds
 - `servicrab check` — validate your config before running anything
 - `servicrab list` — see all services and their restart policies at a glance
@@ -589,6 +591,51 @@ receives. (Values in `servicrab.toml` are — see
 unterminated quote or a line without `=` is a configuration error, reported by
 `servicrab check` with the file name and line number — the stack never starts
 with a half-loaded environment.
+
+---
+
+## Splitting a config across files
+
+A config that describes a dozen services is easier to live with in pieces, so
+`include` pulls services in from other files:
+
+```toml
+version = 1
+include = ["services/db.toml", "services/api.toml"]   # or a single path
+
+[project]
+name = "my-project"
+```
+
+```toml
+# services/db.toml
+[services.db]
+command = ["postgres", "-D", "data"]
+```
+
+An included file holds `[services.<name>]` tables and, if it likes, an
+`include` of its own. `version` and `[project]` stay in `servicrab.toml`: it is
+the file every command is pointed at, and the project name decides where the
+daemon keeps its socket.
+
+**Relative paths in an included file belong to that file.** Both its own
+`include` entries and the `cwd` and `env_file` of the services it declares
+resolve against its directory, so `services/db.toml` can say `cwd = "."` and
+mean `services/`, and a fragment can be moved together with the code it
+describes.
+
+Merging is not overriding. Each of these is a configuration error, reported by
+`servicrab check` with both file names:
+
+- two files declaring the same service — an `include` that quietly replaced a
+  service would be a fine way to spend an afternoon wondering which file is in
+  charge;
+- an `include` cycle, printed as the chain of files that closes it;
+- the same file included from two places;
+- `version` or `[project]` in an included file.
+
+`include` paths are not `${VAR}`-substituted, for the same reason the project
+name is not: which files make up a config should not depend on who ran it.
 
 ---
 

--- a/crates/servicrab-cli/src/commands/init.rs
+++ b/crates/servicrab-cli/src/commands/init.rs
@@ -21,6 +21,13 @@ name = "my-project"
 # [project.env]
 # RUST_LOG = "info"
 
+# ── Splitting this file up ────────────────────────────────────────────────────
+# Services may live in other files.  Paths are relative to this file; an
+# included file holds [services.*] tables (and may include further files), while
+# version and [project] stay here.  Relative paths inside an included file are
+# relative to *it*.
+# include = ["services/db.toml", "services/api.toml"]
+
 # ── Variables ─────────────────────────────────────────────────────────────────
 # Any value below may refer to the environment servicrab runs in:
 #   ${VAR}             the value; an error if VAR is not set

--- a/crates/servicrab-cli/tests/cli.rs
+++ b/crates/servicrab-cli/tests/cli.rs
@@ -198,6 +198,73 @@ fn list_json_output() {
     assert_eq!(first["restart"].as_str().unwrap(), "never");
 }
 
+// ── include ────────────────────────────────────────────────────────────────
+
+/// Write a root config that includes `services/db.toml`, plus that fragment.
+fn temp_dir_with_include(root_extra: &str, fragment: &str) -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join("services")).unwrap();
+    fs::write(dir.path().join("services/db.toml"), fragment).unwrap();
+
+    let path = dir.path().join("servicrab.toml");
+    let root = format!(
+        "version = 1\ninclude = [\"services/db.toml\"]\n[project]\nname = \"demo\"\n{root_extra}"
+    );
+    fs::write(&path, root).unwrap();
+    (dir, path)
+}
+
+#[test]
+fn an_included_service_is_part_of_the_stack() {
+    let (_dir, path) = temp_dir_with_include(
+        "[services.api]\ncommand = [\"echo\", \"api\"]\ndepends_on = [\"db\"]\n",
+        "[services.db]\ncommand = [\"echo\", \"db\"]\n",
+    );
+
+    cmd()
+        .arg("check")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .success()
+        .stdout(contains("db"))
+        .stdout(contains("api"));
+}
+
+#[test]
+fn a_relative_path_in_a_fragment_belongs_to_the_fragment() {
+    // `cwd = "."` in services/db.toml means the services directory, so that a
+    // fragment can be moved together with what it describes.
+    let (dir, path) =
+        temp_dir_with_include("", "[services.db]\ncommand = [\"pwd\"]\ncwd = \".\"\n");
+    let services = dir.path().join("services").canonicalize().unwrap();
+
+    cmd()
+        .arg("run")
+        .arg("db")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .success()
+        .stdout(contains(services.to_str().unwrap()));
+}
+
+#[test]
+fn a_missing_include_is_reported_with_both_files() {
+    let (_dir, path) = temp_dir_with_config(
+        "version = 1\ninclude = [\"services/db.toml\"]\n[project]\nname = \"demo\"\n",
+    );
+
+    cmd()
+        .arg("check")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .failure()
+        .stderr(contains("servicrab.toml"))
+        .stderr(contains("services/db.toml"));
+}
+
 // ── variable substitution ──────────────────────────────────────────────────
 
 /// The config a substitution test loads: one value from the environment, one

--- a/crates/servicrab-core/src/error.rs
+++ b/crates/servicrab-core/src/error.rs
@@ -28,6 +28,57 @@ pub enum ConfigError {
     #[error("could not discover servicrab.toml starting from {dir}")]
     ConfigNotFound { dir: PathBuf },
 
+    /// An included file could not be read.
+    #[error("{included_by} includes {path}, which could not be read: {source}")]
+    IncludeRead {
+        /// The file whose `include` names `path`.
+        included_by: PathBuf,
+        /// The path as resolved against the including file's directory.
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// An included file declares something only the root config may.
+    #[error("{path} is included by {included_by}, so it cannot declare {field}; that belongs in the config that includes it")]
+    IncludeNotAFragment {
+        /// The included file.
+        path: PathBuf,
+        /// The file whose `include` names `path`.
+        included_by: PathBuf,
+        /// `version` or `[project]`.
+        field: String,
+    },
+
+    /// The `include` graph contains a cycle.
+    #[error("include cycle detected: {cycle}")]
+    IncludeCycle {
+        /// The files that include each other, joined with ` -> `.
+        cycle: String,
+    },
+
+    /// The same file is included from two places.
+    #[error("{path} is included by both {first} and {second}; a file may only be included once")]
+    IncludeTwice {
+        /// The file included twice.
+        path: PathBuf,
+        /// The file that included it first.
+        first: PathBuf,
+        /// The file that included it again.
+        second: PathBuf,
+    },
+
+    /// Two files declare the same service.
+    #[error("service {service:?} is declared in both {first} and {second}")]
+    DuplicateService {
+        /// The service name declared twice.
+        service: String,
+        /// The file that declared it first.
+        first: PathBuf,
+        /// The file that declared it again.
+        second: PathBuf,
+    },
+
     /// The `version` field is not `1`.
     #[error("unsupported schema version {version}; only version 1 is supported")]
     UnsupportedVersion { version: u32 },

--- a/crates/servicrab-core/src/include.rs
+++ b/crates/servicrab-core/src/include.rs
@@ -1,0 +1,432 @@
+//! `include` — one config spread over several files.
+//!
+//! An included file is a *fragment*: `[services.<name>]` tables, and possibly
+//! an `include` of its own.  `version` and `[project]` stay in the root config,
+//! which is the only file the daemon is ever pointed at.
+//!
+//! Relative paths inside a fragment — its own `include`, and every `cwd` and
+//! `env_file` it declares — resolve against the fragment's own directory, so a
+//! fragment can live next to the code it describes and be moved with it.  That
+//! is why each service remembers the file it came from in
+//! [`RawService::origin`].
+//!
+//! Merging is not overriding: two files declaring the same service is an error.
+//! An `include` that silently replaced a service would be a fine way to spend
+//! an afternoon wondering which file is in charge.
+
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::error::ConfigError;
+use crate::raw::{RawConfig, RawFragment, RawInclude, RawService};
+
+/// Read every file `raw` includes, directly or transitively, and merge their
+/// services into it.
+///
+/// `root` is the path `raw` was parsed from.  All errors are collected: a typo
+/// in one fragment should not hide a typo in the next.
+pub(crate) fn merge(raw: &mut RawConfig, root: &Path) -> Vec<ConfigError> {
+    for service in raw.services.values_mut() {
+        service.origin = Some(root.to_path_buf());
+    }
+
+    let mut loader = Loader {
+        services: std::mem::take(&mut raw.services),
+        chain: vec![Ancestor {
+            identity: identity(root),
+            path: root.to_path_buf(),
+        }],
+        merged: BTreeMap::new(),
+        errors: Vec::new(),
+    };
+    loader.include(raw.include.take().as_ref(), root);
+
+    raw.services = loader.services;
+    loader.errors
+}
+
+struct Loader {
+    /// Every service seen so far, each remembering which file declared it.
+    services: BTreeMap<String, RawService>,
+    /// The files being read right now, outermost first.
+    chain: Vec<Ancestor>,
+    /// Every file already merged, and what included it.
+    merged: BTreeMap<PathBuf, PathBuf>,
+    errors: Vec<ConfigError>,
+}
+
+/// A file on the current include path.
+struct Ancestor {
+    /// What the file *is*, for comparison.
+    identity: PathBuf,
+    /// What the file was called, for the error message.
+    path: PathBuf,
+}
+
+impl Loader {
+    /// Follow the `include` of the file at `from`.
+    fn include(&mut self, include: Option<&RawInclude>, from: &Path) {
+        let dir = from.parent().unwrap_or(Path::new("."));
+        for relative in include.iter().flat_map(|include| include.paths()) {
+            self.one(&dir.join(relative), from);
+        }
+    }
+
+    /// Merge one included file, then whatever it includes in turn.
+    fn one(&mut self, path: &Path, included_by: &Path) {
+        let identity = identity(path);
+
+        if let Some(at) = self.chain.iter().position(|a| a.identity == identity) {
+            let mut cycle: Vec<String> = self.chain[at..]
+                .iter()
+                .map(|a| a.path.display().to_string())
+                .collect();
+            cycle.push(path.display().to_string());
+            self.errors.push(ConfigError::IncludeCycle {
+                cycle: cycle.join(" -> "),
+            });
+            return;
+        }
+
+        if let Some(first) = self.merged.get(&identity) {
+            self.errors.push(ConfigError::IncludeTwice {
+                path: path.to_path_buf(),
+                first: first.clone(),
+                second: included_by.to_path_buf(),
+            });
+            return;
+        }
+
+        let Some(fragment) = self.read(path, included_by) else {
+            return;
+        };
+        self.merged
+            .insert(identity.clone(), included_by.to_path_buf());
+
+        if fragment.version.is_some() {
+            self.not_a_fragment(path, included_by, "version");
+        }
+        if fragment.project.is_some() {
+            self.not_a_fragment(path, included_by, "[project]");
+        }
+
+        for (name, mut service) in fragment.services {
+            service.origin = Some(path.to_path_buf());
+            match self.services.entry(name) {
+                Entry::Vacant(entry) => {
+                    entry.insert(service);
+                }
+                Entry::Occupied(entry) => {
+                    // Every service in the map carries an origin by now: the
+                    // root's were stamped before the walk started.
+                    let first = entry.get().origin.clone().unwrap_or_default();
+                    self.errors.push(ConfigError::DuplicateService {
+                        service: entry.key().clone(),
+                        first,
+                        second: path.to_path_buf(),
+                    });
+                }
+            }
+        }
+
+        self.chain.push(Ancestor {
+            identity,
+            path: path.to_path_buf(),
+        });
+        self.include(fragment.include.as_ref(), path);
+        self.chain.pop();
+    }
+
+    fn read(&mut self, path: &Path, included_by: &Path) -> Option<RawFragment> {
+        let text = match std::fs::read_to_string(path) {
+            Ok(text) => text,
+            Err(source) => {
+                self.errors.push(ConfigError::IncludeRead {
+                    included_by: included_by.to_path_buf(),
+                    path: path.to_path_buf(),
+                    source,
+                });
+                return None;
+            }
+        };
+
+        match toml::from_str(&text) {
+            Ok(fragment) => Some(fragment),
+            Err(source) => {
+                self.errors.push(ConfigError::Parse {
+                    path: path.to_path_buf(),
+                    source,
+                });
+                None
+            }
+        }
+    }
+
+    fn not_a_fragment(&mut self, path: &Path, included_by: &Path, field: &str) {
+        self.errors.push(ConfigError::IncludeNotAFragment {
+            path: path.to_path_buf(),
+            included_by: included_by.to_path_buf(),
+            field: field.to_string(),
+        });
+    }
+}
+
+/// What a path *is*, so that `./a.toml`, `a.toml` and `b/../a.toml` are one
+/// file and a cycle through a symlink is still a cycle.
+///
+/// Falls back to the path as written when it cannot be resolved — a file that
+/// does not exist is about to be reported as unreadable anyway.
+fn identity(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Write `files` into a fresh directory and merge the includes of the first
+    /// one, which is the root config.
+    fn merge_files(files: &[(&str, &str)]) -> (TempDir, RawConfig, Vec<ConfigError>) {
+        let dir = TempDir::new().unwrap();
+        for (name, contents) in files {
+            let path = dir.path().join(name);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, contents).unwrap();
+        }
+
+        let root = dir.path().join(files[0].0);
+        let mut raw: RawConfig = toml::from_str(files[0].1).expect("the root config parses");
+        let errors = merge(&mut raw, &root);
+        (dir, raw, errors)
+    }
+
+    /// Merge, expecting success.
+    fn ok(files: &[(&str, &str)]) -> (TempDir, RawConfig) {
+        let (dir, raw, errors) = merge_files(files);
+        assert!(
+            errors.is_empty(),
+            "{:?}",
+            errors.iter().map(ToString::to_string).collect::<Vec<_>>()
+        );
+        (dir, raw)
+    }
+
+    /// Merge, expecting exactly one error.
+    fn one_error(files: &[(&str, &str)]) -> ConfigError {
+        let (_dir, _raw, mut errors) = merge_files(files);
+        assert_eq!(
+            errors.len(),
+            1,
+            "{:?}",
+            errors.iter().map(ToString::to_string).collect::<Vec<_>>()
+        );
+        errors.remove(0)
+    }
+
+    const ROOT: &str = r#"
+version = 1
+include = ["services/db.toml"]
+[project]
+name = "demo"
+"#;
+
+    const DB: &str = r#"
+[services.db]
+command = ["postgres"]
+"#;
+
+    #[test]
+    fn an_included_service_joins_the_config() {
+        let (dir, raw) = ok(&[("servicrab.toml", ROOT), ("services/db.toml", DB)]);
+
+        assert_eq!(raw.services.keys().collect::<Vec<_>>(), ["db"]);
+        assert_eq!(
+            raw.services["db"].origin.as_deref(),
+            Some(dir.path().join("services/db.toml").as_path()),
+            "the service should remember the file it came from"
+        );
+        assert!(
+            raw.include.is_none(),
+            "the include should be spent, not left for validation to trip over"
+        );
+    }
+
+    #[test]
+    fn a_single_path_needs_no_list() {
+        let root = "version = 1\ninclude = \"services/db.toml\"\n[project]\nname = \"demo\"\n";
+        let (_dir, raw) = ok(&[("servicrab.toml", root), ("services/db.toml", DB)]);
+
+        assert_eq!(raw.services.keys().collect::<Vec<_>>(), ["db"]);
+    }
+
+    #[test]
+    fn a_fragment_may_include_further_files() {
+        let db = "include = [\"cache.toml\"]\n[services.db]\ncommand = [\"postgres\"]\n";
+        let cache = "[services.cache]\ncommand = [\"redis-server\"]\n";
+        let (dir, raw) = ok(&[
+            ("servicrab.toml", ROOT),
+            ("services/db.toml", db),
+            ("services/cache.toml", cache),
+        ]);
+
+        assert_eq!(raw.services.keys().collect::<Vec<_>>(), ["cache", "db"]);
+        assert_eq!(
+            raw.services["cache"].origin.as_deref(),
+            Some(dir.path().join("services/cache.toml").as_path()),
+            "a nested include resolves against the fragment, not the root"
+        );
+    }
+
+    #[test]
+    fn the_root_keeps_its_own_services() {
+        let root = format!("{ROOT}[services.api]\ncommand = [\"api\"]\n");
+        let (dir, raw) = ok(&[("servicrab.toml", &root), ("services/db.toml", DB)]);
+
+        assert_eq!(raw.services.keys().collect::<Vec<_>>(), ["api", "db"]);
+        assert_eq!(
+            raw.services["api"].origin.as_deref(),
+            Some(dir.path().join("servicrab.toml").as_path())
+        );
+    }
+
+    #[test]
+    fn two_files_may_not_declare_the_same_service() {
+        let root = format!("{ROOT}[services.db]\ncommand = [\"postgres\"]\n");
+        let err = one_error(&[("servicrab.toml", &root), ("services/db.toml", DB)]);
+
+        assert!(
+            matches!(&err, ConfigError::DuplicateService { service, first, second }
+                if service == "db"
+                    && first.ends_with("servicrab.toml")
+                    && second.ends_with("services/db.toml")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_missing_include_names_who_asked_for_it() {
+        let err = one_error(&[("servicrab.toml", ROOT)]);
+
+        assert!(
+            matches!(&err, ConfigError::IncludeRead { included_by, path, .. }
+                if included_by.ends_with("servicrab.toml")
+                    && path.ends_with("services/db.toml")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_fragment_with_broken_toml_is_reported_against_the_fragment() {
+        let err = one_error(&[
+            ("servicrab.toml", ROOT),
+            ("services/db.toml", "not ][ toml"),
+        ]);
+
+        assert!(
+            matches!(&err, ConfigError::Parse { path, .. } if path.ends_with("services/db.toml")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_fragment_may_not_declare_the_project() {
+        let db = format!("[project]\nname = \"other\"\n{DB}");
+        let err = one_error(&[("servicrab.toml", ROOT), ("services/db.toml", &db)]);
+
+        assert!(
+            matches!(&err, ConfigError::IncludeNotAFragment { field, path, .. }
+                if field == "[project]" && path.ends_with("services/db.toml")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_fragment_may_not_declare_a_version() {
+        let db = format!("version = 1\n{DB}");
+        let err = one_error(&[("servicrab.toml", ROOT), ("services/db.toml", &db)]);
+
+        assert!(
+            matches!(&err, ConfigError::IncludeNotAFragment { field, .. } if field == "version"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_field_in_a_fragment_is_still_a_typo() {
+        let err = one_error(&[
+            ("servicrab.toml", ROOT),
+            ("services/db.toml", "servcies = {}\n"),
+        ]);
+
+        let ConfigError::Parse { source, .. } = &err else {
+            panic!("expected a parse error, got {err}");
+        };
+        assert!(source.to_string().contains("servcies"), "{source}");
+    }
+
+    #[test]
+    fn a_file_that_includes_itself_is_a_cycle() {
+        let db = format!("include = [\"db.toml\"]\n{DB}");
+        let err = one_error(&[("servicrab.toml", ROOT), ("services/db.toml", &db)]);
+
+        let ConfigError::IncludeCycle { cycle } = &err else {
+            panic!("expected a cycle, got {err}");
+        };
+        assert_eq!(cycle.matches("db.toml").count(), 2, "{cycle}");
+    }
+
+    #[test]
+    fn a_cycle_back_to_the_root_is_a_cycle() {
+        let db = format!("include = [\"../servicrab.toml\"]\n{DB}");
+        let err = one_error(&[("servicrab.toml", ROOT), ("services/db.toml", &db)]);
+
+        let ConfigError::IncludeCycle { cycle } = &err else {
+            panic!("expected a cycle, got {err}");
+        };
+        assert!(cycle.contains("servicrab.toml"), "{cycle}");
+        assert!(cycle.contains("db.toml"), "{cycle}");
+    }
+
+    #[test]
+    fn a_file_reached_twice_is_reported_once_and_clearly() {
+        // A diamond: two fragments include the same third file.  Its services
+        // would otherwise collide with themselves.
+        let root = "version = 1\ninclude = [\"a.toml\", \"b.toml\"]\n[project]\nname = \"demo\"\n";
+        let side = "include = [\"shared.toml\"]\n";
+        let err = one_error(&[
+            ("servicrab.toml", root),
+            ("a.toml", side),
+            ("b.toml", side),
+            ("shared.toml", DB),
+        ]);
+
+        assert!(
+            matches!(&err, ConfigError::IncludeTwice { path, first, second }
+                if path.ends_with("shared.toml")
+                    && first.ends_with("a.toml")
+                    && second.ends_with("b.toml")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn every_broken_fragment_is_reported_at_once() {
+        // `b.toml` is missing entirely, which must not hide the typo in
+        // `a.toml`: one `servicrab check` should list both.
+        let root = "version = 1\ninclude = [\"a.toml\", \"b.toml\"]\n[project]\nname = \"demo\"\n";
+        let (_dir, _raw, errors) = merge_files(&[("servicrab.toml", root), ("a.toml", "not ][")]);
+
+        let messages: Vec<String> = errors.iter().map(ToString::to_string).collect();
+        assert_eq!(messages.len(), 2, "{messages:?}");
+        assert!(
+            matches!(errors[0], ConfigError::Parse { .. }),
+            "{messages:?}"
+        );
+        assert!(
+            matches!(errors[1], ConfigError::IncludeRead { .. }),
+            "{messages:?}"
+        );
+    }
+}

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -10,17 +10,15 @@
 //! ## Usage
 //!
 //! 1. Discover or specify the path to `servicrab.toml`.
-//! 2. Call [`load::load`] to read, parse, and validate the file.
+//! 2. Call [`load::load`] to read, parse, and validate the file — including
+//!    any files it pulls in with `include`.
 //! 3. Use the resulting [`config::Config`] as the runtime configuration.
-//!
-//! ## Not implemented yet
-//!
-//! - `include` directives, to split a large config across several files.
 
 pub mod config;
 pub mod envfile;
 pub mod error;
 pub mod graph;
+mod include;
 pub mod lifecycle;
 pub mod load;
 pub mod raw;

--- a/crates/servicrab-core/src/load.rs
+++ b/crates/servicrab-core/src/load.rs
@@ -30,7 +30,8 @@ pub fn discover_config(start_dir: &Path) -> Result<PathBuf, ConfigError> {
     })
 }
 
-/// Read, parse, and validate a `servicrab.toml` from the given path.
+/// Read, parse, and validate a `servicrab.toml` from the given path, following
+/// any `include` it declares.
 ///
 /// Returns the validated [`Config`] and any non-fatal [`ConfigWarning`]s, or
 /// a list of [`ConfigError`]s that prevented successful loading.
@@ -42,12 +43,19 @@ pub fn load(path: &Path) -> Result<(Config, Vec<ConfigWarning>), Vec<ConfigError
         }]
     })?;
 
-    let raw: RawConfig = toml::from_str(&raw_str).map_err(|e| {
+    let mut raw: RawConfig = toml::from_str(&raw_str).map_err(|e| {
         vec![ConfigError::Parse {
             path: path.to_path_buf(),
             source: e,
         }]
     })?;
+
+    // Fatal on its own: validating half a config would report services as
+    // missing when they are merely in a file that could not be read.
+    let include_errors = crate::include::merge(&mut raw, path);
+    if !include_errors.is_empty() {
+        return Err(include_errors);
+    }
 
     validate_raw(raw, path)
 }

--- a/crates/servicrab-core/src/raw.rs
+++ b/crates/servicrab-core/src/raw.rs
@@ -8,6 +8,7 @@
 //! names produce a hard error rather than being silently ignored.
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use serde::Deserialize;
 
@@ -18,12 +19,61 @@ pub struct RawConfig {
     /// Schema version; must be `1`.
     pub version: u32,
 
+    /// Other files whose services belong to this config.  Emptied by
+    /// [`crate::load::load`], which merges what they declare into `services`.
+    #[serde(default)]
+    pub include: Option<RawInclude>,
+
     /// Project-level metadata.
     pub project: RawProject,
 
     /// Service definitions.  The outer `BTreeMap` key is the service name.
     #[serde(default)]
     pub services: BTreeMap<String, RawService>,
+}
+
+/// An included file: services, and possibly further includes.
+///
+/// `version` and `[project]` are the root config's business, so they are named
+/// here only to be rejected with a message that says where they belong.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawFragment {
+    /// Files this one includes in turn.
+    #[serde(default)]
+    pub include: Option<RawInclude>,
+
+    /// Service definitions.
+    #[serde(default)]
+    pub services: BTreeMap<String, RawService>,
+
+    /// Set when the file declares `version`.
+    #[serde(default)]
+    pub version: Option<serde::de::IgnoredAny>,
+
+    /// Set when the file declares `[project]`.
+    #[serde(default)]
+    pub project: Option<serde::de::IgnoredAny>,
+}
+
+/// One path or a list of paths, as accepted by `include`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum RawInclude {
+    /// `include = "services/db.toml"`
+    One(String),
+    /// `include = ["services/db.toml", "services/api.toml"]`
+    Many(Vec<String>),
+}
+
+impl RawInclude {
+    /// The declared paths, in declaration order.
+    pub fn paths(&self) -> &[String] {
+        match self {
+            RawInclude::One(p) => std::slice::from_ref(p),
+            RawInclude::Many(ps) => ps,
+        }
+    }
 }
 
 /// Raw project metadata (`[project]`).
@@ -181,11 +231,17 @@ pub struct RawDependency {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RawService {
+    /// Which file declared this service, filled in by [`crate::load::load`]
+    /// rather than by TOML: with `include`, the file a service came from is
+    /// what its relative paths resolve against.
+    #[serde(skip)]
+    pub origin: Option<PathBuf>,
+
     /// Command to execute: first element is the executable, rest are arguments.
     pub command: Vec<String>,
 
-    /// Working directory (relative paths are resolved against the config
-    /// file's parent directory by the validation layer).
+    /// Working directory (relative paths are resolved against the parent
+    /// directory of the file that declared the service).
     #[serde(default)]
     pub cwd: Option<String>,
 

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -135,8 +135,17 @@ pub fn validate_raw(
             continue;
         }
 
+        // With `include`, a service's relative paths belong to the file that
+        // declared it, so that a fragment can be moved with the directory it
+        // describes.  Without one, that file is the config itself.
+        let svc_dir = raw_svc
+            .origin
+            .as_deref()
+            .map(resolve_source_dir)
+            .unwrap_or_else(|| source_dir.clone());
+
         // cwd
-        let cwd = resolve_cwd(raw_svc.cwd.as_deref(), &source_dir, raw_name, &mut errors);
+        let cwd = resolve_cwd(raw_svc.cwd.as_deref(), &svc_dir, raw_name, &mut errors);
 
         // Service env
         let svc_env = validate_service_env(&raw_svc.env, raw_name, &mut errors);
@@ -144,7 +153,7 @@ pub fn validate_raw(
         // Service env files
         let (svc_env_files, svc_file_env) = load_env_files(
             raw_svc.env_file.as_ref(),
-            &source_dir,
+            &svc_dir,
             &format!("service {raw_name:?}"),
             &mut errors,
         );
@@ -1719,6 +1728,7 @@ command = ["echo"]
         // validation function directly.
         let raw = crate::raw::RawConfig {
             version: 1,
+            include: None,
             project: crate::raw::RawProject {
                 logs: None,
                 name: "p".into(),
@@ -1730,6 +1740,7 @@ command = ["echo"]
                 m.insert(
                     "s".to_string(),
                     crate::raw::RawService {
+                        origin: None,
                         command: vec!["exe\0cutable".to_string()],
                         cwd: None,
                         env: Default::default(),
@@ -2418,6 +2429,7 @@ restart_delay = "2s"
         services.insert(
             "s".to_string(),
             RawService {
+                origin: None,
                 command: vec!["echo".to_string()],
                 cwd: None,
                 env: env.into_iter().collect(),
@@ -2438,6 +2450,7 @@ restart_delay = "2s"
         );
         RawConfig {
             version: 1,
+            include: None,
             project: crate::raw::RawProject {
                 logs: None,
                 name: "p".into(),


### PR DESCRIPTION
## Summary

A stack of a dozen services had to live in one `servicrab.toml`. Now it can be
split up:

```toml
version = 1
include = ["services/db.toml", "services/api.toml"]   # or a single path

[project]
name = "my-project"
```

An included file holds `[services.<name>]` tables and may include further
files. Three decisions worth reviewing:

- **Relative paths in an included file belong to that file** — its own
  `include` entries, and the `cwd` and `env_file` of the services it declares.
  So `services/db.toml` can say `cwd = "."` and mean `services/`, and a
  fragment can be moved with the code it describes. This is Compose's rule, and
  it is the only one consistent with how the `include` paths themselves
  resolve. It is why `RawService` grew an `origin`, which is also what the
  duplicate-service error uses to name the file.
- **`version` and `[project]` stay in the root config.** It is the file every
  command is pointed at, and the project name decides where the daemon keeps
  its socket, so it cannot be something a fragment argues about. A fragment
  that declares either gets an error saying where it belongs, rather than
  serde's "unknown field".
- **Merging is not overriding.** Each of these is an error naming the files
  involved: the same service declared twice, an `include` cycle (printed as the
  chain that closes it), the same file included from two places, and the two
  root-only keys above. An include that quietly replaced a service would be a
  fine way to spend an afternoon wondering which file is in charge.

`include` paths are not `${VAR}`-substituted, for the same reason the project
name is not: which files make up a config should not depend on who ran it.

Includes are resolved in `load()`, so every command gets them, `servicrab
reload` included.

## Test plan

- [x] Unit tests in `include.rs`: a fragment's services join the config with
      the right origin, a single path needs no list, a fragment may include
      further files (resolved against itself), the root keeps its own services.
- [x] One test per failure mode: duplicate service, missing include (naming
      both files), broken TOML reported against the fragment, `version` and
      `[project]` in a fragment, a typo in a fragment still being a typo, a
      file including itself, a cycle back to the root, a diamond, and several
      broken fragments reported at once.
- [x] End-to-end: `check` accepts an included service and orders it,
      `run` proves `cwd = "."` in a fragment means the fragment's directory,
      and a missing include fails `check` naming both files.
- [x] `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, full suite
      (234 unit + all integration targets).