### PR TITLE
deps: Move to toml 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,11 +575,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -770,44 +770,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -920,12 +918,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ clap_mangen = "0.3"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-toml = "0.8"
+toml = "1"
 
 # Duration parsing
 humantime = "2"


### PR DESCRIPTION
## Summary

- `toml = "0.8"` → `toml = "1"`, replacing [#21](https://github.com/gaborini/servicrab/pull/21) (Dependabot's branch was cut before #22–#26 and no longer applies cleanly).
- The dependency tree loses `toml_edit` and `toml_write` and gains `toml_parser`, `toml_writer` and `winnow 1.0`; `serde_spanned` and `toml_datetime` move to their 1.x lines.

## Why this needed reading rather than merging

A `servicrab.toml` is the entire input surface of this project, and the parse errors come straight from this crate — so the risk in a major bump is not that it stops compiling, it is that the diagnostics quietly get worse. They did not; spans, carets and the expected-field list are intact:

```
✗ a.toml has 1 error(s):
  • failed to parse a.toml: TOML parse error at line 6, column 1
  |
6 | restrt = "always"
  | ^^^^^^
unknown field `restrt`, expected one of `command`, `cwd`, …
```

Nothing in the workspace serialises TOML (the `init` template is a string literal), so losing the `toml_edit` half of the old tree costs nothing.

## Test plan

- [x] `cargo test --workspace --locked` — 15 targets green, including the validation tests that assert on parse-error text
- [x] `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo fmt --all --check`
- [x] `cargo +1.85 check --workspace --all-targets --locked` — the declared MSRV still holds
- [x] `cargo deny check` — advisories, bans, licenses and sources all ok; no duplicate `winnow`
- [x] `servicrab check` by hand against a syntax error, an unknown field and an unknown enum variant