### PR TITLE
Add profiles, so optional services stay out until asked for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Profiles, for the services you only sometimes want:
+
+  ```toml
+  [services.mailhog]
+  command = ["mailhog"]
+  profiles = ["dev"]
+  ```
+
+  A service that declares no profiles is always started; one that declares any
+  waits for `servicrab up --profile dev` (or `start`, `watch`, and `generate`,
+  which writes the flag into the unit it produces). Several `--profile` flags
+  add up, and a service in several profiles joins when any one of them is
+  enabled. `servicrab list` shows the groups, in the table and in `--json`.
+
+  Naming a service starts it whatever its profiles say, so a profiled service
+  never needs the flag to be targeted directly. Because that makes explicit
+  names a second way of selecting, passing both is refused rather than silently
+  resolved in favour of one.
+
+  Dependencies come along regardless of their profiles: a service can never run
+  without what it declares in `depends_on`. The daemon keeps the profiles it was
+  started with, so `servicrab reload` re-plans the same stack instead of the
+  smaller one a bare `start` would have produced. A `--profile` no service
+  declares is an error listing the ones that exist.
 - `include`, so a stack of a dozen services does not have to live in one file:
 
   ```toml

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 
 - Declare your entire local stack in one `servicrab.toml`, or split it across
   files with `include`
+- Profiles: group the optional services and ask for them with `--profile`
 - `${VAR}` substitution in every config value, strict about unset variables
 - `servicrab init` — scaffold a config in seconds
 - `servicrab check` — validate your config before running anything
@@ -318,10 +319,12 @@ set, or when `TERM=dumb`.
 
 ### Which services are started
 
-- with no arguments: every service with `autostart = true`;
+- with no arguments: every service with `autostart = true` that no profile
+  holds back (see [Profiles](#profiles));
 - with explicit names: those services only;
-- in both cases every transitive `depends_on` entry is pulled in, even when it
-  has `autostart = false`.
+- with `--profile NAME`: the above, plus the services in that profile;
+- in every case each transitive `depends_on` entry is pulled in, even when it
+  has `autostart = false` or sits in a profile of its own.
 
 ### Start and stop ordering
 
@@ -591,6 +594,58 @@ receives. (Values in `servicrab.toml` are — see
 unterminated quote or a line without `=` is a configuration error, reported by
 `servicrab check` with the file name and line number — the stack never starts
 with a half-loaded environment.
+
+---
+
+## Profiles
+
+Most repositories have more than one "everything": the services you always
+want, and the extras you only sometimes do. `profiles` puts a service in a
+group that has to be asked for by name:
+
+```toml
+[services.api]
+command = ["node", "server.js"]        # no profiles: always part of the stack
+
+[services.mailhog]
+command = ["mailhog"]
+profiles = ["dev"]
+
+[services.seeder]
+command = ["./seed.sh"]
+profiles = ["dev", "test"]             # any one of them is enough
+```
+
+```sh
+servicrab up                           # api
+servicrab up --profile dev             # api, mailhog, seeder
+servicrab up --profile test            # api, seeder
+servicrab up --profile dev --profile test
+servicrab start --profile dev          # same, in the background
+servicrab list                         # shows each service's profiles
+```
+
+A service that declares no profiles is always started; one that declares any
+waits to be asked. Naming a service starts it whatever its profiles say, so
+`servicrab up mailhog` needs no flag — and because that is a second way of
+saying which services to start, naming services and passing `--profile` in one
+command is refused rather than silently resolved.
+
+Two things follow from profiles selecting what to start *on its own*:
+
+- **Dependencies come along regardless.** If an always-on service depends on a
+  profiled one, the profiled one is started too — a service can never run
+  without what it declares in `depends_on`. Put the dependent in the profile as
+  well if it should stay out.
+- **The daemon remembers.** `servicrab start --profile dev` records the set for
+  the lifetime of the daemon, so `servicrab reload` re-plans that stack rather
+  than the smaller one a bare `start` would have produced.
+  `servicrab generate systemd --profile dev` writes the flag into the unit for
+  the same reason.
+
+A `--profile` no service declares is an error listing the ones that exist,
+because a typo that silently started less than you asked for is the kind of
+thing you notice an hour later.
 
 ---
 

--- a/crates/servicrab-cli/src/commands/check.rs
+++ b/crates/servicrab-cli/src/commands/check.rs
@@ -1,8 +1,9 @@
 //! `servicrab check [--config PATH]` — load and validate a `servicrab.toml`.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
-use servicrab_core::{load, resolve_config_path};
+use servicrab_core::{load, resolve_config_path, Config};
 
 /// Run the `check` subcommand.
 pub fn run(config: Option<&Path>) -> Result<(), String> {
@@ -20,6 +21,12 @@ pub fn run(config: Option<&Path>) -> Result<(), String> {
 
             let order: Vec<&str> = cfg.start_order.iter().map(|n| n.as_str()).collect();
             println!("  start order: {}", order.join(" → "));
+
+            // The order above lists every service, profiled ones included, so
+            // say which of them wait to be asked for.
+            for line in profile_lines(&cfg) {
+                println!("  {line}");
+            }
 
             if !warnings.is_empty() {
                 println!("  {} warning(s):", warnings.len());
@@ -40,4 +47,24 @@ pub fn run(config: Option<&Path>) -> Result<(), String> {
             ))
         }
     }
+}
+
+/// One line per profile, naming the services it holds. Empty when the config
+/// uses no profiles.
+fn profile_lines(cfg: &Config) -> Vec<String> {
+    let mut members: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for name in &cfg.start_order {
+        let service = &cfg.services[name];
+        for profile in &service.profiles {
+            members
+                .entry(profile.as_str())
+                .or_default()
+                .push(name.as_str());
+        }
+    }
+
+    members
+        .into_iter()
+        .map(|(profile, services)| format!("profile {profile}: {}", services.join(", ")))
+        .collect()
 }

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -6,7 +6,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use servicrab_core::{load, resolve_config_path, Config};
+use servicrab_core::{load, resolve_config_path, Config, Selection};
 
 use crate::daemon::DaemonPaths;
 
@@ -67,22 +67,30 @@ mod imp {
     use crate::style::{self, BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
     /// Run the daemon in the foreground (this is the process `start` spawns).
-    pub fn daemon(config: Option<&Path>, no_restart: bool) -> Result<i32, String> {
+    pub fn daemon(
+        config: Option<&Path>,
+        no_restart: bool,
+        profiles: &[String],
+    ) -> Result<i32, String> {
         let (cfg, config_path, paths) = setup(config)?;
         server::serve(
             &cfg,
             &config_path,
             &paths,
-            server::DaemonOptions { no_restart },
+            server::DaemonOptions {
+                no_restart,
+                profiles: profiles.to_vec(),
+            },
         )
     }
 
     /// Start the daemon, or individual services inside a running one.
     pub fn start(
         config: Option<&Path>,
-        services: &[String],
+        selection: Selection<'_>,
         options: StartOptions,
     ) -> Result<i32, String> {
+        let services = selection.services;
         if !services.is_empty() {
             let code = control(config, services, |name| Request::StartService { name })?;
             if code != 0 || !options.wait {
@@ -123,6 +131,11 @@ mod imp {
             .stderr(errors);
         if options.no_restart {
             command.arg("--no-restart");
+        }
+        // The daemon process is where the profiles have to live: `reload`
+        // re-plans the stack, and it has to plan the one that was started.
+        for profile in selection.profiles {
+            command.arg("--profile").arg(profile);
         }
         // A new session detaches the daemon from this terminal, so Ctrl+C here
         // no longer reaches it and it survives the shell that started it.
@@ -538,13 +551,17 @@ mod imp {
 
     const UNSUPPORTED: &str = "the background daemon is only supported on Linux and macOS";
 
-    pub fn daemon(_config: Option<&Path>, _no_restart: bool) -> Result<i32, String> {
+    pub fn daemon(
+        _config: Option<&Path>,
+        _no_restart: bool,
+        _profiles: &[String],
+    ) -> Result<i32, String> {
         Err(UNSUPPORTED.to_string())
     }
 
     pub fn start(
         _config: Option<&Path>,
-        _services: &[String],
+        _selection: Selection<'_>,
         _options: StartOptions,
     ) -> Result<i32, String> {
         Err(UNSUPPORTED.to_string())

--- a/crates/servicrab-cli/src/commands/generate.rs
+++ b/crates/servicrab-cli/src/commands/generate.rs
@@ -44,6 +44,8 @@ pub struct GenerateOptions {
     pub output: Option<PathBuf>,
     /// Account the daemon should run as (system scope only).
     pub user: Option<String>,
+    /// Profiles the generated unit should start with.
+    pub profiles: Vec<String>,
 }
 
 /// Everything a unit template needs that does not come from the config.
@@ -59,6 +61,19 @@ struct Context {
     user: Option<String>,
     /// How long the init system should wait for a clean stop.
     stop_timeout: Duration,
+    /// Profiles to put on the daemon's command line.
+    profiles: Vec<String>,
+}
+
+impl Context {
+    /// The `--profile` arguments the unit has to pass on, as one string ready
+    /// to append to a command line.
+    fn profile_flags(&self) -> String {
+        self.profiles
+            .iter()
+            .map(|profile| format!(" --profile {profile}"))
+            .collect()
+    }
 }
 
 /// Extra time on top of the slowest service's shutdown timeout, so the init
@@ -95,6 +110,7 @@ pub fn run(target: Target, config: Option<&Path>, options: GenerateOptions) -> R
         scope: options.scope,
         user: options.user.clone(),
         stop_timeout: stop_timeout(&cfg),
+        profiles: options.profiles.clone(),
     };
 
     let unit = match target {
@@ -181,7 +197,10 @@ fn systemd_unit(cfg: &Config, context: &Context) -> String {
         "WorkingDirectory={}\n",
         quote_systemd(&context.working_dir)
     ));
-    unit.push_str(&format!("ExecStart={program} daemon --config {config}\n"));
+    unit.push_str(&format!(
+        "ExecStart={program} daemon --config {config}{}\n",
+        context.profile_flags()
+    ));
     // `systemctl reload` picks up config changes without stopping services
     // that did not change.
     unit.push_str(&format!("ExecReload={program} reload --config {config}\n"));
@@ -234,12 +253,20 @@ fn launchd_plist(cfg: &Config, context: &Context) -> String {
         escape_xml(&label)
     ));
     plist.push_str("\t<key>ProgramArguments</key>\n\t<array>\n");
-    for argument in [
+    let arguments = [
         context.program.display().to_string(),
         "daemon".to_string(),
         "--config".to_string(),
         context.config.display().to_string(),
-    ] {
+    ]
+    .into_iter()
+    .chain(
+        context
+            .profiles
+            .iter()
+            .flat_map(|profile| ["--profile".to_string(), profile.clone()]),
+    );
+    for argument in arguments {
         plist.push_str(&format!("\t\t<string>{}</string>\n", escape_xml(&argument)));
     }
     plist.push_str("\t</array>\n");
@@ -371,6 +398,7 @@ command = ["/usr/bin/api"]
             working_dir: PathBuf::from("/srv/demo"),
             scope: Scope::System,
             user: None,
+            profiles: Vec::new(),
             stop_timeout: Duration::from_secs(30),
         }
     }

--- a/crates/servicrab-cli/src/commands/init.rs
+++ b/crates/servicrab-cli/src/commands/init.rs
@@ -66,6 +66,9 @@ name = "my-project"
 #                 with a condition: { db = { condition = "service_healthy" } }
 #                 Conditions: service_started | service_healthy |
 #                 service_completed_successfully (the last one is for migrations)
+#   profiles      Groups this service belongs to, e.g. ["dev"].  A service with
+#                 profiles only starts when a command enables one of them
+#                 (`servicrab up --profile dev`); without any, it always starts
 #   autostart     Whether to start automatically (default: true)
 #   restart       never | on-failure | always  (default: never)
 #   restart_delay         Minimum backoff before first restart (default: 1s)

--- a/crates/servicrab-cli/src/commands/list.rs
+++ b/crates/servicrab-cli/src/commands/list.rs
@@ -36,6 +36,8 @@ struct ServiceJson<'a> {
     command: Vec<&'a str>,
     cwd: String,
     depends_on: Vec<DependencyJson<'a>>,
+    /// Empty for a service that is part of every run.
+    profiles: Vec<&'a str>,
     autostart: bool,
     restart: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,6 +66,7 @@ fn print_json(services: &std::collections::BTreeMap<ServiceName, Service>) {
                 command: cmd,
                 cwd: svc.cwd.display().to_string(),
                 depends_on: dependencies(svc, services),
+                profiles: svc.profiles.iter().map(String::as_str).collect(),
                 autostart: svc.autostart,
                 restart: match svc.restart {
                     servicrab_core::RestartPolicy::Never => "never",
@@ -137,6 +140,9 @@ fn print_table(services: &std::collections::BTreeMap<ServiceName, Service>, proj
                 .map(|dep| format!("{} ({})", dep.service, dep.condition))
                 .collect();
             println!("  depends on: {}", deps.join(", "));
+        }
+        if !svc.profiles.is_empty() {
+            println!("  profiles: {}", svc.profiles.join(", "));
         }
         if let Some(health) = &svc.health {
             println!(

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -15,7 +15,8 @@ use servicrab_core::runtime::stack::{
 };
 use servicrab_core::{
     event_channel, load, plan_stack, resolve_config_path, spawn_watchers, watched_services, Config,
-    EventKind, EventReceiver, LogRouter, ServiceName, ShutdownReason, SignalWatcher, Stream,
+    EventKind, EventReceiver, LogRouter, Selection, ServiceName, ShutdownReason, SignalWatcher,
+    Stream,
 };
 
 use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
@@ -45,7 +46,11 @@ pub struct UpOptions {
 }
 
 /// Run the `up` subcommand, returning the process exit code to use.
-pub fn run(services: &[String], config: Option<&Path>, options: UpOptions) -> Result<i32, String> {
+pub fn run(
+    selection: Selection<'_>,
+    config: Option<&Path>,
+    options: UpOptions,
+) -> Result<i32, String> {
     let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
 
     let (cfg, warnings) = load(&path).map_err(|errors| {
@@ -62,13 +67,7 @@ pub fn run(services: &[String], config: Option<&Path>, options: UpOptions) -> Re
         eprintln!("⚠  {warning}");
     }
 
-    let plan = plan_stack(&cfg, services).map_err(|e| e.to_string())?;
-    if plan.is_empty() {
-        return Err(
-            "no services to start: none of the configured services have autostart = true"
-                .to_string(),
-        );
-    }
+    let plan = plan_stack(&cfg, selection).map_err(|e| e.to_string())?;
 
     let watched = watched_services(&cfg, &plan);
     if options.require_watch && watched.is_empty() {

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -30,10 +30,22 @@ const STREAM_BACKLOG: usize = 4096;
 const COLLECTOR_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Options for the daemon body.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct DaemonOptions {
     /// Never restart services, whatever their configured policy says.
     pub no_restart: bool,
+    /// Profiles this daemon supervises.  Kept for the lifetime of the process,
+    /// because a reload has to plan the same stack that was started.
+    pub profiles: Vec<String>,
+}
+
+impl DaemonOptions {
+    fn selection(&self) -> servicrab_core::Selection<'_> {
+        servicrab_core::Selection {
+            services: &[],
+            profiles: &self.profiles,
+        }
+    }
 }
 
 /// Everything the socket side of the daemon may touch.
@@ -51,6 +63,9 @@ struct Session {
     project: String,
     /// Where the configuration was loaded from, so it can be re-read.
     config_path: PathBuf,
+    /// The profiles this daemon was started with: a reload has to plan the same
+    /// stack, or it would quietly drop or adopt services nobody asked about.
+    profiles: Vec<String>,
     /// Kept so reloads can rebuild the watchers.  It is dropped when the
     /// daemon stops, which is what lets the collector task finish: it ends
     /// when the last event sender is gone.
@@ -132,13 +147,7 @@ pub fn serve(
     paths: &DaemonPaths,
     options: DaemonOptions,
 ) -> Result<i32, String> {
-    let plan = plan_stack(cfg, &[]).map_err(|e| e.to_string())?;
-    if plan.is_empty() {
-        return Err(
-            "no services to start: none of the configured services have autostart = true"
-                .to_string(),
-        );
-    }
+    let plan = plan_stack(cfg, options.selection()).map_err(|e| e.to_string())?;
 
     paths.ensure_dir()?;
     // A socket file always survives its daemon, so a stale one is only an
@@ -207,6 +216,7 @@ pub fn serve(
             names: Mutex::new(plan.clone()),
             project: project.clone(),
             config_path: config_path.to_path_buf(),
+            profiles: options.profiles.clone(),
             events: Mutex::new(Some(events_tx.clone())),
             stream: stream_tx,
             watchers: Mutex::new(Vec::new()),
@@ -473,7 +483,11 @@ async fn reload(session: &Session) -> Response {
         tracing::warn!("{warning}");
     }
 
-    let plan = match plan_stack(&cfg, &[]) {
+    let selection = servicrab_core::Selection {
+        services: &[],
+        profiles: &session.profiles,
+    };
+    let plan = match plan_stack(&cfg, selection) {
         Ok(plan) => plan,
         Err(err) => {
             return Response::Error {
@@ -481,11 +495,6 @@ async fn reload(session: &Session) -> Response {
             }
         }
     };
-    if plan.is_empty() {
-        return Response::Error {
-            message: "no services would be left running: none have autostart = true".to_string(),
-        };
-    }
 
     // The registry is updated first so that events from services the reload
     // adds are not dropped for lack of an entry.

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -112,6 +112,11 @@ enum Commands {
         #[arg(long, short = 'c')]
         config: Option<std::path::PathBuf>,
 
+        /// Also start the services in this profile.  Repeatable.  Cannot be
+        /// combined with naming services.
+        #[arg(long = "profile", value_name = "NAME", conflicts_with = "services")]
+        profiles: Vec<String>,
+
         /// Never restart services, whatever their configured policy says.
         #[arg(long, default_value_t = false)]
         no_restart: bool,
@@ -146,6 +151,11 @@ enum Commands {
         /// servicrab.toml by walking up from the current directory.
         #[arg(long, short = 'c')]
         config: Option<std::path::PathBuf>,
+
+        /// Also start the services in this profile.  Repeatable.  Cannot be
+        /// combined with naming services.
+        #[arg(long = "profile", value_name = "NAME", conflicts_with = "services")]
+        profiles: Vec<String>,
 
         /// Never restart services, whatever their configured policy says.
         #[arg(long, default_value_t = false)]
@@ -206,6 +216,12 @@ enum Commands {
         /// servicrab.toml by walking up from the current directory.
         #[arg(long, short = 'c')]
         config: Option<std::path::PathBuf>,
+
+        /// Also supervise the services in this profile.  Repeatable.  The
+        /// daemon keeps the set, so `reload` plans the same stack.  Cannot be
+        /// combined with naming services.
+        #[arg(long = "profile", value_name = "NAME", conflicts_with = "services")]
+        profiles: Vec<String>,
 
         /// Never restart services, whatever their configured policy says.
         #[arg(long, default_value_t = false)]
@@ -328,6 +344,11 @@ enum Commands {
         /// Account the daemon should run as (system scope only).
         #[arg(long)]
         user: Option<String>,
+
+        /// Put `--profile NAME` on the daemon's command line in the generated
+        /// unit.  Repeatable.
+        #[arg(long = "profile", value_name = "NAME")]
+        profiles: Vec<String>,
     },
 
     /// Print a shell completion script to stdout.
@@ -352,6 +373,10 @@ enum Commands {
         /// servicrab.toml by walking up from the current directory.
         #[arg(long, short = 'c')]
         config: Option<std::path::PathBuf>,
+
+        /// Also supervise the services in this profile.  Repeatable.
+        #[arg(long = "profile", value_name = "NAME")]
+        profiles: Vec<String>,
 
         /// Never restart services, whatever their configured policy says.
         #[arg(long, default_value_t = false)]
@@ -398,13 +423,17 @@ fn main() {
         Commands::Up {
             services,
             config,
+            profiles,
             no_restart,
             no_prefix,
             timestamps,
             abort_on_failure,
             json,
         } => commands::up::run(
-            &services,
+            servicrab_core::Selection {
+                services: &services,
+                profiles: &profiles,
+            },
             config.as_deref(),
             commands::up::UpOptions {
                 no_restart,
@@ -418,13 +447,17 @@ fn main() {
         Commands::Watch {
             services,
             config,
+            profiles,
             no_restart,
             no_prefix,
             timestamps,
             abort_on_failure,
             json,
         } => commands::up::run(
-            &services,
+            servicrab_core::Selection {
+                services: &services,
+                profiles: &profiles,
+            },
             config.as_deref(),
             commands::up::UpOptions {
                 no_restart,
@@ -438,12 +471,16 @@ fn main() {
         Commands::Start {
             services,
             config,
+            profiles,
             no_restart,
             wait,
             timeout,
         } => commands::daemon::start(
             config.as_deref(),
-            &services,
+            servicrab_core::Selection {
+                services: &services,
+                profiles: &profiles,
+            },
             commands::daemon::StartOptions {
                 no_restart,
                 wait,
@@ -474,15 +511,18 @@ fn main() {
         ),
         Commands::Status { config, json } => commands::daemon::status(config.as_deref(), json),
         Commands::Down { config } => commands::daemon::down(config.as_deref()),
-        Commands::Daemon { config, no_restart } => {
-            commands::daemon::daemon(config.as_deref(), no_restart)
-        }
+        Commands::Daemon {
+            config,
+            profiles,
+            no_restart,
+        } => commands::daemon::daemon(config.as_deref(), no_restart, &profiles),
         Commands::Generate {
             target,
             config,
             scope,
             output,
             user,
+            profiles,
         } => commands::generate::run(
             target,
             config.as_deref(),
@@ -490,6 +530,7 @@ fn main() {
                 scope,
                 output,
                 user,
+                profiles,
             },
         ),
         Commands::Completions { shell } => commands::completions::run::<Cli>(shell).map(|()| 0),

--- a/crates/servicrab-cli/tests/cli.rs
+++ b/crates/servicrab-cli/tests/cli.rs
@@ -3,6 +3,7 @@
 use std::fs;
 
 use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use tempfile::TempDir;
 
@@ -153,6 +154,53 @@ command = ["echo", "db"]
         .stdout(contains("api"));
 }
 
+#[test]
+fn check_says_which_services_wait_for_a_profile() {
+    let toml = r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["echo", "api"]
+[services.mailhog]
+command = ["echo", "mail"]
+profiles = ["dev"]
+[services.seeder]
+command = ["echo", "seed"]
+profiles = ["dev", "test"]
+"#;
+    let (_dir, path) = temp_dir_with_config(toml);
+
+    cmd()
+        .arg("check")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .success()
+        .stdout(contains("profile dev: mailhog, seeder"))
+        .stdout(contains("profile test: seeder"));
+}
+
+#[test]
+fn check_stays_quiet_about_profiles_when_there_are_none() {
+    let toml = r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["echo", "api"]
+"#;
+    let (_dir, path) = temp_dir_with_config(toml);
+
+    cmd()
+        .arg("check")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .success()
+        .stdout(contains("profile").not());
+}
+
 // ── list ───────────────────────────────────────────────────────────────────
 
 #[test]
@@ -196,6 +244,52 @@ fn list_json_output() {
     assert!(first["command"].is_array());
     assert!(first["autostart"].as_bool().unwrap());
     assert_eq!(first["restart"].as_str().unwrap(), "never");
+}
+
+// ── profiles ───────────────────────────────────────────────────────────────
+
+#[test]
+fn list_reports_the_profiles_a_service_belongs_to() {
+    let toml = r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["echo"]
+[services.seeder]
+command = ["echo"]
+profiles = ["dev", "test"]
+"#;
+    let (_dir, path) = temp_dir_with_config(toml);
+
+    cmd()
+        .arg("list")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .success()
+        .stdout(contains("profiles: dev, test"));
+
+    let output = cmd()
+        .arg("list")
+        .arg("--config")
+        .arg(&path)
+        .arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8(output).unwrap()).expect("valid JSON");
+    assert_eq!(json[0]["name"], "api");
+    assert_eq!(json[0]["profiles"], serde_json::json!([]), "{json:#}");
+    assert_eq!(
+        json[1]["profiles"],
+        serde_json::json!(["dev", "test"]),
+        "{json:#}"
+    );
 }
 
 // ── include ────────────────────────────────────────────────────────────────

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -675,6 +675,86 @@ fn an_unknown_service_is_rejected_by_the_daemon() {
     assert!(stderr.contains("api"), "{stderr}");
 }
 
+// ── profiles ───────────────────────────────────────────────────────────────
+
+#[test]
+fn a_daemon_keeps_its_profiles_across_a_reload() {
+    // The profiles live in the daemon process, so a reload has to plan the
+    // stack that was started rather than the one a bare `start` would give.
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let seeder = resident(dir.path(), "seeder.sh");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+[services.seeder]
+command = ["{}"]
+restart = "always"
+profiles = ["dev"]
+"#,
+            api.display(),
+            seeder.display()
+        ),
+    );
+
+    let daemon = Daemon::start_with(&cfg, &["--profile", "dev"]);
+    daemon.wait_for_status("both services to run", |s| {
+        s.contains("api") && s.contains("seeder")
+    });
+
+    let (code, stdout, stderr) = cli(&["reload"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("no changes"), "{stdout}");
+
+    let status = daemon.status();
+    assert!(
+        status.contains("seeder"),
+        "the reload should not have dropped the profiled service:\n{status}"
+    );
+}
+
+#[test]
+fn a_daemon_without_the_profile_leaves_the_service_out() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+[services.seeder]
+command = ["true"]
+profiles = ["dev"]
+"#,
+            api.display()
+        ),
+    );
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    let status = daemon.status();
+    assert!(!status.contains("seeder"), "{status}");
+
+    // And it is not a service the daemon will take commands about, because it
+    // is not part of this stack.
+    let (code, _, stderr) = cli(&["restart", "seeder"], &cfg);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("unknown service"), "{stderr}");
+}
+
 /// The pid the daemon reports for `api`, or 0 when it is not running.
 fn pid_of(daemon: &Daemon) -> i64 {
     let (_, stdout, _) = cli(&["status", "--json"], &daemon.config);

--- a/crates/servicrab-cli/tests/generate.rs
+++ b/crates/servicrab-cli/tests/generate.rs
@@ -71,6 +71,38 @@ fn a_launchd_plist_is_written_to_stdout() {
 }
 
 #[test]
+fn a_unit_carries_the_profiles_it_was_generated_with() {
+    // Otherwise the init system would start a different stack than the operator
+    // tried out with `servicrab start --profile`.
+    let dir = TempDir::new().unwrap();
+    let cfg = project(dir.path());
+
+    let (code, stdout, stderr) = cli(
+        &[
+            "generate",
+            "systemd",
+            "--profile",
+            "dev",
+            "--profile",
+            "obs",
+        ],
+        &cfg,
+    );
+    assert_eq!(code, 0, "{stderr}");
+    assert!(
+        stdout.contains("daemon --config") && stdout.contains("--profile dev --profile obs"),
+        "{stdout}"
+    );
+
+    let (code, stdout, stderr) = cli(&["generate", "launchd", "--profile", "dev"], &cfg);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(
+        stdout.contains("<string>--profile</string>") && stdout.contains("<string>dev</string>"),
+        "{stdout}"
+    );
+}
+
+#[test]
 fn the_unit_can_be_written_to_a_file() {
     let dir = TempDir::new().unwrap();
     let cfg = project(dir.path());

--- a/crates/servicrab-cli/tests/up.rs
+++ b/crates/servicrab-cli/tests/up.rs
@@ -215,6 +215,102 @@ autostart = false
     assert!(stderr.contains("no services to start"), "stderr: {stderr}");
 }
 
+// ── profiles ───────────────────────────────────────────────────────────────
+
+/// A stack whose `seeder` only runs when a profile asks for it.
+fn profiled_config(dir: &Path) -> PathBuf {
+    config(
+        dir,
+        r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["echo", "api-line"]
+
+[services.seeder]
+command = ["echo", "seeder-line"]
+profiles = ["dev"]
+"#,
+    )
+}
+
+#[test]
+fn a_profiled_service_is_left_out_by_default() {
+    let dir = TempDir::new().unwrap();
+    let cfg = profiled_config(dir.path());
+
+    let (code, stdout, _stderr) = up(&cfg, &[]);
+    assert_eq!(code, 0, "stdout: {stdout}");
+    assert!(stdout.contains("api-line"), "stdout: {stdout}");
+    assert!(!stdout.contains("seeder-line"), "stdout: {stdout}");
+}
+
+#[test]
+fn enabling_the_profile_brings_the_service_in() {
+    let dir = TempDir::new().unwrap();
+    let cfg = profiled_config(dir.path());
+
+    let (code, stdout, _stderr) = up(&cfg, &["--profile", "dev"]);
+    assert_eq!(code, 0, "stdout: {stdout}");
+    assert!(stdout.contains("api-line"), "stdout: {stdout}");
+    assert!(stdout.contains("seeder-line"), "stdout: {stdout}");
+}
+
+#[test]
+fn a_profile_no_service_declares_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let cfg = profiled_config(dir.path());
+
+    let (code, _stdout, stderr) = up(&cfg, &["--profile", "prod"]);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("no service is in profile"), "{stderr}");
+    assert!(
+        stderr.contains("dev"),
+        "the message should list what exists: {stderr}"
+    );
+}
+
+#[test]
+fn naming_services_and_enabling_profiles_at_once_is_refused() {
+    // Two ways of saying what to start, with no unsurprising combination —
+    // better to ask than to let one of them quietly lose.
+    let dir = TempDir::new().unwrap();
+    let cfg = profiled_config(dir.path());
+
+    let (code, _stdout, stderr) = up(&cfg, &["api", "--profile", "dev"]);
+    assert_eq!(code, 2, "clap rejects the combination: {stderr}");
+    assert!(stderr.contains("--profile"), "{stderr}");
+}
+
+#[test]
+fn a_stack_that_is_all_behind_profiles_says_so() {
+    let dir = TempDir::new().unwrap();
+    let cfg = config(
+        dir.path(),
+        r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.seeder]
+command = ["true"]
+profiles = ["dev"]
+"#,
+    );
+
+    let (code, _stdout, stderr) = up(&cfg, &[]);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("no services to start"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("--profile") && stderr.contains("dev"),
+        "the message should point at the way out: {stderr}"
+    );
+}
+
 // ── output ─────────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/servicrab-core/src/config.rs
+++ b/crates/servicrab-core/src/config.rs
@@ -355,6 +355,10 @@ pub struct Service {
     pub env_files: Vec<PathBuf>,
     /// Validated dependencies that must be ready before this one starts.
     pub depends_on: Vec<Dependency>,
+    /// Groups this service belongs to, in declaration order.  Empty means the
+    /// service is part of every run; otherwise a command has to enable one of
+    /// these profiles for it to be started on its own.
+    pub profiles: Vec<String>,
     /// Whether the supervisor should start this service automatically.
     pub autostart: bool,
     /// Restart policy.

--- a/crates/servicrab-core/src/error.rs
+++ b/crates/servicrab-core/src/error.rs
@@ -91,6 +91,26 @@ pub enum ConfigError {
     #[error("invalid service name {name:?}: {reason}")]
     InvalidServiceName { name: String, reason: String },
 
+    /// A profile name violates naming rules.
+    #[error("service {service:?}: invalid profile name {profile:?}: {reason}")]
+    InvalidProfileName {
+        /// The service that lists the profile.
+        service: String,
+        /// The offending name.
+        profile: String,
+        /// Why it is not usable.
+        reason: String,
+    },
+
+    /// A service lists the same profile more than once.
+    #[error("service {service:?}: duplicate profile {profile:?}")]
+    DuplicateProfile {
+        /// The service that lists it twice.
+        service: String,
+        /// The repeated name.
+        profile: String,
+    },
+
     /// `[services]` is present but contains no entries.
     #[error("no services defined; at least one [services.*] entry is required")]
     NoServices,
@@ -330,6 +350,22 @@ pub enum RuntimeError {
         service: String,
         /// Comma-separated list of configured service names.
         known: String,
+    },
+
+    /// No service belongs to a requested profile.
+    #[error("no service is in profile {profile:?}; profiles in use: {known}")]
+    UnknownProfile {
+        /// The profile that was asked for.
+        profile: String,
+        /// Comma-separated list of the profiles the config declares.
+        known: String,
+    },
+
+    /// The plan came out empty, so there is nothing to supervise.
+    #[error("no services to start: {reason}")]
+    NothingToStart {
+        /// Which of the ways to end up with an empty plan this was.
+        reason: String,
     },
 
     /// The configured executable could not be spawned.

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -43,6 +43,6 @@ pub use runtime::filewatch::{spawn_watchers, watched_services};
 pub use runtime::{
     control_channel, event_channel, plan_stack, Control, ControlTx, EventKind, EventReceiver,
     EventSender, EventSink, ForegroundRunner, Health, LogRouter, LogWriter, OutputMode, RunOptions,
-    RunOutcome, ServiceEvent, ServiceRunner, ServiceStatus, SignalWatcher, StackOptions,
+    RunOutcome, Selection, ServiceEvent, ServiceRunner, ServiceStatus, SignalWatcher, StackOptions,
     StackOutcome, StackSupervisor, StatusRegistry, Stream,
 };

--- a/crates/servicrab-core/src/raw.rs
+++ b/crates/servicrab-core/src/raw.rs
@@ -257,6 +257,12 @@ pub struct RawService {
     #[serde(default)]
     pub depends_on: Option<RawDependsOn>,
 
+    /// Groups this service belongs to.  A service with no profiles is always
+    /// part of the stack; one with profiles joins only when a command enables
+    /// one of them.
+    #[serde(default)]
+    pub profiles: Vec<String>,
+
     /// Whether to start this service automatically.  Defaults to `true`.
     #[serde(default = "default_true")]
     pub autostart: bool,

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -51,7 +51,7 @@ pub use filewatch::{scan, spawn_watchers, watch_service, watched_services, FileS
 #[cfg(unix)]
 pub use health::{HealthMonitor, HealthSignal};
 pub use logs::{LogRouter, LogWriter};
-pub use plan::{known_services, lookup_service, plan_stack};
+pub use plan::{known_profiles, known_services, lookup_service, plan_stack, Selection};
 pub use stack::{
     control_channel, Ack, Control, ControlRx, ControlTx, Readiness, ServiceReport, ServiceResult,
     StackOptions, StackOutcome, StackSupervisor,

--- a/crates/servicrab-core/src/runtime/plan.rs
+++ b/crates/servicrab-core/src/runtime/plan.rs
@@ -38,30 +38,100 @@ pub fn known_services(config: &Config) -> String {
         .join(", ")
 }
 
+/// Comma-separated list of the profiles the configuration declares.
+pub fn known_profiles(config: &Config) -> String {
+    let profiles: BTreeSet<&str> = config
+        .services
+        .values()
+        .flat_map(|service| service.profiles.iter().map(String::as_str))
+        .collect();
+
+    if profiles.is_empty() {
+        return "(none)".to_string();
+    }
+    profiles.into_iter().collect::<Vec<_>>().join(", ")
+}
+
+/// What a stack command was asked to start.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Selection<'a> {
+    /// Service names given on the command line; empty means "the stack".
+    pub services: &'a [String],
+    /// Profiles enabled on the command line.
+    pub profiles: &'a [String],
+}
+
+impl<'a> Selection<'a> {
+    /// A selection of nothing but the services named.
+    pub fn services(services: &'a [String]) -> Self {
+        Self {
+            services,
+            profiles: &[],
+        }
+    }
+
+    /// Whether `service` may be started without being named.
+    ///
+    /// A service without profiles always may; one with profiles is opt-in,
+    /// which is the whole point of declaring them.
+    fn enabled(&self, service: &crate::config::Service) -> bool {
+        service.profiles.is_empty()
+            || service
+                .profiles
+                .iter()
+                .any(|profile| self.profiles.contains(profile))
+    }
+}
+
 /// Build the start plan for a stack command.
 ///
-/// * With no requested names, every service with `autostart = true` is
-///   selected.
-/// * With explicit names, only those services are selected.
+/// * With no service named, every service with `autostart = true` that the
+///   enabled profiles allow — which, with no profile enabled, means every
+///   service that declares no profiles.
+/// * With services named, exactly those, whatever their profiles say: naming a
+///   service is a stronger statement than enabling its group, so the profiles
+///   are not consulted.  The CLI rejects the two together rather than let one
+///   quietly lose.
 ///
-/// In both cases every transitive dependency is pulled in — a service can
-/// never be started without the services it declares in `depends_on`.  The
-/// result is ordered according to the configuration's deterministic
-/// topological start order.
-pub fn plan_stack(config: &Config, requested: &[String]) -> Result<Vec<ServiceName>, RuntimeError> {
+/// In both cases every transitive dependency is pulled in, profiles included:
+/// a service can never be started without the services it declares in
+/// `depends_on`, and a dependency that sits in a profile of its own is one
+/// somebody chose not to start *on its own*.  The result follows the
+/// configuration's deterministic topological start order.
+pub fn plan_stack(
+    config: &Config,
+    selection: Selection<'_>,
+) -> Result<Vec<ServiceName>, RuntimeError> {
+    for profile in selection.profiles {
+        if !config
+            .services
+            .values()
+            .any(|service| service.profiles.contains(profile))
+        {
+            return Err(RuntimeError::UnknownProfile {
+                profile: profile.clone(),
+                known: known_profiles(config),
+            });
+        }
+    }
+
     let mut selected: BTreeSet<ServiceName> = BTreeSet::new();
 
-    if requested.is_empty() {
+    if selection.services.is_empty() {
         for (name, service) in &config.services {
-            if service.autostart {
+            if service.autostart && selection.enabled(service) {
                 collect_with_dependencies(config, name, &mut selected);
             }
         }
     } else {
-        for name in requested {
+        for name in selection.services {
             let service = lookup_service(config, name)?;
             collect_with_dependencies(config, &service.name, &mut selected);
         }
+    }
+
+    if selected.is_empty() {
+        return Err(nothing_to_start(config, selection));
     }
 
     Ok(config
@@ -70,6 +140,41 @@ pub fn plan_stack(config: &Config, requested: &[String]) -> Result<Vec<ServiceNa
         .filter(|name| selected.contains(*name))
         .cloned()
         .collect())
+}
+
+/// Explain an empty plan, which is always a failed command.
+///
+/// Only the no-names path can produce one: a named service is either found or
+/// reported as unknown.
+fn nothing_to_start(config: &Config, selection: Selection<'_>) -> RuntimeError {
+    let reason = if !selection.profiles.is_empty() {
+        format!(
+            "no service with autostart = true is in {}",
+            list(selection.profiles)
+        )
+    } else if config
+        .services
+        .values()
+        .any(|service| !service.profiles.is_empty())
+    {
+        format!(
+            "every service with autostart = true is behind a profile; \
+             enable one with --profile (declared: {})",
+            known_profiles(config)
+        )
+    } else {
+        "none of the configured services have autostart = true".to_string()
+    };
+
+    RuntimeError::NothingToStart { reason }
+}
+
+/// `profile "dev"` or `profiles dev, test`, for a message that reads.
+fn list(profiles: &[String]) -> String {
+    match profiles {
+        [one] => format!("profile {one:?}"),
+        many => format!("profiles {}", many.join(", ")),
+    }
 }
 
 fn collect_with_dependencies(
@@ -127,34 +232,50 @@ autostart = false
 depends_on = ["cache"]
 "#;
 
+    /// Plan the whole stack with the given profiles enabled.
+    fn plan_with(config: &Config, profiles: &[&str]) -> Vec<String> {
+        let profiles: Vec<String> = profiles.iter().map(ToString::to_string).collect();
+        let plan = plan_stack(
+            config,
+            Selection {
+                services: &[],
+                profiles: &profiles,
+            },
+        )
+        .expect("plan");
+        plan.iter().map(|n| n.to_string()).collect()
+    }
+
+    /// Plan the services named.
+    fn plan_named(config: &Config, services: &[&str]) -> Vec<String> {
+        let services: Vec<String> = services.iter().map(ToString::to_string).collect();
+        let plan = plan_stack(config, Selection::services(&services)).expect("plan");
+        plan.iter().map(|n| n.to_string()).collect()
+    }
+
     #[test]
     fn empty_request_selects_autostart_services_and_their_dependencies() {
         let (_dir, config) = config_with(STACK);
-        let plan = plan_stack(&config, &[]).expect("plan");
-        let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
-        assert_eq!(names, vec!["db", "api"]);
+        assert_eq!(plan_with(&config, &[]), ["db", "api"]);
     }
 
     #[test]
     fn explicit_request_pulls_in_dependencies() {
         let (_dir, config) = config_with(STACK);
-        let plan = plan_stack(&config, &["worker".to_string()]).expect("plan");
-        let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
-        assert_eq!(names, vec!["cache", "worker"]);
+        assert_eq!(plan_named(&config, &["worker"]), ["cache", "worker"]);
     }
 
     #[test]
     fn plan_follows_the_topological_start_order() {
         let (_dir, config) = config_with(STACK);
-        let plan = plan_stack(&config, &["api".to_string(), "db".to_string()]).expect("plan");
-        let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
-        assert_eq!(names, vec!["db", "api"]);
+        assert_eq!(plan_named(&config, &["api", "db"]), ["db", "api"]);
     }
 
     #[test]
     fn unknown_service_is_rejected() {
         let (_dir, config) = config_with(STACK);
-        let err = plan_stack(&config, &["nope".to_string()]).expect_err("unknown service");
+        let named = ["nope".to_string()];
+        let err = plan_stack(&config, Selection::services(&named)).expect_err("unknown service");
         assert!(matches!(err, RuntimeError::UnknownService { .. }));
         assert!(err.to_string().contains("api"));
     }
@@ -162,7 +283,109 @@ depends_on = ["cache"]
     #[test]
     fn duplicate_requests_are_deduplicated() {
         let (_dir, config) = config_with(STACK);
-        let plan = plan_stack(&config, &["db".to_string(), "db".to_string()]).expect("plan");
-        assert_eq!(plan.len(), 1);
+        assert_eq!(plan_named(&config, &["db", "db"]), ["db"]);
+    }
+
+    // ── profiles ───────────────────────────────────────────────────────────
+
+    const PROFILED: &str = r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.db]
+command = ["true"]
+
+[services.api]
+command = ["true"]
+depends_on = ["db"]
+
+[services.mailhog]
+command = ["true"]
+profiles = ["dev"]
+
+[services.seeder]
+command = ["true"]
+profiles = ["dev", "test"]
+"#;
+
+    #[test]
+    fn a_profiled_service_stays_out_until_its_profile_is_enabled() {
+        let (_dir, config) = config_with(PROFILED);
+
+        assert_eq!(plan_with(&config, &[]), ["db", "api"]);
+        assert_eq!(
+            plan_with(&config, &["dev"]),
+            ["db", "api", "mailhog", "seeder"]
+        );
+    }
+
+    #[test]
+    fn a_service_joins_when_any_of_its_profiles_is_enabled() {
+        let (_dir, config) = config_with(PROFILED);
+
+        // `seeder` is in both, `mailhog` only in `dev`.
+        assert_eq!(plan_with(&config, &["test"]), ["db", "api", "seeder"]);
+    }
+
+    #[test]
+    fn several_profiles_add_up() {
+        let (_dir, config) = config_with(PROFILED);
+
+        assert_eq!(
+            plan_with(&config, &["test", "dev"]),
+            ["db", "api", "mailhog", "seeder"]
+        );
+    }
+
+    #[test]
+    fn a_profiled_service_can_still_be_named() {
+        let (_dir, config) = config_with(PROFILED);
+
+        assert_eq!(plan_named(&config, &["mailhog"]), ["mailhog"]);
+    }
+
+    #[test]
+    fn a_dependency_comes_along_whatever_its_profile() {
+        // `worker` is unprofiled but depends on a service that is not: asking
+        // for the plain stack has to bring `tools` with it, because a service
+        // cannot run without what it depends on.
+        let (_dir, config) = config_with(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.tools]
+command = ["true"]
+profiles = ["dev"]
+[services.worker]
+command = ["true"]
+depends_on = ["tools"]
+"#,
+        );
+
+        assert_eq!(plan_with(&config, &[]), ["tools", "worker"]);
+    }
+
+    #[test]
+    fn a_profile_nothing_declares_is_a_typo() {
+        let (_dir, config) = config_with(PROFILED);
+        let profiles = ["prod".to_string()];
+
+        let err = plan_stack(
+            &config,
+            Selection {
+                services: &[],
+                profiles: &profiles,
+            },
+        )
+        .expect_err("unknown profile");
+
+        assert!(
+            matches!(&err, RuntimeError::UnknownProfile { profile, known }
+                if profile == "prod" && known == "dev, test"),
+            "{err}"
+        );
     }
 }

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -964,6 +964,7 @@ async fn wait_for_dependencies(deps: &[DependencyEdge], stop: &mut ShutdownRx) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::Selection;
 
     fn name(raw: &str) -> ServiceName {
         crate::validation::validate_service_name(raw).expect("valid test name")
@@ -979,7 +980,8 @@ mod tests {
 
     /// A run state holding idle slots for every service in the config.
     fn state_for(cfg: Config) -> RunState {
-        let plan = crate::runtime::plan_stack(&cfg, &[]).expect("plannable test config");
+        let plan =
+            crate::runtime::plan_stack(&cfg, Selection::default()).expect("plannable test config");
         let mut state = RunState {
             config: Arc::new(cfg),
             plan: Vec::new(),
@@ -1013,7 +1015,7 @@ command = ["sleep", "60"]
     fn an_unchanged_config_produces_an_empty_diff() {
         let state = state_for(config(BASE));
         let cfg = config(BASE);
-        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+        let plan = crate::runtime::plan_stack(&cfg, Selection::default()).unwrap();
 
         let diff = state.diff(&cfg, &plan);
         assert!(diff.is_empty(), "{diff:?}");
@@ -1028,7 +1030,7 @@ command = ["sleep", "60"]
 command = [\"sleep\", \"60\"]
 "
         ));
-        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+        let plan = crate::runtime::plan_stack(&cfg, Selection::default()).unwrap();
 
         let diff = state.diff(&cfg, &plan);
         assert_eq!(diff.added, vec![name("cache")]);
@@ -1048,7 +1050,7 @@ name = "demo"
 command = ["sleep", "60"]
 "#,
         );
-        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+        let plan = crate::runtime::plan_stack(&cfg, Selection::default()).unwrap();
 
         let diff = state.diff(&cfg, &plan);
         assert_eq!(diff.removed, vec![name("worker")]);
@@ -1070,7 +1072,7 @@ command = ["sleep", "90"]
 command = ["sleep", "60"]
 "#,
         );
-        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+        let plan = crate::runtime::plan_stack(&cfg, Selection::default()).unwrap();
 
         let diff = state.diff(&cfg, &plan);
         assert_eq!(diff.changed, vec![name("api")]);
@@ -1093,7 +1095,7 @@ env = { PORT = "8080" }
 command = ["sleep", "60"]
 "#,
         );
-        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+        let plan = crate::runtime::plan_stack(&cfg, Selection::default()).unwrap();
 
         assert_eq!(state.diff(&cfg, &plan).changed, vec![name("api")]);
     }
@@ -1108,7 +1110,7 @@ command = ["sleep", "60"]
             .retired = true;
 
         let cfg = config(BASE);
-        let plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+        let plan = crate::runtime::plan_stack(&cfg, Selection::default()).unwrap();
         assert_eq!(state.diff(&cfg, &plan).added, vec![name("worker")]);
     }
 
@@ -1129,7 +1131,7 @@ depends_on = ["worker"]
 command = ["sleep", "60"]
 "#,
         );
-        state.plan = crate::runtime::plan_stack(&cfg, &[]).unwrap();
+        state.plan = crate::runtime::plan_stack(&cfg, Selection::default()).unwrap();
         state.config = Arc::new(cfg);
         state.rewire_dependencies();
 

--- a/crates/servicrab-core/src/subst.rs
+++ b/crates/servicrab-core/src/subst.rs
@@ -79,9 +79,9 @@ struct Expander<'a> {
 
 impl Expander<'_> {
     fn service(&mut self, service: &mut RawService, scope: &str) {
-        // `depends_on` is left alone: its keys name services, and its
-        // conditions come from a closed set, so a variable there could only
-        // make the shape of the stack depend on who started it.
+        // `depends_on` and `profiles` are left alone: they name services,
+        // groups, and conditions from a closed set, so a variable there could
+        // only make the shape of the stack depend on who started it.
         self.list(&mut service.command, scope, "command");
         self.maybe(service.cwd.as_mut(), scope, "cwd");
         self.map_values(&mut service.env, scope, "env");
@@ -498,6 +498,7 @@ command = ["api"]
 depends_on = ["${V}"]
 [services.web]
 command = ["web"]
+profiles = ["${V}"]
 [services.web.depends_on]
 db = { condition = "${V}" }
 "#;
@@ -511,8 +512,12 @@ db = { condition = "${V}" }
         assert_eq!(raw.project.name, "${V}");
         let entries = raw.services["api"].depends_on.as_ref().unwrap().entries();
         assert_eq!(entries[0].0, "${V}");
-        let web = raw.services["web"].depends_on.as_ref().unwrap().entries();
-        assert_eq!(web[0].1, Some("${V}"));
+        let web = &raw.services["web"];
+        assert_eq!(
+            web.depends_on.as_ref().unwrap().entries()[0].1,
+            Some("${V}")
+        );
+        assert_eq!(web.profiles, ["${V}"]);
     }
 
     #[test]

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -273,6 +273,8 @@ pub fn validate_raw(
             })
             .collect();
 
+        let profiles = validate_profiles(&raw_svc.profiles, raw_name, &mut errors);
+
         let args = raw_svc.command[1..].to_vec();
 
         services.insert(
@@ -285,6 +287,7 @@ pub fn validate_raw(
                 env: merged_env,
                 env_files: svc_env_files,
                 depends_on,
+                profiles,
                 autostart: raw_svc.autostart,
                 restart,
                 restart_delay,
@@ -430,6 +433,35 @@ pub(crate) fn validate_service_name(name: &str) -> Result<ServiceName, ConfigErr
             name: name.to_string(),
             reason,
         })
+}
+
+/// Validate a service's `profiles`, dropping the entries that are unusable.
+///
+/// Profile names follow the service-name rules: they are typed on the command
+/// line, so `--profile` and the config have to agree on what a name may be.
+fn validate_profiles(raw: &[String], service: &str, errors: &mut Vec<ConfigError>) -> Vec<String> {
+    let mut profiles: Vec<String> = Vec::with_capacity(raw.len());
+
+    for name in raw {
+        if let Err(reason) = validate_name(name, 48) {
+            errors.push(ConfigError::InvalidProfileName {
+                service: service.to_string(),
+                profile: name.clone(),
+                reason,
+            });
+            continue;
+        }
+        if profiles.contains(name) {
+            errors.push(ConfigError::DuplicateProfile {
+                service: service.to_string(),
+                profile: name.clone(),
+            });
+            continue;
+        }
+        profiles.push(name.clone());
+    }
+
+    profiles
 }
 
 /// Core name validation (shared between project and service names).
@@ -1741,6 +1773,7 @@ command = ["echo"]
                     "s".to_string(),
                     crate::raw::RawService {
                         origin: None,
+                        profiles: Vec::new(),
                         command: vec!["exe\0cutable".to_string()],
                         cwd: None,
                         env: Default::default(),
@@ -2174,6 +2207,67 @@ shutdown_timeout = "30s"
         load_from_str(toml).expect("valid dependency should pass");
     }
 
+    // ── Profiles ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn profiles_survive_validation_in_declaration_order() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nprofiles=[\"test\",\"dev\"]\n";
+        let (cfg, _) = load_from_str(toml).unwrap();
+
+        assert_eq!(
+            cfg.services[&ServiceName("s".to_string())].profiles,
+            ["test", "dev"]
+        );
+    }
+
+    #[test]
+    fn a_service_without_profiles_has_none() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\n";
+        let (cfg, _) = load_from_str(toml).unwrap();
+
+        assert!(cfg.services[&ServiceName("s".to_string())]
+            .profiles
+            .is_empty());
+    }
+
+    #[test]
+    fn a_profile_name_follows_the_service_name_rules() {
+        // It is typed on the command line as `--profile dev`, so the two have
+        // to agree on what a name may be.
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nprofiles=[\"not a name\"]\n";
+        let err = expect_one_error(toml);
+
+        assert!(
+            matches!(&err, ConfigError::InvalidProfileName { service, profile, .. }
+                if service == "s" && profile == "not a name"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn an_empty_profile_name_is_rejected() {
+        let toml =
+            "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nprofiles=[\"\"]\n";
+        let err = expect_one_error(toml);
+
+        assert!(
+            matches!(&err, ConfigError::InvalidProfileName { profile, .. } if profile.is_empty()),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_repeated_profile_is_a_typo() {
+        let toml = "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nprofiles=[\"dev\",\"dev\"]\n";
+        let err = expect_one_error(toml);
+
+        assert!(
+            matches!(&err, ConfigError::DuplicateProfile { service, profile }
+                if service == "s" && profile == "dev"),
+            "{err:?}"
+        );
+    }
+
     // ── Variable substitution ──────────────────────────────────────────────
 
     #[test]
@@ -2430,6 +2524,7 @@ restart_delay = "2s"
             "s".to_string(),
             RawService {
                 origin: None,
+                profiles: Vec::new(),
                 command: vec!["echo".to_string()],
                 cwd: None,
                 env: env.into_iter().collect(),


### PR DESCRIPTION
## Summary

- `profiles = ["dev"]` keeps a service out of the stack until a command enables one of its profiles; a service that declares no profiles starts as before.
- `--profile NAME` (repeatable) on `up`, `watch`, `start`, `daemon` and `generate`. The daemon stores the set, so `reload` re-plans the same stack rather than the smaller one a bare `start` would have produced, and `generate` writes the flags into the unit it emits.
- `servicrab list` shows each service's profiles in the table and in `--json`; `servicrab check` adds a `profile <name>: a, b` line per profile, since its start order lists profiled services too.

## Decisions worth a look

- **Naming services and passing `--profile` in one command is refused.** Naming a service starts it whatever its profiles say (so `up mailhog` needs no flag), which makes explicit names a second selector; resolving a conflict silently in favour of one of them is how you start the wrong stack. Enforced by `clap`'s `conflicts_with`.
- **Dependencies ignore profiles.** A service can never run without what it declares in `depends_on`, so a profiled dependency is pulled in for an always-on dependent. Put the dependent in the profile too if it should stay out.
- **An unknown `--profile` is an error** listing the profiles that exist, rather than a stack quietly smaller than asked for.
- Selection now travels as a `Selection { services, profiles }` struct instead of a `&[String]`, so a new axis does not mean another positional argument in every caller.

## Test plan

- [x] `cargo test --workspace --locked` — 15 targets green
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D warnings`
- [x] Unit: profile name validation (reuses the service-name rules), duplicate profile in one list, planning with/without a profile, dependency pull-in, unknown profile
- [x] Integration: `up --profile` selection, the flag conflict, a stack entirely behind profiles, `list` output, `check` output, `generate` unit contents, and a daemon that keeps its profiles across a `reload`