### PR TITLE
Add restart = "unless-stopped"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `restart = "unless-stopped"`, for the service you sometimes run yourself:
+
+  ```toml
+  [services.api]
+  command = ["node", "server.js"]
+  restart = "unless-stopped"
+  ```
+
+  It restarts exactly like `always`, except that a service stopped with
+  `servicrab stop` stays stopped across `servicrab down` and the next
+  `servicrab start`. A hand-stopped service was already left alone for as long
+  as its daemon lived, whatever its policy; what this policy adds is the memory.
+  `servicrab start api` hands the service back.
+
+  The memory is a list of names in `.servicrab/stopped`, plain text so that
+  deleting it — or a line of it — forgets a stop. It records every hand stop but
+  only `unless-stopped` services act on it, so adopting this changes nothing
+  about an existing stack. Dependents of a held-back service start out stopped
+  too: a service cannot run without what it declares in `depends_on`, and
+  starting one to wait for something nobody will start is not better than
+  leaving it alone. `start --wait` does not wait for either kind, and
+  `servicrab up` ignores the whole thing — a foreground run has nothing to
+  remember.
 - Profiles, for the services you only sometimes want:
 
   ```toml

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 - `servicrab reload` — apply config changes to a running stack without stopping the services you did not touch
 - `servicrab events` — follow a running stack live: logs, state changes, restarts and health verdicts, as text or JSON
 - `servicrab generate systemd|launchd` — hand the stack over to the init system, with `systemctl reload` wired to `servicrab reload`
-- Restart policies: `never`, `on-failure`, `always`, with exponential backoff
+- Restart policies: `never`, `on-failure`, `always`, `unless-stopped`, with
+  exponential backoff
 - Environment: per-service variables, working directories, and dotenv-style `env_file` layering
 - Shell completions for bash, zsh, fish, PowerShell and elvish, and man pages via `servicrab man`
 - Dependency declarations and a deterministic start order
@@ -232,6 +233,13 @@ finished. Nothing is written to disk and no background process is left behind.
 | `never` (default) | stop | stop | stop |
 | `on-failure` | stop | restart | restart |
 | `always` | restart | restart | restart |
+| `unless-stopped` | restart | restart | restart |
+
+`unless-stopped` restarts exactly like `always`; the two differ only in what a
+daemon does with a service you stopped by hand — see
+[Services you stopped by hand](#services-you-stopped-by-hand). In this
+single-service foreground mode there is nothing to remember, so the two are the
+same thing.
 
 Between attempts the runner waits:
 
@@ -810,6 +818,47 @@ worker   backoff          -         -         3  -
   worker: stopped (exit code 1), last status: exit code 1
 ```
 
+### Services you stopped by hand
+
+A hand-stopped service stays stopped for as long as that daemon lives, whatever
+its restart policy says. What the policy decides is whether the *next* daemon
+remembers:
+
+```toml
+[services.api]
+command = ["node", "server.js"]
+restart = "unless-stopped"
+```
+
+```bash
+servicrab stop api      # you are running api in a debugger instead
+servicrab down          # end of the day
+servicrab start         # api is still yours; the rest of the stack comes back
+servicrab start api     # hand it back to servicrab
+```
+
+With `restart = "always"` that last daemon would have started `api` again,
+because `always` means always. `unless-stopped` is the same policy plus a
+memory, and only for the initial start: once running, the two behave
+identically.
+
+The memory is a list of service names in `.servicrab/stopped`, written by the
+daemon whenever you stop or start a service. It is plain text on purpose —
+deleting it, or a line from it, is a perfectly good way to forget a stop. Two
+consequences worth knowing:
+
+- **It only affects `unless-stopped` services.** The file records every stop,
+  but every other policy starts as it always has, so adopting this changes
+  nothing about an existing stack.
+- **Dependents are held back too.** A service cannot run without what it
+  declares in `depends_on`, so if a held-back service is a dependency, whatever
+  depends on it starts out stopped as well rather than waiting for something
+  nobody is going to start. `servicrab start` on the dependency brings it up;
+  its dependents need starting too.
+
+`servicrab up` ignores all of this: a foreground run has nothing to remember,
+and there is no `stop` command while it is the thing holding your terminal.
+
 ### Waiting for the stack to be ready
 
 `start` returns as soon as the daemon is up, which is not the same as the stack
@@ -829,7 +878,9 @@ conditions `--wait` returns exactly when the last dependent would have been
 released. A `depends_on` entry that spells out
 [a condition](#dependency-conditions) is not reflected here: `--wait` asks
 whether each service is ready, not whether it satisfies a particular dependent,
-so it does not check the exit status of a one-shot.
+so it does not check the exit status of a one-shot. A service the daemon
+deliberately left stopped is not waited for either — see
+[Services you stopped by hand](#services-you-stopped-by-hand).
 
 The exit code is the point:
 
@@ -849,9 +900,10 @@ servicrab down
 ```
 
 The daemon keeps its runtime state next to the config file, in
-`.servicrab/`: `daemon.sock` (the control socket), `daemon.pid`, and
-`daemon.log` (its own diagnostics — service output goes to the log files
-described above). Add `.servicrab/` to your `.gitignore`.
+`.servicrab/`: `daemon.sock` (the control socket), `daemon.pid`, `daemon.log`
+(its own diagnostics — service output goes to the log files described above),
+and `stopped` (the services you stopped by hand). Add `.servicrab/` to your
+`.gitignore`.
 
 Each project gets its own daemon, so several stacks can run side by side.
 `start` refuses to launch a second daemon for the same config, and both the

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -3,12 +3,13 @@
 //! `daemon` is the body that supervises the stack; `start` launches it
 //! detached; `status` and `down` are thin socket clients.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use servicrab_core::{load, resolve_config_path, Config, Selection};
+use servicrab_core::{load, plan_stack, resolve_config_path, Config, Selection, ServiceName};
 
-use crate::daemon::DaemonPaths;
+use crate::daemon::{stopped, DaemonPaths};
 
 /// How long to wait for a freshly spawned daemon to answer.
 const START_TIMEOUT: Duration = Duration::from_secs(15);
@@ -97,7 +98,9 @@ mod imp {
                 return Ok(code);
             }
             let (_, _, paths) = setup(config)?;
-            return wait_for_ready(&paths.socket, services, options.timeout);
+            // Naming a service is a request to start it, so nothing it may
+            // have been remembered for holds any more.
+            return wait_for_ready(&paths.socket, services, &BTreeSet::new(), options.timeout);
         }
 
         let (cfg, config_path, paths) = setup(config)?;
@@ -182,7 +185,12 @@ mod imp {
         );
 
         if options.wait {
-            return wait_for_ready(&paths.socket, &[], options.timeout);
+            // The daemon leaves hand-stopped services stopped, so waiting for
+            // them to become ready would only ever time out.
+            let held_back = plan_stack(&cfg, selection)
+                .map(|plan| stopped::held_back(&cfg, &plan, &stopped::read(&paths.stopped)))
+                .unwrap_or_default();
+            return wait_for_ready(&paths.socket, &[], &held_back, options.timeout);
         }
         Ok(0)
     }
@@ -238,13 +246,15 @@ mod imp {
         }
     }
 
-    /// Poll the daemon until every service in `only` (or all of them) is ready.
+    /// Poll the daemon until every service in `only` (or all of them) is ready,
+    /// leaving out the ones in `skip`.
     ///
     /// The daemon is left running either way: a stack that came up wrong is
     /// easier to diagnose alive, with `status`, `logs` and `events`.
     fn wait_for_ready(
         socket: &Path,
         only: &[String],
+        skip: &BTreeSet<ServiceName>,
         timeout: Option<Duration>,
     ) -> Result<i32, String> {
         let timeout = timeout.unwrap_or(WAIT_TIMEOUT);
@@ -265,6 +275,7 @@ mod imp {
             let watched: Vec<&ServiceInfo> = services
                 .iter()
                 .filter(|service| only.is_empty() || only.contains(&service.name))
+                .filter(|service| !skip.iter().any(|name| name.as_str() == service.name))
                 .collect();
 
             let mut waiting: Vec<&str> = Vec::new();

--- a/crates/servicrab-cli/src/commands/init.rs
+++ b/crates/servicrab-cli/src/commands/init.rs
@@ -70,7 +70,10 @@ name = "my-project"
 #                 profiles only starts when a command enables one of them
 #                 (`servicrab up --profile dev`); without any, it always starts
 #   autostart     Whether to start automatically (default: true)
-#   restart       never | on-failure | always  (default: never)
+#   restart       never | on-failure | always | unless-stopped (default: never)
+#                 unless-stopped restarts like always, except that a service
+#                 you stopped with `servicrab stop` stays stopped even after
+#                 `servicrab down` and `servicrab start`
 #   restart_delay         Minimum backoff before first restart (default: 1s)
 #   restart_max_delay     Maximum backoff cap (default: 30s)
 #   max_restarts          Give up after this many attempts (default: 10)

--- a/crates/servicrab-cli/src/commands/list.rs
+++ b/crates/servicrab-cli/src/commands/list.rs
@@ -72,6 +72,7 @@ fn print_json(services: &std::collections::BTreeMap<ServiceName, Service>) {
                     servicrab_core::RestartPolicy::Never => "never",
                     servicrab_core::RestartPolicy::OnFailure => "on-failure",
                     servicrab_core::RestartPolicy::Always => "always",
+                    servicrab_core::RestartPolicy::UnlessStopped => "unless-stopped",
                 },
                 health: svc.health.as_ref().map(|h| h.probe.to_string()),
             }

--- a/crates/servicrab-cli/src/daemon/mod.rs
+++ b/crates/servicrab-cli/src/daemon/mod.rs
@@ -5,6 +5,7 @@
 //! message instead of pretending to work.
 
 pub mod paths;
+pub mod stopped;
 
 #[cfg(unix)]
 pub mod client;

--- a/crates/servicrab-cli/src/daemon/paths.rs
+++ b/crates/servicrab-cli/src/daemon/paths.rs
@@ -21,6 +21,8 @@ pub struct DaemonPaths {
     pub pid: PathBuf,
     /// Where a detached daemon's own output is appended.
     pub log: PathBuf,
+    /// The services an operator stopped by hand, one name per line.
+    pub stopped: PathBuf,
 }
 
 impl DaemonPaths {
@@ -45,6 +47,7 @@ impl DaemonPaths {
             socket,
             pid: dir.join("daemon.pid"),
             log: dir.join("daemon.log"),
+            stopped: dir.join("stopped"),
             dir,
         }
     }

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -20,6 +20,7 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::task::JoinHandle;
 
 use super::paths::DaemonPaths;
+use super::stopped;
 use crate::wire::{to_wire_event, to_wire_status};
 
 /// How many events a slow subscriber may fall behind before it is told that
@@ -66,6 +67,8 @@ struct Session {
     /// The profiles this daemon was started with: a reload has to plan the same
     /// stack, or it would quietly drop or adopt services nobody asked about.
     profiles: Vec<String>,
+    /// Where the hand-stopped services are remembered.
+    stopped: PathBuf,
     /// Kept so reloads can rebuild the watchers.  It is dropped when the
     /// daemon stops, which is what lets the collector task finish: it ends
     /// when the last event sender is gone.
@@ -79,6 +82,17 @@ struct Session {
 }
 
 impl Session {
+    /// Remember, or forget, that an operator stopped `service` by hand.
+    ///
+    /// Only `restart = "unless-stopped"` acts on this, and only when a stack is
+    /// started, so a file we could not write costs nothing right now — it is
+    /// logged and the command still succeeds.
+    fn remember(&self, service: &str, is_stopped: bool) {
+        if let Err(problem) = stopped::record(&self.stopped, service, is_stopped) {
+            tracing::warn!("{problem}");
+        }
+    }
+
     fn known_names(&self) -> Vec<ServiceName> {
         self.names
             .lock()
@@ -148,6 +162,18 @@ pub fn serve(
     options: DaemonOptions,
 ) -> Result<i32, String> {
     let plan = plan_stack(cfg, options.selection()).map_err(|e| e.to_string())?;
+    let held_back = stopped::held_back(cfg, &plan, &stopped::read(&paths.stopped));
+    if !held_back.is_empty() {
+        tracing::info!(
+            services = %held_back
+                .iter()
+                .map(ServiceName::as_str)
+                .collect::<Vec<_>>()
+                .join(", "),
+            file = %paths.stopped.display(),
+            "leaving hand-stopped services (and their dependents) stopped"
+        );
+    }
 
     paths.ensure_dir()?;
     // A socket file always survives its daemon, so a stale one is only an
@@ -217,6 +243,7 @@ pub fn serve(
             project: project.clone(),
             config_path: config_path.to_path_buf(),
             profiles: options.profiles.clone(),
+            stopped: paths.stopped.clone(),
             events: Mutex::new(Some(events_tx.clone())),
             stream: stream_tx,
             watchers: Mutex::new(Vec::new()),
@@ -232,8 +259,9 @@ pub fn serve(
         write_pid(&paths.pid)?;
         tracing::info!(project = %project, socket = %paths.socket.display(), "daemon ready");
 
-        let supervisor =
-            StackSupervisor::new(cfg, plan, stack_options, events_tx).with_control(control_rx);
+        let supervisor = StackSupervisor::new(cfg, plan, stack_options, events_tx)
+            .with_control(control_rx)
+            .with_stopped(held_back);
         let outcome = supervisor.run(&mut stop_rx).await;
 
         // Dropping the last event senders is what ends the collector, so the
@@ -427,25 +455,39 @@ async fn respond(request: Request, session: &Session) -> Response {
             }
         }
         Request::StartService { name } => {
-            command(session, &name, |service, ack| Control::Start {
+            let response = command(session, &name, |service, ack| Control::Start {
                 service,
                 ack,
             })
-            .await
+            .await;
+            // Starting a service is how an operator takes back a stop, whether
+            // it happened in this daemon or in an earlier one.
+            if matches!(response, Response::Ok { .. }) {
+                session.remember(&name, false);
+            }
+            response
         }
         Request::StopService { name } => {
-            command(session, &name, |service, ack| Control::Stop {
+            let response = command(session, &name, |service, ack| Control::Stop {
                 service,
                 ack,
             })
-            .await
+            .await;
+            if matches!(response, Response::Ok { .. }) {
+                session.remember(&name, true);
+            }
+            response
         }
         Request::RestartService { name } => {
-            command(session, &name, |service, ack| Control::Restart {
+            let response = command(session, &name, |service, ack| Control::Restart {
                 service,
                 ack,
             })
-            .await
+            .await;
+            if matches!(response, Response::Ok { .. }) {
+                session.remember(&name, false);
+            }
+            response
         }
         Request::Reload => reload(session).await,
         // `Request` is `#[non_exhaustive]`, so an older daemon can still be

--- a/crates/servicrab-cli/src/daemon/stopped.rs
+++ b/crates/servicrab-cli/src/daemon/stopped.rs
@@ -1,0 +1,193 @@
+//! Which services the operator stopped by hand, remembered between daemon
+//! runs.
+//!
+//! Only `restart = "unless-stopped"` consults this, and only when a stack is
+//! started: a hand-stopped service is never restarted under any policy, but
+//! only this one survives `servicrab down` followed by `servicrab start`.
+//!
+//! The file is a plain list of names, one per line, next to the daemon's socket
+//! and log — small enough to read and edit when a stack ends up in a state
+//! nobody wanted.  The daemon is its only writer.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use servicrab_core::{with_dependents, Config, RestartPolicy, ServiceName};
+
+/// Read the remembered set.
+///
+/// A missing or unreadable file simply means nothing is remembered: the memory
+/// of a stopped service is a convenience, and refusing to start a stack over it
+/// would be worse than starting one service too many.
+pub fn read(path: &Path) -> BTreeSet<String> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return BTreeSet::new();
+    };
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// Record whether `service` is currently stopped by hand.
+///
+/// Read-modify-write on every change rather than a set held in memory: the file
+/// is the state, so a hand edit is picked up and two daemons for one project —
+/// which the socket already prevents — could not silently disagree.
+pub fn record(path: &Path, service: &str, stopped: bool) -> Result<(), String> {
+    let mut names = read(path);
+    let changed = if stopped {
+        names.insert(service.to_string())
+    } else {
+        names.remove(service)
+    };
+    if !changed {
+        return Ok(());
+    }
+
+    let mut text = names.into_iter().collect::<Vec<_>>().join("\n");
+    if !text.is_empty() {
+        text.push('\n');
+    }
+    std::fs::write(path, text).map_err(|e| format!("could not write {}: {e}", path.display()))
+}
+
+/// The planned services that must not be started, given what is remembered.
+///
+/// A remembered name only counts while the service asks for it with
+/// `restart = "unless-stopped"`; every other policy starts as it always has, so
+/// adopting this file cannot change an existing stack.  Dependents of a held
+/// back service are held back too — see [`with_dependents`].
+pub fn held_back(
+    config: &Config,
+    plan: &[ServiceName],
+    remembered: &BTreeSet<String>,
+) -> BTreeSet<ServiceName> {
+    let seeds: BTreeSet<ServiceName> = plan
+        .iter()
+        .filter(|name| remembered.contains(name.as_str()))
+        .filter(|name| {
+            config
+                .services
+                .get(*name)
+                .is_some_and(|service| service.restart == RestartPolicy::UnlessStopped)
+        })
+        .cloned()
+        .collect();
+
+    if seeds.is_empty() {
+        return BTreeSet::new();
+    }
+    with_dependents(config, plan, &seeds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn set(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(ToString::to_string).collect()
+    }
+
+    fn config_with(body: &str) -> (TempDir, Config, Vec<ServiceName>) {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("servicrab.toml");
+        let mut file = std::fs::File::create(&path).expect("create config");
+        file.write_all(body.as_bytes()).expect("write config");
+        let (config, _) = servicrab_core::load(&path).expect("valid config");
+        let plan = config.start_order.clone();
+        (dir, config, plan)
+    }
+
+    const STACK: &str = r#"
+version = 1
+[project]
+name = "demo"
+
+[services.db]
+command = ["true"]
+restart = "unless-stopped"
+
+[services.api]
+command = ["true"]
+depends_on = ["db"]
+restart = "always"
+
+[services.cache]
+command = ["true"]
+restart = "always"
+"#;
+
+    #[test]
+    fn an_absent_file_remembers_nothing() {
+        let dir = TempDir::new().expect("temp dir");
+        assert!(read(&dir.path().join("stopped")).is_empty());
+    }
+
+    #[test]
+    fn a_recorded_name_survives_a_reread() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("stopped");
+
+        record(&path, "api", true).expect("record");
+        record(&path, "db", true).expect("record");
+        assert_eq!(read(&path), set(&["api", "db"]));
+
+        record(&path, "api", false).expect("record");
+        assert_eq!(read(&path), set(&["db"]));
+    }
+
+    #[test]
+    fn recording_the_same_state_twice_is_a_no_op() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("stopped");
+
+        record(&path, "api", true).expect("record");
+        record(&path, "api", true).expect("record");
+        assert_eq!(read(&path), set(&["api"]));
+
+        // Forgetting a name that was never there must not create the file.
+        let empty = dir.path().join("none");
+        record(&empty, "api", false).expect("record");
+        assert!(!empty.exists());
+    }
+
+    #[test]
+    fn blank_lines_and_stray_whitespace_are_ignored() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("stopped");
+        std::fs::write(&path, "api\n\n  db  \n\n").expect("write");
+        assert_eq!(read(&path), set(&["api", "db"]));
+    }
+
+    #[test]
+    fn only_unless_stopped_services_are_held_back() {
+        let (_dir, config, plan) = config_with(STACK);
+
+        // `cache` is remembered, but its policy does not ask to be.
+        assert!(held_back(&config, &plan, &set(&["cache"])).is_empty());
+    }
+
+    #[test]
+    fn a_held_back_service_takes_its_dependents_with_it() {
+        let (_dir, config, plan) = config_with(STACK);
+        let held = held_back(&config, &plan, &set(&["db"]));
+
+        let held: Vec<&str> = held.iter().map(ServiceName::as_str).collect();
+        assert_eq!(held, vec!["api", "db"]);
+    }
+
+    #[test]
+    fn a_name_outside_the_plan_is_ignored() {
+        let (_dir, config, plan) = config_with(STACK);
+        let plan: Vec<ServiceName> = plan
+            .into_iter()
+            .filter(|name| name.as_str() != "db")
+            .collect();
+
+        assert!(held_back(&config, &plan, &set(&["db", "gone"])).is_empty());
+    }
+}

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -755,6 +755,151 @@ profiles = ["dev"]
     assert!(stderr.contains("unknown service"), "{stderr}");
 }
 
+// ── restart = "unless-stopped" ──────────────────────────────────────────────
+
+/// A stack of one `unless-stopped` service and one that always restarts, so
+/// every test here can compare the two policies side by side.
+fn two_policies(dir: &Path) -> PathBuf {
+    let api = resident(dir, "api.sh");
+    let cache = resident(dir, "cache.sh");
+    config(
+        dir,
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "unless-stopped"
+[services.cache]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display(),
+            cache.display()
+        ),
+    )
+}
+
+/// The STATE column for one service in a `status` table.
+fn state_of(status: &str, service: &str) -> String {
+    status
+        .lines()
+        .find(|line| line.split_whitespace().next() == Some(service))
+        .unwrap_or_else(|| panic!("{service} is missing from the status:\n{status}"))
+        .split_whitespace()
+        .nth(1)
+        .expect("a state column")
+        .to_string()
+}
+
+#[test]
+fn a_hand_stopped_service_stays_stopped_across_a_daemon_restart() {
+    let dir = TempDir::new().unwrap();
+    let cfg = two_policies(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        state_of(s, "api") == "running" && state_of(s, "cache") == "running"
+    });
+
+    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
+    assert_eq!(cli(&["stop", "cache"], &cfg).0, 0);
+    drop(daemon);
+
+    let daemon = Daemon::start(&cfg);
+    // `cache` restarts unconditionally, so the stop was only for as long as
+    // that daemon lived; `api` asked to be remembered.
+    let status =
+        daemon.wait_for_status("cache to run again", |s| state_of(s, "cache") == "running");
+    assert_eq!(state_of(&status, "api"), "stopped", "{status}");
+}
+
+#[test]
+fn starting_a_remembered_service_takes_the_stop_back() {
+    let dir = TempDir::new().unwrap();
+    let cfg = two_policies(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| state_of(s, "api") == "running");
+    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
+    assert_eq!(cli(&["start", "api"], &cfg).0, 0);
+    drop(daemon);
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run again", |s| state_of(s, "api") == "running");
+}
+
+#[test]
+fn the_remembered_stop_is_a_plain_list_of_names() {
+    // The file is state a human may have to look at — or edit — when a stack
+    // ends up in a shape nobody wanted.
+    let dir = TempDir::new().unwrap();
+    let cfg = two_policies(dir.path());
+    let remembered = dir.path().join(".servicrab/stopped");
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| state_of(s, "api") == "running");
+    assert!(!remembered.exists(), "nothing was stopped yet");
+
+    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
+    assert_eq!(fs::read_to_string(&remembered).unwrap(), "api\n");
+
+    assert_eq!(cli(&["restart", "api"], &cfg).0, 0);
+    assert_eq!(fs::read_to_string(&remembered).unwrap(), "");
+}
+
+#[test]
+fn a_service_held_back_keeps_its_dependents_stopped() {
+    let dir = TempDir::new().unwrap();
+    let db = resident(dir.path(), "db.sh");
+    let api = resident(dir.path(), "api.sh");
+    let cache = resident(dir.path(), "cache.sh");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.db]
+command = ["{}"]
+restart = "unless-stopped"
+[services.api]
+command = ["{}"]
+depends_on = ["db"]
+restart = "always"
+[services.cache]
+command = ["{}"]
+restart = "always"
+"#,
+            db.display(),
+            api.display(),
+            cache.display()
+        ),
+    );
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("the stack to run", |s| {
+        state_of(s, "db") == "running" && state_of(s, "api") == "running"
+    });
+    assert_eq!(cli(&["stop", "db"], &cfg).0, 0);
+    drop(daemon);
+
+    // `--wait` returns 0 rather than waiting out its timeout on a service the
+    // daemon deliberately left alone.
+    let daemon = Daemon::start_with(&cfg, &["--wait", "--timeout", "10s"]);
+    let status = daemon.status();
+    assert_eq!(state_of(&status, "db"), "stopped", "{status}");
+    assert_eq!(
+        state_of(&status, "api"),
+        "stopped",
+        "a service cannot run without its dependency:\n{status}"
+    );
+    assert_eq!(state_of(&status, "cache"), "running", "{status}");
+}
+
 /// The pid the daemon reports for `api`, or 0 when it is not running.
 fn pid_of(daemon: &Daemon) -> i64 {
     let (_, stdout, _) = cli(&["status", "--json"], &daemon.config);

--- a/crates/servicrab-core/src/config.rs
+++ b/crates/servicrab-core/src/config.rs
@@ -68,6 +68,14 @@ pub enum RestartPolicy {
     OnFailure,
     /// Always restart, regardless of exit status.
     Always,
+    /// Always restart, except that a service stopped by hand stays stopped —
+    /// including across daemon restarts, which is the only way this differs
+    /// from [`RestartPolicy::Always`].
+    ///
+    /// A hand-stopped service is never restarted under any policy; what this
+    /// one adds is that the daemon remembers it, so `servicrab down` followed
+    /// by `servicrab start` does not quietly bring it back.
+    UnlessStopped,
 }
 
 impl std::fmt::Display for RestartPolicy {
@@ -76,6 +84,7 @@ impl std::fmt::Display for RestartPolicy {
             RestartPolicy::Never => write!(f, "never"),
             RestartPolicy::OnFailure => write!(f, "on-failure"),
             RestartPolicy::Always => write!(f, "always"),
+            RestartPolicy::UnlessStopped => write!(f, "unless-stopped"),
         }
     }
 }

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -41,8 +41,8 @@ pub use lifecycle::{
 pub use load::{discover_config, load, resolve_config_path};
 pub use runtime::filewatch::{spawn_watchers, watched_services};
 pub use runtime::{
-    control_channel, event_channel, plan_stack, Control, ControlTx, EventKind, EventReceiver,
-    EventSender, EventSink, ForegroundRunner, Health, LogRouter, LogWriter, OutputMode, RunOptions,
-    RunOutcome, Selection, ServiceEvent, ServiceRunner, ServiceStatus, SignalWatcher, StackOptions,
-    StackOutcome, StackSupervisor, StatusRegistry, Stream,
+    control_channel, event_channel, plan_stack, with_dependents, Control, ControlTx, EventKind,
+    EventReceiver, EventSender, EventSink, ForegroundRunner, Health, LogRouter, LogWriter,
+    OutputMode, RunOptions, RunOutcome, Selection, ServiceEvent, ServiceRunner, ServiceStatus,
+    SignalWatcher, StackOptions, StackOutcome, StackSupervisor, StatusRegistry, Stream,
 };

--- a/crates/servicrab-core/src/lifecycle.rs
+++ b/crates/servicrab-core/src/lifecycle.rs
@@ -377,7 +377,11 @@ impl RestartTracker {
     fn should_restart(&self, reason: ExitReason) -> bool {
         match self.policy {
             RestartPolicy::Never => false,
-            RestartPolicy::Always => match reason {
+            // `unless-stopped` differs from `always` only in what survives a
+            // daemon restart, which is not something this tracker can observe:
+            // a hand-stopped service never reaches the policy at all, because
+            // the shutdown reason short-circuits above.
+            RestartPolicy::Always | RestartPolicy::UnlessStopped => match reason {
                 ExitReason::SpawnFailure { retryable } => retryable,
                 _ => true,
             },
@@ -554,6 +558,36 @@ mod tests {
                 delay: SEC,
                 attempt: 1
             }
+        );
+    }
+
+    #[test]
+    fn unless_stopped_restarts_whatever_the_exit_status_was() {
+        for reason in [
+            ExitReason::Code(0),
+            ExitReason::Code(7),
+            ExitReason::Signal(9),
+        ] {
+            let mut t = tracker(RestartPolicy::UnlessStopped);
+            assert!(
+                matches!(
+                    t.decide(outcome(reason), None),
+                    RestartDecision::Restart { .. }
+                ),
+                "{reason:?}"
+            );
+        }
+
+        // What the policy is *named* for is the one case it shares with every
+        // other policy; the difference only shows up across daemon restarts,
+        // which this tracker cannot see.
+        let mut t = tracker(RestartPolicy::UnlessStopped);
+        assert_eq!(
+            t.decide(
+                outcome(ExitReason::Code(1)),
+                Some(ShutdownReason::Requested)
+            ),
+            RestartDecision::Stop
         );
     }
 

--- a/crates/servicrab-core/src/raw.rs
+++ b/crates/servicrab-core/src/raw.rs
@@ -387,6 +387,9 @@ pub enum RawRestartPolicy {
     OnFailure,
     /// Always restart.
     Always,
+    /// Always restart, but do not start again after a daemon restart when the
+    /// service was stopped by hand.
+    UnlessStopped,
 }
 
 fn default_true() -> bool {

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -51,7 +51,9 @@ pub use filewatch::{scan, spawn_watchers, watch_service, watched_services, FileS
 #[cfg(unix)]
 pub use health::{HealthMonitor, HealthSignal};
 pub use logs::{LogRouter, LogWriter};
-pub use plan::{known_profiles, known_services, lookup_service, plan_stack, Selection};
+pub use plan::{
+    known_profiles, known_services, lookup_service, plan_stack, with_dependents, Selection,
+};
 pub use stack::{
     control_channel, Ack, Control, ControlRx, ControlTx, Readiness, ServiceReport, ServiceResult,
     StackOptions, StackOutcome, StackSupervisor,

--- a/crates/servicrab-core/src/runtime/plan.rs
+++ b/crates/servicrab-core/src/runtime/plan.rs
@@ -177,6 +177,42 @@ fn list(profiles: &[String]) -> String {
     }
 }
 
+/// `seeds` plus every planned service that transitively depends on one of
+/// them.
+///
+/// A service cannot run without what it declares in `depends_on`, so whoever
+/// leaves a service out has to leave its dependents out too — starting them
+/// would only produce dependents that wait for something nobody is going to
+/// start.  Names outside `plan` are ignored, in both the seeds and the result.
+pub fn with_dependents(
+    config: &Config,
+    plan: &[ServiceName],
+    seeds: &BTreeSet<ServiceName>,
+) -> BTreeSet<ServiceName> {
+    let mut held: BTreeSet<ServiceName> = seeds
+        .iter()
+        .filter(|name| plan.contains(name))
+        .cloned()
+        .collect();
+
+    // The plan is topologically ordered, so one pass in start order reaches
+    // every dependent: a service always follows the ones it depends on.
+    for name in plan {
+        let Some(service) = config.services.get(name) else {
+            continue;
+        };
+        if service
+            .depends_on
+            .iter()
+            .any(|dep| held.contains(&dep.service))
+        {
+            held.insert(name.clone());
+        }
+    }
+
+    held
+}
+
 fn collect_with_dependencies(
     config: &Config,
     name: &ServiceName,
@@ -387,5 +423,76 @@ depends_on = ["tools"]
                 if profile == "prod" && known == "dev, test"),
             "{err}"
         );
+    }
+
+    // ── dependents ─────────────────────────────────────────────────────────
+
+    /// `with_dependents` over the whole stack, as sorted names.
+    fn dependents_of(config: &Config, seeds: &[&str]) -> Vec<String> {
+        let seeds: BTreeSet<ServiceName> = config
+            .services
+            .keys()
+            .filter(|name| seeds.contains(&name.as_str()))
+            .cloned()
+            .collect();
+        with_dependents(config, &config.start_order, &seeds)
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    const CHAIN: &str = r#"
+version = 1
+[project]
+name = "demo"
+[services.db]
+command = ["true"]
+[services.api]
+command = ["true"]
+depends_on = ["db"]
+[services.web]
+command = ["true"]
+depends_on = ["api"]
+[services.cache]
+command = ["true"]
+"#;
+
+    #[test]
+    fn dependents_are_collected_through_the_chain() {
+        let (_dir, config) = config_with(CHAIN);
+        assert_eq!(dependents_of(&config, &["db"]), ["api", "db", "web"]);
+    }
+
+    #[test]
+    fn a_service_nothing_depends_on_brings_nobody() {
+        let (_dir, config) = config_with(CHAIN);
+        assert_eq!(dependents_of(&config, &["cache"]), ["cache"]);
+    }
+
+    #[test]
+    fn the_far_end_of_the_chain_pulls_nothing_back() {
+        // Dependencies are not dependents: holding `web` back leaves the
+        // services it relies on running.
+        let (_dir, config) = config_with(CHAIN);
+        assert_eq!(dependents_of(&config, &["web"]), ["web"]);
+    }
+
+    #[test]
+    fn a_seed_outside_the_plan_is_ignored_along_with_its_dependents() {
+        let (_dir, config) = config_with(CHAIN);
+        let plan: Vec<ServiceName> = config
+            .start_order
+            .iter()
+            .filter(|name| name.as_str() != "db")
+            .cloned()
+            .collect();
+        let seeds: BTreeSet<ServiceName> = config
+            .services
+            .keys()
+            .filter(|name| name.as_str() == "db")
+            .cloned()
+            .collect();
+
+        assert!(with_dependents(&config, &plan, &seeds).is_empty());
     }
 }

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -12,7 +12,7 @@
 //! promise that the service is *usable*, so a dependent may still need to retry
 //! its own connection attempts.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -216,6 +216,7 @@ pub struct StackSupervisor<'a> {
     options: StackOptions,
     events: EventSender,
     control: Option<ControlRx>,
+    stopped: BTreeSet<ServiceName>,
 }
 
 impl<'a> StackSupervisor<'a> {
@@ -235,12 +236,27 @@ impl<'a> StackSupervisor<'a> {
             options,
             events,
             control: None,
+            stopped: BTreeSet::new(),
         }
     }
 
     /// Accept per-service commands while the stack runs.
     pub fn with_control(mut self, control: ControlRx) -> Self {
         self.control = Some(control);
+        self
+    }
+
+    /// Leave these planned services stopped instead of starting them with the
+    /// rest of the stack.
+    ///
+    /// They keep their place in the plan, so a later `Control::Start` brings
+    /// one up, and they report themselves stopped straight away: dependents get
+    /// the same signal they would get from a service stopped by hand, and the
+    /// daemon's status shows why nothing is running.  Who ends up in this set is
+    /// a decision for the caller — see
+    /// [`crate::runtime::with_dependents`].
+    pub fn with_stopped(mut self, stopped: BTreeSet<ServiceName>) -> Self {
+        self.stopped = stopped;
         self
     }
 
@@ -273,13 +289,18 @@ impl<'a> StackSupervisor<'a> {
             state.insert_slot(&name, Arc::new(service));
         }
         state.rewire_dependencies();
+        let mut running = 0;
         for name in state.plan.clone() {
+            if self.stopped.contains(&name) {
+                state.publish_stopped(&name, &self.events);
+                continue;
+            }
             if let Some(slot) = state.slots.get_mut(&name) {
                 slot.spawn(self.events.clone(), run_options, report_tx.clone());
+                running += 1;
             }
         }
 
-        let mut running = state.slots.len();
         let mut reports: Vec<ServiceReport> = Vec::with_capacity(running);
         let mut shutdown_reason: Option<ShutdownReason> = None;
 
@@ -572,6 +593,29 @@ impl RunState {
                 pending: None,
             },
         );
+    }
+
+    /// Report a service as stopped without ever starting it.
+    ///
+    /// The event is what the daemon's status registry and the event stream go
+    /// by; the readiness update is what a dependent goes by, and it says the
+    /// same thing a service stopped by hand would.
+    fn publish_stopped(&self, name: &ServiceName, events: &EventSender) {
+        let Some(slot) = self.slots.get(name) else {
+            return;
+        };
+        // `send_modify` rather than `send`: the value has to be there for a
+        // dependent that subscribes later, even when nobody is watching yet.
+        slot.readiness.send_modify(|status| {
+            *status = DependencyStatus {
+                state: ServiceState::Stopped,
+                ..DependencyStatus::new()
+            };
+        });
+        let _ = events.send(ServiceEvent::new(
+            name.clone(),
+            EventKind::State(ServiceState::Stopped),
+        ));
     }
 
     /// Point every slot at the status of the dependencies it currently has.
@@ -1141,6 +1185,38 @@ command = ["sleep", "60"]
             .map(|edge| edge.name.clone())
             .collect();
         assert_eq!(deps, vec![name("worker")]);
+    }
+
+    #[test]
+    fn a_held_back_service_reports_itself_stopped_without_running() {
+        let state = state_for(config(BASE));
+        let (events, mut stream) = event_channel();
+
+        state.publish_stopped(&name("api"), &events);
+
+        // Dependents must get a verdict rather than wait for a service nobody
+        // is going to start.
+        let status = *state.slots[&name("api")].readiness.borrow();
+        for condition in [
+            DependencyCondition::ServiceStarted,
+            DependencyCondition::ServiceHealthy,
+            DependencyCondition::ServiceCompletedSuccessfully,
+        ] {
+            assert_eq!(
+                status.readiness(condition),
+                Readiness::Gone,
+                "{condition:?}"
+            );
+        }
+
+        let event = stream.try_recv().expect("one event");
+        assert_eq!(event.service, name("api"));
+        assert!(
+            matches!(event.kind, EventKind::State(ServiceState::Stopped)),
+            "{:?}",
+            event.kind
+        );
+        assert!(state.slots[&name("api")].handle.is_none());
     }
 
     #[test]

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -163,6 +163,7 @@ pub fn validate_raw(
             RawRestartPolicy::Never => RestartPolicy::Never,
             RawRestartPolicy::OnFailure => RestartPolicy::OnFailure,
             RawRestartPolicy::Always => RestartPolicy::Always,
+            RawRestartPolicy::UnlessStopped => RestartPolicy::UnlessStopped,
         };
 
         // Durations
@@ -345,7 +346,10 @@ pub fn validate_raw(
                     });
                 }
                 Some(DependencyCondition::ServiceCompletedSuccessfully)
-                    if target.restart == RawRestartPolicy::Always =>
+                    if matches!(
+                        target.restart,
+                        RawRestartPolicy::Always | RawRestartPolicy::UnlessStopped
+                    ) =>
                 {
                     errors.push(ConfigError::DependencyNeverCompletes {
                         service: raw_name.clone(),
@@ -2087,6 +2091,18 @@ _SVCRAB_TEST_KEY = "service"
     }
 
     #[test]
+    fn restart_policy_unless_stopped() {
+        let (cfg, _) = load_from_str(
+            "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nrestart=\"unless-stopped\"\n",
+        )
+        .expect("valid config");
+        assert_eq!(
+            cfg.services[&ServiceName("s".into())].restart,
+            RestartPolicy::UnlessStopped
+        );
+    }
+
+    #[test]
     fn restart_policy_always() {
         let (cfg, _) = load_from_str(
             "version=1\n[project]\nname=\"p\"\n[services.s]\ncommand=[\"echo\"]\nrestart=\"always\"\n",
@@ -2410,6 +2426,18 @@ tcp = "127.0.0.1:1"
         let err = expect_one_error(&with_condition(
             "service_completed_successfully",
             r#"restart = "always""#,
+        ));
+        assert!(
+            matches!(&err, ConfigError::DependencyNeverCompletes { service, dep }
+                if service == "b" && dep == "a"),
+            "{err:?}"
+        );
+
+        // `unless-stopped` restarts just as unconditionally, so it can never
+        // reach a completed run either.
+        let err = expect_one_error(&with_condition(
+            "service_completed_successfully",
+            r#"restart = "unless-stopped""#,
         ));
         assert!(
             matches!(&err, ConfigError::DependencyNeverCompletes { service, dep }


### PR DESCRIPTION
## Summary

- `restart = "unless-stopped"` restarts exactly like `always`, except that a service stopped with `servicrab stop` stays stopped across `servicrab down` and the next `servicrab start`. A hand-stopped service was already left alone for as long as its daemon lived, whatever its policy — what this policy adds is the memory, and only for the initial start.
- The memory is a list of names in `.servicrab/stopped`, written by the daemon on every stop/start/restart. `servicrab start api` hands the service back.
- `servicrab list` reports the new policy; `servicrab check` and `up` are unaffected.

## Decisions worth a look

- **The file records every hand stop, but only `unless-stopped` services act on it.** The file states a fact ("you stopped this"); the config decides what the fact means. So adopting this cannot change how an existing stack starts, and switching a service's policy later needs no migration.
- **Dependents of a held-back service are held back too** (`with_dependents` in `runtime/plan.rs`). A service cannot run without what it declares in `depends_on`, so the alternative was spawning it and having it immediately report `Skipped` — the same outcome, plus a failure in the run's verdict and a line of noise at every daemon start.
- **Plain text, not JSON.** It sits next to `daemon.pid`, and deleting it (or one line of it) is a perfectly good way to forget a stop. That is a feature of the format, so there is a test pinning the exact contents.
- **`--no-restart` does not switch the memory off.** It is about restarting, not about starting; a flag that resurrects a service you deliberately stopped would be the surprising reading.
- Core stays policy-free: `StackSupervisor::with_stopped` takes a set of names and leaves those slots unspawned, publishing `State(Stopped)` so the status registry, the event stream and dependents all see the same thing. Which names end up in it is the CLI's decision, in `daemon/stopped.rs`.

## Test plan

- [x] `cargo test --workspace --locked` — 15 targets green
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`
- [x] Unit: the policy restarts like `always` and still yields to a hand stop; a held-back slot reports itself stopped without running; `with_dependents` over a chain (and that dependencies are *not* pulled back); the file's read/write/prune behaviour and the `unless-stopped`-only filter
- [x] Integration: hand stop survives `down` + `start` while `always` comes back; `start` takes the stop back; the file's exact contents; a held-back dependency keeps its dependent stopped while an unrelated service runs, with `start --wait` returning 0 instead of timing out