### PR TITLE
Harden the supervisor, the daemon and the release pipeline for 1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,7 +54,7 @@ body:
     attributes:
       label: Servicrab version
       description: Output of `servicrab --version`.
-      placeholder: servicrab 0.1.0
+      placeholder: servicrab 0.3.0
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,7 +54,7 @@ body:
     attributes:
       label: Servicrab version
       description: Output of `servicrab --version`.
-      placeholder: servicrab 0.3.0
+      placeholder: servicrab 1.0.0
     validations:
       required: true
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,17 +7,30 @@ name: Audit
 # This is deliberately a separate workflow from CI.  Advisories are published
 # on the RustSec calendar, not ours: a new one should not fail an unrelated
 # documentation pull request, and it should be found even in a week when nobody
-# opens one.  Hence the schedule, plus a run whenever the dependency set or the
-# policy itself changes.
+# opens one.  Hence the schedule, plus a run on every push to `main` and on
+# every release tag.
 on:
   push:
     branches: ["main"]
-    paths:
-      - "**/Cargo.toml"
-      - "Cargo.lock"
-      - "deny.toml"
-      - ".github/workflows/audit.yml"
+    tags: ["v*"]
+    # No `paths` filter on push any more, and the `paths` key is what forced the
+    # shape: it applies to the whole event, so a filtered branch and an
+    # unfiltered tag cannot coexist in one `push` entry — and two `push` entries
+    # are not an option either, the second silently replaces the first.
+    #
+    # Dropping it on push is right on its own merits.  The filter meant a commit
+    # that only changed Rust code never re-audited, and a release tag never
+    # audited at all.  A tag is the one moment the answer has to be current: the
+    # advisory that matters is the one standing when the artefacts are built, not
+    # the one standing when Cargo.lock was last edited.  On `main` the cost is a
+    # few extra minutes per push, against an audit that is actually up to date.
+    #
+    # This stays out of the release workflow's dependency chain on purpose — an
+    # advisory published this morning is worth reporting, not worth failing a tag
+    # that is already pushed.
   pull_request:
+    # The filter stays here, where the reasoning in the header still holds: a
+    # newly published advisory should not fail an unrelated pull request.
     paths:
       - "**/Cargo.toml"
       - "Cargo.lock"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install stable Rust toolchain
+        id: toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -47,9 +48,21 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # The toolchain belongs in the key because `target/` is cached: build
+          # artefacts are only valid for the compiler that produced them, and
+          # `@stable` silently becomes a different compiler every six weeks.
+          # The old `restore-keys: ${{ runner.os }}-cargo-` made that worse than
+          # a plain miss — after a toolchain bump the prefix was guaranteed to
+          # find the previous toolchain's `target/`, and cargo then decides for
+          # itself how much of it to trust.  `cachekey` is the action's own short
+          # hash of the rustc commit, so it changes exactly when the compiler
+          # does.
+          key: ${{ runner.os }}-cargo-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          # Narrowed to the same toolchain: a stale `target/` from the same
+          # compiler with a slightly different lockfile is still a useful
+          # starting point, one from another compiler is not.
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-${{ steps.toolchain.outputs.cachekey }}-
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -84,6 +97,23 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
 
+      # Registry only, and no `target/`.  Downloaded crate sources do not depend
+      # on the compiler, so this needs no toolchain in the key and cannot go
+      # stale the way a cached `target/` can — which is the whole hazard the
+      # check job's key had to work around.  It is also why the key is safe to
+      # share: every job restoring it wants the same bytes.  A `target/` cache
+      # per job would instead need a namespace per job, or they would overwrite
+      # each other's artefacts under one key.
+      - name: Cache the Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
       # --locked matters: the promise is about the versions we ship in
       # Cargo.lock, not about whatever resolves today.
       - name: Check the workspace on the MSRV
@@ -98,6 +128,16 @@ jobs:
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache the Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
       # Windows is a non-goal: supervision is Unix-only and the runtime reports
       # UnsupportedPlatform there.  What this job protects is the `cfg(not(unix))`
@@ -117,6 +157,16 @@ jobs:
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache the Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
       # Catches missing manifest metadata and files left out of the package
       # long before a release tag depends on them.
       - name: Package every crate
@@ -131,6 +181,16 @@ jobs:
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache the Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
       # The crate documentation is dense with intra-doc links, and a link that
       # stops resolving is invisible without this: rustdoc emits a warning and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,25 @@ jobs:
       # long before a release tag depends on them.
       - name: Package every crate
         run: cargo package --workspace --locked
+
+  docs:
+    name: docs (rustdoc, deny warnings)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # The crate documentation is dense with intra-doc links, and a link that
+      # stops resolving is invisible without this: rustdoc emits a warning and
+      # exits zero, so `cargo doc` "succeeds" while shipping a broken page to
+      # docs.rs.  `-D warnings` is what turns that into a failure.
+      #
+      # --no-deps: our own links are the promise; a warning inside a dependency's
+      # documentation is not ours to fix and not ours to be blocked by.
+      - name: Build the documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --all-features --no-deps --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
+      prerelease: ${{ steps.resolve.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -85,7 +86,23 @@ jobs:
 
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "Releasing ${TAG}; the workspace version is ${manifest}."
+
+          # The trigger is `tags: ["v*"]`, so a `v1.0.0-rc1` tag runs this
+          # workflow just like a final one — and `gh release create` passed
+          # neither `--prerelease` nor `--latest=false`, so the release candidate
+          # would have become the "latest" release.  The install snippet in the
+          # README resolves `releases/latest`, so everyone following the
+          # documented install would have been handed a release candidate.
+          #
+          # Anything after the patch level is a prerelease, which is the semver
+          # rule and matches the `v<semver>` shape checked above.
+          case "$version" in
+            *-*) prerelease=true ;;
+            *)   prerelease=false ;;
+          esac
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+
+          echo "Releasing ${TAG}; the workspace version is ${manifest}; prerelease=${prerelease}."
 
       # Nothing in this pipeline used to run a test: it built, asked the binary
       # for its version, and published.  Pushing a tag on a red commit shipped
@@ -294,6 +311,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.meta.outputs.tag }}
           VERSION: ${{ needs.meta.outputs.version }}
+          PRERELEASE: ${{ needs.meta.outputs.prerelease }}
         run: |
           set -euo pipefail
           notes=$(awk -v tag="${VERSION}" '
@@ -304,6 +322,20 @@ jobs:
           if [ -z "${notes//[[:space:]]/}" ]; then
             notes="See CHANGELOG.md."
           fi
+
+          # `--latest` is stated in both directions rather than left to gh, which
+          # decides it "automatically based on date and version": a release cut
+          # today for an older maintenance branch would otherwise claim to be the
+          # latest.  On a prerelease, `--latest=false` is what actually keeps the
+          # README's `releases/latest` install pointing at the last final
+          # release; `--prerelease` alone only labels it in the UI.
+          flags=()
+          if [ "$PRERELEASE" = "true" ]; then
+            flags+=(--prerelease --latest=false)
+          else
+            flags+=(--latest)
+          fi
+
           # --verify-tag: the tag has to already exist.  Without it a typo in a
           # dispatched tag name makes gh create that tag itself, off the default
           # branch — a release whose assets came from one commit and whose tag
@@ -311,4 +343,5 @@ jobs:
           gh release create "$TAG" dist/* \
             --verify-tag \
             --title "$TAG" \
-            --notes "$notes"
+            --notes "$notes" \
+            "${flags[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,18 @@ jobs:
   # tag and the version are resolved once, here, and every job downstream reads
   # them from this job's outputs rather than from the event.
   meta:
-    name: Resolve the tag
+    name: Resolve the tag and gate on the manifest
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
     steps:
-      - name: Resolve the tag and the version it claims
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Resolve the tag and check it against the manifest
         id: resolve
         env:
           # The expression the release job already used, and the only one that is
@@ -44,9 +48,40 @@ jobs:
         run: |
           set -euo pipefail
           version="${TAG#v}"
+
+          # The header of this file states that the tag matches the workspace
+          # version, and until now nothing enforced it: a `v1.0.0` tag on a
+          # commit whose manifest still said `0.3.0` built and shipped in
+          # silence, and the mismatch only surfaced at `cargo publish`.
+          #
+          # A tag that is not `v<semver>` at all means the workflow was
+          # dispatched with something that is not a release tag — a branch name,
+          # most likely, which is exactly how the asset-naming bug above got in.
+          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::'${TAG}' is not a release tag; expected v<major>.<minor>.<patch>[-prerelease]."
+            exit 1
+          fi
+
+          # Read from [workspace.package] only, so a `version` key in another
+          # table cannot answer for the workspace.  No toolchain is installed in
+          # this job on purpose: the gate has to fail within seconds, before four
+          # runners spend half an hour building something to be thrown away.
+          manifest=$(awk -F'"' '
+            /^\[/ { in_wp = ($0 == "[workspace.package]"); next }
+            in_wp && /^version[[:space:]]*=/ { print $2; exit }
+          ' Cargo.toml)
+          if [ -z "$manifest" ]; then
+            echo "::error::could not read version from [workspace.package] in Cargo.toml."
+            exit 1
+          fi
+          if [ "$version" != "$manifest" ]; then
+            echo "::error::tag ${TAG} claims version ${version}, but [workspace.package] in Cargo.toml says ${manifest}; the tag and the manifest have to agree before a release is cut."
+            exit 1
+          fi
+
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "Releasing ${TAG} (version ${version})."
+          echo "Releasing ${TAG}; the workspace version is ${manifest}."
 
   build:
     name: ${{ matrix.target }}
@@ -107,7 +142,20 @@ jobs:
       - name: Smoke-test the binary
         # Cross-built macOS x86_64 cannot run on an arm runner.
         if: matrix.target != 'x86_64-apple-darwin'
-        run: ./target/${{ matrix.target }}/release/servicrab --version
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          reported=$(./target/${{ matrix.target }}/release/servicrab --version)
+          echo "$reported"
+          # The manifest gate in `meta` reads a text file; this reads the binary
+          # that is actually being shipped, so a stale build directory or a
+          # patch-level override somewhere in the tree cannot slip a differently
+          # versioned executable into a tarball named after the tag.
+          if [ "$reported" != "servicrab ${VERSION}" ]; then
+            echo "::error::the built binary reports '${reported}', but the tag says version ${VERSION}."
+            exit 1
+          fi
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,21 @@ env:
 permissions:
   contents: read
 
+# CI cancels superseded runs; a release must not.  There is no such thing as a
+# release run made irrelevant by a later one, hence `cancel-in-progress: false`
+# — cancelling one halfway would leave a release created and half its assets
+# uploaded.
+#
+# The group is the workflow, not the tag, so releases serialise completely.
+# Two runs for the *same* tag (a push and a dispatch of it, or a re-run) would
+# otherwise both reach `gh release create` and one would fail on a release that
+# already exists.  Two runs for *different* tags would instead race over which
+# one ends up marked latest, and the answer would depend on which finished
+# last.  Releases are rare enough that queueing costs nothing.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   # Every job used to work the version out for itself, from two different
   # expressions: the build job read `$GITHUB_REF_NAME` while the release job read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,11 @@ jobs:
   meta:
     name: Resolve the tag and gate on the manifest
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      # Reading CI's verdict for the tagged commit needs the runs API.
+      actions: read
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
@@ -82,6 +86,64 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "Releasing ${TAG}; the workspace version is ${manifest}."
+
+      # Nothing in this pipeline used to run a test: it built, asked the binary
+      # for its version, and published.  Pushing a tag on a red commit shipped
+      # it.
+      #
+      # Of the two ways to close that, this one demands CI's verdict for the
+      # exact commit the tag points at, rather than re-running the suite here.
+      # CI is five jobs — fmt, clippy and the suite on Linux and macOS, the MSRV
+      # check, the Windows stubs and `cargo package` — and re-running a subset of
+      # that in the release path would be a weaker check wearing the same badge.
+      # It is also the procedure the release notes already describe: push, wait
+      # for CI, then tag.  This step only makes the machine insist on it.
+      #
+      # The cost is that the verdict is only as good as CI's coverage of that
+      # tree, which is the same trust the branch protection on `main` already
+      # rests on.  A tag on a commit CI never saw is refused outright.
+      - name: Require CI to be green for the tagged commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse HEAD)
+
+          # A tag pushed straight after the commit races CI rather than
+          # following it, and that is a wait, not a failure.  Bounded, so a
+          # never-scheduled run still ends the job instead of hanging on it.
+          deadline=$(( $(date +%s) + 900 ))
+          while :; do
+            runs=$(gh api \
+              "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${sha}&per_page=100" \
+              --jq '[.workflow_runs[] | {status, conclusion}]')
+            total=$(printf '%s' "$runs" | jq 'length')
+            green=$(printf '%s' "$runs" | jq '[.[] | select(.conclusion == "success")] | length')
+            # A re-run that failed counts: "green once, red later" is red.
+            red=$(printf '%s' "$runs" | jq '[.[] | select(.status == "completed" and .conclusion != "success")] | length')
+            pending=$(printf '%s' "$runs" | jq '[.[] | select(.status != "completed")] | length')
+
+            if [ "$red" -gt 0 ]; then
+              echo "::error::CI completed without succeeding for ${sha}, the commit ${TAG} points at; a tag is not a way to ship a red commit."
+              exit 1
+            fi
+            if [ "$green" -gt 0 ] && [ "$pending" -eq 0 ]; then
+              echo "CI is green for ${sha} (${green} run(s))."
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              if [ "$total" -eq 0 ]; then
+                echo "::error::no CI run exists for ${sha}. Push the commit and let CI finish before tagging it."
+              else
+                echo "::error::CI for ${sha} was still running when the wait ran out; ${pending} run(s) unfinished."
+              fi
+              exit 1
+            fi
+            echo "Waiting for CI on ${sha}: ${total} run(s), ${green} green, ${pending} unfinished."
+            sleep 30
+          done
 
   build:
     name: ${{ matrix.target }}
@@ -199,6 +261,11 @@ jobs:
           if [ -z "${notes//[[:space:]]/}" ]; then
             notes="See CHANGELOG.md."
           fi
+          # --verify-tag: the tag has to already exist.  Without it a typo in a
+          # dispatched tag name makes gh create that tag itself, off the default
+          # branch — a release whose assets came from one commit and whose tag
+          # names another.
           gh release create "$TAG" dist/* \
+            --verify-tag \
             --title "$TAG" \
             --notes "$notes"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,38 @@ permissions:
   contents: read
 
 jobs:
+  # Every job used to work the version out for itself, from two different
+  # expressions: the build job read `$GITHUB_REF_NAME` while the release job read
+  # `inputs.tag || github.ref_name`.  Those agree on a tag push and disagree on a
+  # `workflow_dispatch` run, where `$GITHUB_REF_NAME` is the *branch* — so a
+  # dispatched release attached `servicrab-main-<target>.tar.gz` tarballs to a
+  # `v<version>` release, assets that do not carry the version they ship.  The
+  # tag and the version are resolved once, here, and every job downstream reads
+  # them from this job's outputs rather than from the event.
+  meta:
+    name: Resolve the tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve the tag and the version it claims
+        id: resolve
+        env:
+          # The expression the release job already used, and the only one that is
+          # correct for both triggers.
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Releasing ${TAG} (version ${version})."
+
   build:
     name: ${{ matrix.target }}
+    needs: meta
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -39,7 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          # The resolved tag, not the event ref: on a dispatch run `github.ref`
+          # is the branch, and building a "release" from a moving branch is how
+          # a tag ends up shipping something it never pointed at.
+          ref: ${{ needs.meta.outputs.tag }}
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -58,10 +91,11 @@ jobs:
 
       - name: Package
         id: package
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          name="servicrab-${version}-${{ matrix.target }}"
+          name="servicrab-${VERSION}-${{ matrix.target }}"
           mkdir -p "dist/${name}"
           cp "target/${{ matrix.target }}/release/servicrab" "dist/${name}/"
           cp README.md CHANGELOG.md LICENSE-MIT LICENSE-APACHE "dist/${name}/"
@@ -85,14 +119,17 @@ jobs:
 
   release:
     name: Publish the GitHub release
-    needs: build
+    needs: [meta, build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          # The resolved tag, not the event ref: on a dispatch run `github.ref`
+          # is the branch, and building a "release" from a moving branch is how
+          # a tag ends up shipping something it never pointed at.
+          ref: ${{ needs.meta.outputs.tag }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -102,10 +139,11 @@ jobs:
       - name: Create the release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag || github.ref_name }}
+          TAG: ${{ needs.meta.outputs.tag }}
+          VERSION: ${{ needs.meta.outputs.version }}
         run: |
           set -euo pipefail
-          notes=$(awk -v tag="${TAG#v}" '
+          notes=$(awk -v tag="${VERSION}" '
             $0 ~ "^## \\[" tag "\\]" { printing = 1; next }
             printing && /^## \[/ { exit }
             printing { print }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Provenance is signed with a short-lived Sigstore certificate obtained
+      # against an OIDC token, and the attestation is then persisted against the
+      # repository — one permission for each half.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -245,6 +250,44 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      # A per-target `.sha256` produced in the same job as its tarball proves
+      # nothing to a downloader: whatever could alter the tarball could rewrite
+      # the digest beside it.  Two things are added here, and neither is GPG or
+      # cosign, which would mean a key for the maintainer to hold and rotate.
+      #
+      # The aggregate file is the ergonomic half.  One `SHA256SUMS` verifies
+      # every asset in a single `shasum -a 256 -c`, and it is what a downloader
+      # who only wants to check a mirror actually reaches for.  The per-target
+      # files stay: they were published before, and dropping them would break
+      # anyone already fetching one.
+      - name: Aggregate the checksums
+        run: |
+          set -euo pipefail
+          cd dist
+          # Sorted by filename so the file is stable across runs regardless of
+          # the order the four build jobs happened to finish in.
+          cat ./*.tar.gz.sha256 | sort -k2 > SHA256SUMS
+          # The digests were computed on four different runners; recompute them
+          # here to prove the artefact round-trip did not damage anything.
+          shasum -a 256 -c SHA256SUMS
+          echo "--- SHA256SUMS"
+          cat SHA256SUMS
+
+      # The trustworthy half.  The attestation binds each tarball's digest to
+      # this workflow, this repository and this commit, signed by Sigstore with a
+      # certificate GitHub issues to the run and which nobody here can reuse.
+      # `gh attestation verify` checks it without the verifier having to trust
+      # any file we publish alongside the artefact — which is exactly what the
+      # `.sha256` files cannot offer.
+      - name: Attest the release artefacts
+        uses: actions/attest-build-provenance@v4
+        with:
+          # Each tarball is its own subject, so `gh attestation verify
+          # servicrab-<version>-<target>.tar.gz --repo gaborini/servicrab`
+          # answers for the file a user actually downloaded, with no indirection
+          # through a checksum list.
+          subject-path: dist/*.tar.gz
 
       - name: Create the release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--color=auto|always|never`, and `--no-color` as a shorthand for
+  `--color=never`. Both are global, so they can go anywhere on the command line.
+  `CLICOLOR_FORCE` is honoured too, for colouring a stream that is a pipe. The
+  order of precedence, from strongest: `--color`, `NO_COLOR`, `CLICOLOR_FORCE`,
+  `TERM=dumb`, and finally whether the stream is a terminal.
+
 - A `Dependabot auto-merge` workflow. `main` now requires a pull request with
   green checks and one approving review, which a bot cannot collect, so the
   weekly dependency bumps are approved and queued for auto-merge from CI
   instead. Major-version updates are left for a human, including a grouped
   update that contains one — the checks are a real review for a patch bump, and
   not much of one for a breaking change.
+
+### Fixed
+
+- Colour is decided from the stream being written to, rather than from stdout
+  for everything. Most of what Servicrab renders — the `up` and `watch` banner
+  and status lines, `events`, the `start --wait` progress — goes to stderr, so
+  `servicrab up 2> stack.err` used to write ANSI escapes into the file, and
+  `servicrab up | cat` used to drop the colour that stderr's terminal justified.
+  Each stream is now asked about itself, and a run can legitimately colour one
+  and not the other.
+
+- `servicrab man` and `servicrab completions <SHELL>` no longer fail when the
+  reader goes away. `servicrab man | head` reported a broken pipe as an error
+  and exited 1; `servicrab completions bash | head` panicked inside the
+  generator, which writes to the stream directly. Both now treat it as the
+  reader having seen enough, and exit 0.
+
+- `servicrab logs` with an empty log directory says so and exits 0. A stack that
+  has not run yet is a state of the world, not a command that failed.
+
+- `servicrab status` and `servicrab down` print their "no daemon is running"
+  message to stderr. It is a diagnostic, so `servicrab status > snapshot` now
+  leaves the file empty rather than putting prose where a table belongs. Exit
+  codes are unchanged (1 for `status`, 0 for `down`), and `status --json` still
+  writes its object to stdout.
+
+- `servicrab logs --follow` no longer prints lines twice. It sampled the file
+  length, read to whatever the end was by then — which could be past that
+  sample — and then rewound to the stale sample, so everything appended in
+  between came out again on the next pass. The offset is now the position the
+  read actually reached.
+
+- `servicrab logs --follow` no longer prints half of a line and then the whole
+  of it. A file that ends mid-line is what a service being written to looks
+  like; the fragment is now held back until its newline arrives. Without
+  `--follow` there is no next pass, so the fragment is still shown.
+
+- `servicrab logs` tolerates output that is not UTF-8. One stray byte — a binary
+  blob, another encoding, a multi-byte character caught mid-write — used to fail
+  the whole command, and cut a `--follow` silently short at that line.
+  Undecodable bytes are replaced and the rest of the log is readable.
 
 ## [0.3.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `servicrab check --json`, emitting the project name, the service count, the
+  start order and the profile membership — and, when the config does not load,
+  a structured error list rather than a paragraph. `check` is the most scripted
+  command and its whole job is reporting problems, so those had to become data.
+- Every `--json` output now carries a `schema_version`, so a script can refuse a
+  stream it was not written for instead of guessing. Whole documents
+  (`check --json`, `list --json`, `status --json`) carry it as a top-level key;
+  the NDJSON streams (`up --json`, `watch --json`, `events --json`) open with
+  the same `{"type":"ok","schema_version":1}` handshake the daemon answers
+  `subscribe` with, rather than repeating the version on every event line.
+- `Response::Error` gained a `code` field — `unknown_service`, `busy`,
+  `not_running`, `already_running`, `validation_failed`, `unsupported`,
+  `failed` — and, for a validation failure, an `errors` list. `message` was the
+  only thing to match on before, and it is prose.
+- `Response::Ok` for a reload gained `changes`, reporting `{added, changed,
+  removed}` as numbers beside the sentence that used to be the only way to
+  learn them.
+- `ServiceInfo` gained a `pgid` field. `pid` stays as a deprecated alias
+  carrying the same number: it always was a process-group id — its own doc
+  comment said so, and `Event::Started` calls the same value `pgid` — and
+  signalling it as a pid reaches only the group leader.
+- Exit code `3` means "no daemon is running for this project". A dedicated code
+  so that a script can tell "there was nothing to talk to" from a real failure
+  without matching on the message.
 - A `Dependabot auto-merge` workflow. `main` now requires a pull request with
   green checks and one approving review, which a bot cannot collect, so the
   weekly dependency bumps are approved and queued for auto-merge from CI
   instead. Major-version updates are left for a human, including a grouped
   update that contains one — the checks are a real review for a patch bump, and
   not much of one for a breaking change.
+
+### Changed
+
+- **`list --json` prints an object, not a bare array.** The services are still
+  an array, now under a `services` key, alongside `project` and
+  `schema_version`. A top-level array has nowhere to put a version.
+- **"No daemon" is exit `3` everywhere.** It was `1` for `status`, `stop`,
+  `restart`, `start SERVICE`, `reload` and `events`, and `0` for `down`. `down`
+  still never *fails* because nothing was running — running it twice is safe,
+  which is the point of it — the code just says whether there was anything to
+  do.
+- **`status`'s "no daemon" message moved to stderr**, where every other error
+  already was; it used to be printed on stdout while exiting non-zero.
+- **Every error is one format**: stderr, an `error: ` prefix, and the individual
+  problems as bullets below it. `stop`, `restart` and `reload` used to print a
+  bare `✗ …` for a rejection, with no prefix; `check` printed its errors itself
+  and then let the top level summarize them again, saying the same thing twice.
+  `✗` remains in `check`'s human report, but not as an error marker.
+- **Under `--json`, errors are JSON**, on stderr, carrying `schema_version` and
+  a `code`. They used to be a text `error: …` line even when the caller had
+  explicitly asked for machine-readable output.
+- `status --json`'s "not running" answer goes through serde like the running
+  one, so the two cannot drift; it used to be a hand-written compact string.
+  Both are pretty-printed now, and carry the same keys.
+- The reload error over the socket is one line plus a list. It used to be an
+  entire multi-line validation report — newlines, bullets and all — stuffed
+  into a single JSON string.
+- `message` on a `Response` is documented as being for people, and explicitly
+  not part of the API. The README no longer quotes the strings verbatim, since
+  doing so was what made them one.
+- The man page's `EXIT STATUS` section documents every code in the contract. It
+  covered only `exec` and `run`, and never mentioned the `129`/`130`/`143` that
+  `up` and `watch` exit with on a signal.
+- In `servicrab-core`, a control command's acknowledgement carries a
+  `ControlOutcome` or a `ControlRefusal` rather than `Result<String, String>`.
+  Both still `Display` as exactly the sentences they replaced.
 
 ## [0.3.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The `ping`/`pong` exchange now carries the revision of the wire format each
+  side speaks. It is optional, because 0.3 spoke this format without naming it
+  and "did not say" has to stay distinguishable from "said 0" — a client that
+  read silence as a mismatch would refuse to talk to a 0.3 daemon. Nothing
+  refuses on the strength of the number; the daemon logs a client that is
+  behind, which is where an operator chasing version skew is already looking.
+
 - A `Dependabot auto-merge` workflow. `main` now requires a pull request with
   green checks and one approving review, which a bot cannot collect, so the
   weekly dependency bumps are approved and queued for auto-merge from CI
   instead. Major-version updates are left for a human, including a grouped
   update that contains one — the checks are a real review for a patch bump, and
   not much of one for a breaking change.
+
+### Fixed
+
+- A newer daemon could end an older client's event stream with a single line.
+  `#[non_exhaustive]` is a promise to downstream *crates* and says nothing about
+  a line of JSON: serde rejects an unrecognised tag outright, so one unknown
+  event kind failed to decode and `servicrab events` exited with an error,
+  mid-run, taking every event behind it. One new event type in a later release
+  would have done that to every client of every earlier one. Each enum the
+  daemon can widen now has an `unknown` fallback: a client skips what it cannot
+  name, keeps reading, and passes the line through verbatim under `--json`, so a
+  consumer that knows more than that build does loses nothing. The same applies
+  to a `status` snapshot, where one unfamiliar state or health verdict used to
+  fail the whole reply.
+
+  A request a daemon does not recognise now gets `this daemon does not support
+  that request` rather than `malformed message: unknown variant …`, which read
+  as "your client is broken" when the truth was "this daemon is older than your
+  client".
+
+- A config written for a later schema reported one of its own keys as a typo
+  instead of naming the version. The version check ran after the field-level
+  parse, and that parse is fatal — so `version = 2` plus any key a future schema
+  would add came back as `unknown field 'new_key_from_v2'`, with not a word
+  about the version. The one message that tells an operator to upgrade servicrab
+  was unreachable for exactly the files it was written for. `version` is now
+  read first, by a pass that names nothing else. An unrecognised key inside a
+  `version = 1` file is still fatal: there it is a typo, and a misspelled
+  `comand` that loaded quietly would be far worse than one that refuses.
 
 ## [0.3.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fail the whole reply.
 
   A request a daemon does not recognise now gets `this daemon does not support
-  that request` rather than `malformed message: unknown variant …`, which read
-  as "your client is broken" when the truth was "this daemon is older than your
-  client".
+  the request "strat"; it supports: ping, status, …` rather than `malformed
+  message: unknown variant …`, which read as "your client is broken" when the
+  truth was "this daemon is older than your client". The name and the list are
+  both there deliberately: deciding an unknown request is no longer a decode
+  error also throws away what serde said about it, and a typo in a hand-rolled
+  client is a far more common reason to see this message than a genuinely newer
+  client is.
 
 - A config written for a later schema reported one of its own keys as a typo
   instead of naming the version. The version check ran after the field-level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,104 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2026-08-03
+
+The first stable release. From here the CLI surface, the socket protocol and the
+`--json` output follow semantic versioning; the Rust API of the internal crates
+and the exact wording of human-readable output do not. See
+[what 1.0 promises](README.md#what-10-promises) for the boundary.
+
+Almost everything below is the release audit: the output contract, the exit
+codes, the socket's privacy, and a supervisor that keeps the process-group
+guarantee it always claimed. Read the breaking changes first.
+
+### Breaking changes
+
+A 0.x script can depend on all of these. Each one is deliberate.
+
+- **`down` exits `3` when no daemon was running, where it used to exit `0`.**
+  This breaks `servicrab down && …`: on an already-stopped stack the right-hand
+  side no longer runs. `down` still never *fails* because nothing was there —
+  running it twice is safe, which is the point of it — the code just
+  distinguishes the two outcomes. The README gives the `case $?` replacement
+  under
+  [`3`, and the one breaking change in it](README.md#3-and-the-one-breaking-change-in-it).
+- **"No daemon is running for this project" is exit `3` everywhere.** It was `1`
+  for `status`, `stop`, `restart`, `start SERVICE`, `reload` and `events`, and
+  `0` for `down`. A script that read `1` as "the command failed" now sees a
+  different number for the one case it most often wants to handle rather than
+  report.
+- **That note is now a diagnostic on stderr**, for `status` and `down` alike; it
+  used to go to stdout. `servicrab status > snapshot` on a stopped stack leaves
+  the file empty instead of putting prose where a table belongs, and
+  `status --json` still writes its object to stdout.
+- **`list --json` prints an object, not a bare array.** The services are still an
+  array, now under a `services` key alongside `project` and `schema_version`, so
+  `jq '.[]'` becomes `jq '.services[]'`. A top-level array has nowhere to put a
+  version.
+- **Under `--json`, errors are JSON on stderr**, carrying `schema_version` and a
+  `code`. They used to be a text `error: …` line even when the caller had
+  explicitly asked for machine-readable output.
+- **`status --json`'s "not running" reply goes through serde** like the running
+  one, so the two cannot drift. It used to be a hand-written compact string;
+  both are pretty-printed now and carry the same keys. Anything comparing that
+  reply byte-for-byte will see a difference.
+- **Every error is one format**: stderr, an `error: ` prefix, and the individual
+  problems as bullets below it. `stop`, `restart` and `reload` used to print a
+  bare `✗ …` with no prefix, and `check` printed its errors itself and then let
+  the top level summarize them again. Output scrapers will need updating; `✗`
+  remains in `check`'s human report, but not as an error marker.
+- **`max_restarts = 0` now means unlimited restarts, not "give up on the first
+  failure".** Zero was accepted with no validation and emptied the budget, which
+  is what `restart = "never"` already says, and the opposite of what Compose and
+  systemd mean by it. A config written from that habit silently got a supervisor
+  that never retried. Configs that meant the old reading should say
+  `restart = "never"`.
+- **`health.retries = 0` is refused instead of being quietly rewritten to `1`.**
+  A config that loaded before now fails validation. There is no sensible reading
+  of zero — a service cannot be called unhealthy without one failed probe — and
+  every other out-of-domain value in the validator already errored.
+- **`servicrab logs` exits `0` on an empty log directory** and says so. A stack
+  that has not run yet is a state of the world, not a command that failed. It
+  still exits `1` when there is no log file to read at all: no `[project.logs]`
+  table, or a named service with `[logs] enabled = false`.
+- **The daemon's socket has moved for projects with long paths.** A project whose
+  path overflowed `sun_path` used to put its socket in the shared temp directory
+  under a name derived from a hash of the config path. That location is gone;
+  the socket now goes to `$XDG_RUNTIME_DIR`, or to `$TMPDIR` when that is a
+  directory this user owns with no group or other bits — plain `/tmp` fails that
+  check by design. With no private directory available the long path stays put
+  and the bind reports `ENAMETOOLONG` rather than trading a startup failure for
+  a spoofable socket. When there is no daemon, `status` names the relocated
+  socket, which is the moment someone starts looking for it. The length check
+  now runs on the canonicalised path, so `-c a/servicrab.toml` and
+  `-c ./a/servicrab.toml` are one project rather than two.
+- **The daemon serves only its own uid.** It asks the kernel who connected and
+  refuses anyone else with one error line naming both uids. `sudo servicrab
+  status` against a user's daemon — a mistake the generated systemd unit's
+  `User=` invites — now fails instead of working.
+- **`SIGHUP` shuts the stack down instead of killing the supervisor.** Closing
+  the terminal on a foreground `run` or `up` used to kill servicrab instantly
+  and leave every service's process group running; it now performs the ordinary
+  ordered shutdown and exits `129`. Like `SIGINT` and `SIGTERM` it counts as
+  user-requested, so `restart = "always"` does not resurrect a service whose
+  operator has gone away.
+- **The reload error over the socket is one line plus a list.** It used to be an
+  entire multi-line validation report — newlines, bullets and all — stuffed into
+  a single JSON string, so a client that split that string on newlines will need
+  to read `errors` instead.
+- **In `servicrab-core`, a control command's acknowledgement carries a
+  `ControlOutcome` or a `ControlRefusal` rather than `Result<String, String>`.**
+  A source break for anything using the crate directly, which the 1.0 promise
+  deliberately does not cover. Both types still `Display` as exactly the
+  sentences they replaced.
+
+### Deprecated
+
+- `ServiceInfo.pid`, in favour of the new `pgid`, which carries the same number.
+  It always was a process-group id — its own doc comment said so, and
+  `Event::Started` calls the same value `pgid` — and signalling it as a pid
+  reaches only the group leader. `pid` still ships, so nothing breaks yet.
 
 ### Added
 
@@ -40,13 +137,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Response::Ok` for a reload gained `changes`, reporting `{added, changed,
   removed}` as numbers beside the sentence that used to be the only way to
   learn them.
-- `ServiceInfo` gained a `pgid` field. `pid` stays as a deprecated alias
-  carrying the same number: it always was a process-group id — its own doc
-  comment said so, and `Event::Started` calls the same value `pgid` — and
-  signalling it as a pid reaches only the group leader.
-- Exit code `3` means "no daemon is running for this project". A dedicated code
-  so that a script can tell "there was nothing to talk to" from a real failure
-  without matching on the message.
+- `ServiceInfo` gained a `pgid` field, carrying the process-group id that `pid`
+  was always reporting. See Deprecated, above.
+- Exit code `3`, meaning "no daemon is running for this project" — a dedicated
+  code so that a script can tell "there was nothing to talk to" from a real
+  failure without matching on the message. Which commands used to say what is in
+  Breaking changes, above.
+- Configuration warnings for the two settings that are accepted and do nothing:
+  a `[services.<name>.logs] enabled` with no `[project.logs]` table, which
+  captures nothing because the router is only built when the project declares a
+  log directory, and an explicit `on_unhealthy = "restart"` alongside
+  `restart = "never"`, where the unhealthy service is stopped and never comes
+  back. `check` used to print a bare `✓` for both. The default `on_unhealthy`
+  with `restart = "never"` is not warned about: that is the legitimate
+  readiness-gating setup.
+- A `LogLinesDropped { count }` event, rendered by `up`, by `events` and in the
+  status registry, so a service that outruns the log path says how much was
+  lost rather than losing it silently. See Performance, below, for the
+  allowance it reports against.
 - A `Dependabot auto-merge` workflow. `main` now requires a pull request with
   green checks and one approving review, which a bot cannot collect, so the
   weekly dependency bumps are approved and queued for auto-merge from CI
@@ -56,88 +164,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`list --json` prints an object, not a bare array.** The services are still
-  an array, now under a `services` key, alongside `project` and
-  `schema_version`. A top-level array has nowhere to put a version.
-- **"No daemon" is exit `3` everywhere.** It was `1` for `status`, `stop`,
-  `restart`, `start SERVICE`, `reload` and `events`, and `0` for `down`. `down`
-  still never *fails* because nothing was running — running it twice is safe,
-  which is the point of it — the code just says whether there was anything to
-  do.
-- **The "no daemon" note is a diagnostic on stderr** for both `status` and
-  `down`, where every other error already was; it used to be printed on stdout.
-  The stream and the exit code changed independently and both are new here: see
-  Fixed, below, for what writing it to stdout did to `servicrab status >
-  snapshot`.
-- **Every error is one format**: stderr, an `error: ` prefix, and the individual
-  problems as bullets below it. `stop`, `restart` and `reload` used to print a
-  bare `✗ …` for a rejection, with no prefix; `check` printed its errors itself
-  and then let the top level summarize them again, saying the same thing twice.
-  `✗` remains in `check`'s human report, but not as an error marker.
-- **Under `--json`, errors are JSON**, on stderr, carrying `schema_version` and
-  a `code`. They used to be a text `error: …` line even when the caller had
-  explicitly asked for machine-readable output.
-- `status --json`'s "not running" answer goes through serde like the running
-  one, so the two cannot drift; it used to be a hand-written compact string.
-  Both are pretty-printed now, and carry the same keys.
-- The reload error over the socket is one line plus a list. It used to be an
-  entire multi-line validation report — newlines, bullets and all — stuffed
-  into a single JSON string.
+The output and exit-code changes are all in Breaking changes, above, because
+every one of them is something a 0.x script could be reading. What is left:
+
 - `message` on a `Response` is documented as being for people, and explicitly
   not part of the API. The README no longer quotes the strings verbatim, since
   doing so was what made them one.
+- `servicrab list` and `servicrab logs` print the configuration warnings they
+  used to discard, on stderr, as `run`, `up`, `exec`, `generate`, `daemon` and
+  `check` already did. The user who reaches for `list` or `logs` to find out why
+  a service is behaving oddly was the least likely to be told that part of their
+  config does nothing — and `logs` in particular fails on the very configs a
+  warning would explain. `list --json` stays parseable on stdout.
+- The hand-stop record in `.servicrab/stopped` is written atomically — to a
+  temporary file, fsynced, renamed — and gains an optional version line, so the
+  format can change later. A file written by 0.3, or one an operator edited the
+  line out of, still reads. Startup now also drops remembered names the
+  configuration no longer declares, so a renamed or deleted service stops
+  accumulating; names are compared against every declared service rather than
+  the started plan, because a profile that is inactive this run is not a service
+  that is gone. Deleting a line is still a legitimate way to forget a stop.
 - The man page's `EXIT STATUS` section documents every code in the contract. It
   covered only `exec` and `run`, and never mentioned the `129`/`130`/`143` that
   `up` and `watch` exit with on a signal.
-- In `servicrab-core`, a control command's acknowledgement carries a
-  `ControlOutcome` or a `ControlRefusal` rather than `Result<String, String>`.
-  Both still `Display` as exactly the sentences they replaced.
 - The crates.io description of `servicrab` no longer says "cross-platform". It
   names Linux and macOS, because supervision has never worked anywhere else and
   the description is the one line a prospective user reads before installing.
   `servicrab-core`'s description now mentions the process runtime it contains.
 
-### Documentation
+### Security
 
-The release audit found the documentation making claims the code does not
-support, so this round verified each one against the binary and corrected it.
-The substantive corrections, rather than the wording:
+- The daemon socket is no longer placed in the shared temp directory under a
+  predictable hashed name, and the daemon no longer serves other users. Both are
+  described in Breaking changes, above, because the socket's location can move
+  and a cross-uid client that used to work now does not. What they close: the
+  old path was guessable by every local user and steerable through `$TMPDIR`, so
+  squatting it was a permanent denial of service, and binding a listener there
+  and answering `pong` made every `status`, `stop`, `down`, `reload` and `events`
+  talk to the attacker — and leak project and service names on the way. The uid
+  check is the second line: a filesystem that ignores Unix modes, or a directory
+  an operator loosened, would otherwise hand over the whole stack.
+- The socket is private from the instant it exists. Binding it and only then
+  restricting the mode left it live and group-writable in between — `0775` on
+  exactly the distributions that use private user groups with `umask 002` — and
+  connecting is all it takes to start, stop or shut down every service in the
+  project. The mode is now part of creating the inode, set by narrowing the umask
+  around the `bind`; the `chmod` stays as a check for a platform that ignores the
+  umask for sockets, not as the mechanism.
+- One socket client can no longer exhaust the daemon. Everything past `accept`
+  is reachable before a byte has been understood and none of it was bounded: an
+  unterminated line grew a `String` until the OOM killer intervened, a silent
+  client held a task and a descriptor for the daemon's life, malformed lines
+  could be pumped in forever, and there was no cap on concurrent connections.
+  There is now a 64 KiB frame limit, a 30-second idle timeout, a ceiling of 64
+  live connections, and a connection is closed after three malformed lines — a
+  client that then talks sense has its strikes forgiven, so a typo costs
+  nothing. The `subscribe` filter became a size-limited `BTreeSet`; it was a
+  client-supplied `Vec` rescanned for every event and every subscriber.
 
-- **The README documents every configuration field's range.** Not one bound was
-  written down before, so the only way to learn that `stable_after` has a floor
-  of a second or that `max_files` stops at 100 was to be refused by `check`.
-  There is a new reference table with every field's type, default and range.
-- **`servicrab-core` is no longer described as free of I/O and async.** Its
-  crate docs said "all I/O is delegated to callers" and `CONTRIBUTING.md` said
-  to keep it "free of I/O and async dependencies", while the crate reads config
-  files, walks `PATH`, opens TCP health probes, and depends on `tokio`. The
-  boundary that does exist — core never formats output for a terminal — is now
-  what all three documents describe.
-- **The durability guarantee is stated as it is, not as intended.** The README
-  said the socket and the pidfile are removed "when the daemon exits, however it
-  exits". Only the graceful path unlinks them; after `SIGKILL`, an OOM kill or a
-  panic both files survive and the supervised children are orphaned, because
-  nothing reconciles them on the next start. There is a new section on what to
-  do about that.
-- **`--profile` and the `-c` alias appear in the command reference**, which
-  listed neither.
-- The README no longer claims a `--json` event stream and `servicrab down` are
-  unimplemented; both shipped in 0.1.0. `SECURITY.md`'s supported-versions table
-  no longer stops at `0.1.x`. The bug-report template no longer suggests a
-  two-year-stale version string. The "exactly what CI runs" list was missing the
-  packaging dry run and counted `cargo deny`, which is not a required check.
-- `${VAR}` substitution is documented as applying to string-valued fields, which
-  is what it has always done — `max_restarts`, `logs.max_files`,
-  `health.retries`, `autostart`, `logs.enabled` and `restart` are not strings.
-- New sections state what v1.0 freezes (the CLI surface, the socket protocol and
-  the JSON output; not the Rust API of the internal crates, and not the column
-  alignment of `--help`), collect the exit codes in one table matching the man
-  page, and replace the roadmap of five simultaneously-current phases.
-
-A new test, `crates/servicrab-cli/tests/config_reference.rs`, keeps the range
-table honest: for each documented bound it runs `check` on a config sitting on
-the bound and one just past it, so widening a limit in `validation.rs` without
-updating the README fails the suite.
 
 ### Fixed
 
@@ -186,15 +270,6 @@ updating the README fails the suite.
   generator, which writes to the stream directly. Both now treat it as the
   reader having seen enough, and exit 0.
 
-- `servicrab logs` with an empty log directory says so and exits 0. A stack that
-  has not run yet is a state of the world, not a command that failed.
-
-- `servicrab status` and `servicrab down` print their "no daemon is running"
-  message to stderr. It is a diagnostic, so `servicrab status > snapshot` now
-  leaves the file empty rather than putting prose where a table belongs, and
-  `status --json` still writes its object to stdout. The exit codes moved too,
-  in the same release but for a different reason — see Changed, above.
-
 - `servicrab logs --follow` no longer prints lines twice. It sampled the file
   length, read to whatever the end was by then — which could be past that
   sample — and then rewound to the stale sample, so everything appended in
@@ -210,6 +285,191 @@ updating the README fails the suite.
   blob, another encoding, a multi-byte character caught mid-write — used to fail
   the whole command, and cut a `--follow` silently short at that line.
   Undecodable bytes are replaced and the rest of the log is readable.
+
+- `servicrab list` no longer panics on a command containing multi-byte
+  characters. The preview sliced `cmd_str[..29]` and `len()` counts bytes, so a
+  config as ordinary as `command = ["echo", "x€€€€€€€€€"]` aborted with "end byte
+  index 29 is not a char boundary" and exit 101. An accented path or an emoji in
+  any argument was enough. The preview now cuts on a character boundary.
+
+- Two daemons can no longer supervise one project. Checking whether the socket
+  answers and then binding it is a time-of-check/time-of-use race, and a tokio
+  runtime gets built in the window: interleaved, the second start unlinked the
+  first daemon's live socket and bound its own, both supervised the whole stack —
+  duplicate processes, duplicate port binds — and whichever exited first deleted
+  the other's socket and pidfile. An exclusive `flock` on the pidfile, held for
+  the daemon's whole life, gives mutual exclusion the kernel enforces and that
+  survives `SIGKILL`. `servicrab start` had the same race one level up and now
+  watches the daemon it spawned rather than only the socket, so the loser of a
+  race stops reporting "daemon started" for a daemon it did not start — and a
+  fifteen-second timeout becomes an immediate, accurate message.
+
+- The process-group guarantee holds on the paths that used to skip it. `stop_all`
+  aborted a supervision task that outstayed its grace period and left cleanup to
+  `kill_on_drop`, which reaches only the direct child, so a grandchild such as
+  `node` under `npm` was orphaned; the same gap sat behind every `?` in
+  `ServiceRunner::run`. The supervisor now sweeps the last reported pgid before
+  aborting, and a process handle sweeps its own group on drop unless it has
+  already been swept.
+
+- A `reload` no longer leaves a service's process group behind. `diff` reports a
+  retiring slot as added and inserting it overwrote the still-winding-down
+  task's stop channel and join handle, so the replacement service was
+  unreachable to `stop_all` and its group outlived the supervisor. A revived slot
+  keeps its channel and handle and defers the spawn, so exactly one process per
+  service is ever alive.
+
+- A service with no dependents recorded its readiness. `watch::Sender::send`
+  returns without writing the value when there is no receiver, so a running,
+  healthy service kept a stale `Pending`, and a later `reload` that gave it a
+  dependent blocked on that stale value — for a stable service, indefinitely.
+
+- A hand-stop is no longer lost to a concurrent one. Recording a stop was an
+  unlocked read-modify-write over a `fs::write` that truncates first, so two
+  stops arriving on two connections lost one of them, and a crash in the window
+  left a file that reads back as "nothing was ever stopped".
+
+- Shutdown signals are claimed before the daemon becomes reachable. The socket is
+  bound before the async runtime exists, so `SIGTERM`, `SIGINT` and `SIGHUP` kept
+  their default disposition in between and a signal there killed the daemon
+  outright, leaving a socket file for the next start to misread.
+
+- The socket is removed when the runtime itself fails to start; that early return
+  used to leave the file on disk.
+
+- A peer refused for its uid is told why, in one line naming both uids, instead
+  of having the connection closed in silence — which every client reported as
+  "the daemon closed the connection without answering". The commands that gate on
+  "is a daemon running" no longer read a refusal as an absent daemon and send the
+  operator looking for one to start.
+
+- A socket that cannot be bound is explained once, up front, by every command
+  that needs one — naming the directory that was refused and why. The rejections
+  used to be reachable only from `bind`, so the daemon reported `ENAMETOOLONG`,
+  every client reported `SUN_LEN` from `connect`, and the message that would let
+  an operator fix it reached nobody.
+
+- A failing per-service command reports what it printed, rather than only that it
+  failed.
+
+- `servicrab up` honours Ctrl+C when nobody is reading its output. Drawing is
+  synchronous, so a consumer that stopped reading parked the renderer in a write
+  that never returned, and shutdown joined that renderer — so `up` never exited
+  at all, while the services were already stopped and the exit code already
+  decided. The wait is now bounded: log files drain first because they are the
+  durable half, and the terminal tail is best effort.
+
+- A stopping service is reported promptly even with a health check. The monitor
+  held a clone of the event sink between probes, keeping the service's event
+  channel and its relay alive, which is what the supervisor waits on before
+  reporting the run. That cost a fixed 2s on every stop of a health-checked
+  service — 2.02s before, 0.02s after, measured with a 30s interval — and on an
+  unbounded wait it exceeded the client's timeout and failed the command outright
+  while the service had already stopped. A probe in flight is still allowed to
+  finish, so no child is abandoned mid-run.
+
+- An output reader that cannot drain is aborted rather than detached, so the stop
+  can be reported. `tokio::time::timeout` consumes the `JoinHandle` and dropping
+  a handle only detaches, so the reader kept its event sink, the relay never
+  ended, and the report the daemon's `stop` and `restart` wait for never came —
+  the client hit its 10-second read timeout and reported "Resource temporarily
+  unavailable" for a service that had exited cleanly. This is what made the
+  daemon suite fail roughly one run in ten.
+
+- The filewatch debounce loop terminates. It waited for quiet unconditionally, so
+  anything changing faster than `debounce` — a log inside the watched tree, a
+  build directory — kept it waiting forever while it re-scanned the whole tree
+  every period and never requested a restart. It now gives up waiting after ten
+  rounds and restarts on what it has. Separately, the tree walk was recursive
+  with no depth bound, so a deep tree overflowed the stack and aborted the
+  supervisor; descent stops at 64 levels and says so.
+
+- A dead health probe is no longer a perpetual event source.
+  `HealthProbeFailed` went out on every failing tick with no ceiling, so
+  `on_unhealthy = "ignore"` plus a permanently dead probe meant an event per
+  interval, published to every subscriber and written into the status registry.
+  The two reports that carry information are kept — the first failure and the one
+  that exhausts the retry budget — and between them the reports thin out to one
+  per hundred, with a recovery resetting the throttle.
+
+### Performance
+
+- File and directory work is off the async workers. The log router did
+  `create_dir_all`, `open`, `write_all` and a flush per line straight from the
+  pumps in `up`, `run` and the daemon collector, and the filewatch scan did a
+  `read_dir` per directory plus a `symlink_metadata` for up to 20 000 entries,
+  four times per round, inline. Those pumps share their threads with the
+  supervisor, so a full or network-backed disk stalled the very threads driving
+  child `wait()`s, health probes and the control channel. Both now run on
+  blocking tasks; the log writer buffers and flushes when it catches up with the
+  queue, and at least every 256 lines while a flood keeps it full.
+
+- Captured output is bounded. Every internal channel was unbounded and captured
+  stdout travels line by line, so a service that floods stdout grew the
+  supervisor's heap without limit and told nobody. Log lines now have an
+  allowance of 1024 queued per event channel and the newest beyond it is dropped
+  — the newest, because it is the only one the sender can still choose to lose,
+  so what survives stays in order. Everything the supervisor says *about* a
+  service still goes through unconditionally: losing a state change would corrupt
+  the status registry.
+
+- A full log queue drops the line rather than stalling the pump that fills it.
+  The queue was back-pressure, which reintroduced one stage further along exactly
+  what moving the file work off the worker was meant to prevent — the daemon's
+  collector also keeps the status registry current and feeds every `events`
+  subscriber. A log with a hole in it that says where the hole is beats a
+  supervisor that stops answering.
+
+- A flood no longer reports its own losses without bound. One delivered line was
+  read as the flood letting up, but it frees exactly one slot the flood refills
+  at once, so the loss was announced once per delivered line: 1536 reports for
+  2560 lines, measured. A let-up now means the consumer won back half the
+  allowance.
+
+### Documentation
+
+The release audit found the documentation making claims the code does not
+support, so this round verified each one against the binary and corrected it.
+The substantive corrections, rather than the wording:
+
+- **The README documents every configuration field's range.** Not one bound was
+  written down before, so the only way to learn that `stable_after` has a floor
+  of a second or that `max_files` stops at 100 was to be refused by `check`.
+  There is a new reference table with every field's type, default and range.
+- **`servicrab-core` is no longer described as free of I/O and async.** Its
+  crate docs said "all I/O is delegated to callers" and `CONTRIBUTING.md` said
+  to keep it "free of I/O and async dependencies", while the crate reads config
+  files, walks `PATH`, opens TCP health probes, and depends on `tokio`. The
+  boundary that does exist — core never formats output for a terminal — is now
+  what all three documents describe.
+- **The durability guarantee is stated as it is, not as intended.** The README
+  said the socket and the pidfile are removed "when the daemon exits, however it
+  exits". Only the graceful path unlinks them; after `SIGKILL`, an OOM kill or a
+  panic both files survive and the supervised children are orphaned, because
+  nothing reconciles them on the next start. There is a new section on what to
+  do about that, including the `pgrep -fl 'servicrab daemon'` that finds the
+  orphans — and a measured count of what that command found on one development
+  machine, in place of the smaller anecdote that had been there.
+- **`--profile` and the `-c` alias appear in the command reference**, which
+  listed neither.
+- The README no longer claims a `--json` event stream and `servicrab down` are
+  unimplemented; both shipped in 0.1.0. `SECURITY.md`'s supported-versions table
+  no longer stops at `0.1.x`. The bug-report template no longer suggests a
+  two-year-stale version string. The "exactly what CI runs" list was missing the
+  packaging dry run and counted `cargo deny`, which is not a required check.
+- `${VAR}` substitution is documented as applying to string-valued fields, which
+  is what it has always done — `max_restarts`, `logs.max_files`,
+  `health.retries`, `autostart`, `logs.enabled` and `restart` are not strings.
+- New sections state what v1.0 freezes (the CLI surface, the socket protocol and
+  the JSON output; not the Rust API of the internal crates, and not the column
+  alignment of `--help`), collect the exit codes in one table matching the man
+  page, and replace the roadmap of five simultaneously-current phases.
+
+A new test, `crates/servicrab-cli/tests/config_reference.rs`, keeps the range
+table honest: for each documented bound it runs `check` on a config sitting on
+the bound and one just past it, so widening a limit in `validation.rs` without
+updating the README fails the suite. `tests/help.rs` and `tests/contract.rs` pin
+the help text and the output contract the same way.
 
 ## [0.3.0] - 2026-07-30
 
@@ -480,7 +740,7 @@ config commands work and the runtime reports `UnsupportedPlatform`.
 - `servicrab up --json` and `servicrab watch --json` emit the same event lines
   the daemon streams, for scripts and wrappers.
 
-[Unreleased]: https://github.com/gaborini/servicrab/compare/v0.3.0...HEAD
+[1.0.0]: https://github.com/gaborini/servicrab/compare/v0.3.0...v1.0.0
 [0.3.0]: https://github.com/gaborini/servicrab/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gaborini/servicrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/gaborini/servicrab/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In `servicrab-core`, a control command's acknowledgement carries a
   `ControlOutcome` or a `ControlRefusal` rather than `Result<String, String>`.
   Both still `Display` as exactly the sentences they replaced.
+- The crates.io description of `servicrab` no longer says "cross-platform". It
+  names Linux and macOS, because supervision has never worked anywhere else and
+  the description is the one line a prospective user reads before installing.
+  `servicrab-core`'s description now mentions the process runtime it contains.
+
+### Documentation
+
+The release audit found the documentation making claims the code does not
+support, so this round verified each one against the binary and corrected it.
+The substantive corrections, rather than the wording:
+
+- **The README documents every configuration field's range.** Not one bound was
+  written down before, so the only way to learn that `stable_after` has a floor
+  of a second or that `max_files` stops at 100 was to be refused by `check`.
+  There is a new reference table with every field's type, default and range.
+- **`servicrab-core` is no longer described as free of I/O and async.** Its
+  crate docs said "all I/O is delegated to callers" and `CONTRIBUTING.md` said
+  to keep it "free of I/O and async dependencies", while the crate reads config
+  files, walks `PATH`, opens TCP health probes, and depends on `tokio`. The
+  boundary that does exist — core never formats output for a terminal — is now
+  what all three documents describe.
+- **The durability guarantee is stated as it is, not as intended.** The README
+  said the socket and the pidfile are removed "when the daemon exits, however it
+  exits". Only the graceful path unlinks them; after `SIGKILL`, an OOM kill or a
+  panic both files survive and the supervised children are orphaned, because
+  nothing reconciles them on the next start. There is a new section on what to
+  do about that.
+- **`--profile` and the `-c` alias appear in the command reference**, which
+  listed neither.
+- The README no longer claims a `--json` event stream and `servicrab down` are
+  unimplemented; both shipped in 0.1.0. `SECURITY.md`'s supported-versions table
+  no longer stops at `0.1.x`. The bug-report template no longer suggests a
+  two-year-stale version string. The "exactly what CI runs" list was missing the
+  packaging dry run and counted `cargo deny`, which is not a required check.
+- `${VAR}` substitution is documented as applying to string-valued fields, which
+  is what it has always done — `max_restarts`, `logs.max_files`,
+  `health.retries`, `autostart`, `logs.enabled` and `restart` are not strings.
+- New sections state what v1.0 freezes (the CLI surface, the socket protocol and
+  the JSON output; not the Rust API of the internal crates, and not the column
+  alignment of `--help`), collect the exit codes in one table matching the man
+  page, and replace the roadmap of five simultaneously-current phases.
+
+A new test, `crates/servicrab-cli/tests/config_reference.rs`, keeps the range
+table honest: for each documented bound it runs `check` on a config sitting on
+the bound and one just past it, so widening a limit in `validation.rs` without
+updating the README fails the suite.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,15 @@ file.
    git checkout -b feat/my-feature
    ```
 4. **Make changes**, then run the checks locally before pushing. These are the
-   same commands CI runs, so a clean sweep here means a green pipeline:
+   same commands CI runs, `--locked` included — without it cargo may resolve a
+   newer transitive dependency and you would be testing something other than
+   what `Cargo.lock` ships:
    ```sh
-   cargo fmt --all
-   cargo clippy --workspace --all-targets --all-features -- -D warnings
-   cargo test --workspace --all-features
+   cargo fmt --all -- --check
+   cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+   cargo test --workspace --all-features --locked
+   RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
+   cargo package --workspace --locked
    ```
 5. **Open a pull request** against the `main` branch.
 
@@ -39,10 +43,15 @@ file.
 
 `main` is protected, so a change reaches it through a pull request that has:
 
-- **the five CI checks green** — `fmt + clippy + test` on Linux and macOS, the
-  MSRV check, the Windows stub build, and the crates.io packaging dry run;
+- **the six CI checks green** — `fmt + clippy + test` on Linux and macOS, the
+  MSRV check, the Windows stub build, the crates.io packaging dry run, and the
+  rustdoc build with `-D warnings`;
 - **one approving review** from a maintainer;
 - **every review conversation resolved**.
+
+The `Audit` workflow's `cargo-deny` job is not one of the six. It runs on a pull
+request only when `Cargo.toml`, `Cargo.lock` or `deny.toml` changed, on the
+grounds that a newly published advisory should not fail an unrelated change.
 
 Your branch does not have to be up to date with `main` before merging: this is a
 small project, and forcing a rebase for every unrelated commit costs more than it
@@ -87,7 +96,23 @@ cargo +1.85 check --workspace --all-features --all-targets --locked
 ## Development tips
 
 - The workspace uses a **resolver = "2"** so that feature flags are resolved per-crate.
-- Keep `servicrab-core` free of I/O and async dependencies — it must stay usable from both the CLI and future daemon without pulling in the full Tokio runtime.
+- **File names are `snake_case`**, matching the module names they define
+  (`validation.rs`, `stack_stub.rs`). There is no `camelCase` file in the
+  workspace and no `*.test.rs` convention; if a tool tells you otherwise, it is
+  guessing from a different language.
+- **Imports are absolute**: `use crate::…` inside a crate,
+  `use servicrab_core::…` across crates. `use super::*;` appears only inside
+  `#[cfg(test)] mod tests`, to reach the module under test.
+- Keep the CLI's concerns out of `servicrab-core`. The split is not "no I/O" —
+  core reads config files, walks `PATH`, opens TCP health probes and runs on
+  `tokio` — it is that **core never formats output for a terminal**: it returns
+  typed values and publishes structured events, and the CLI decides how they
+  look. So no `clap`, no styling, no terminal detection, and no `println!` in
+  core; and no supervision logic in the CLI.
+- Platform-specific process code lives behind `#[cfg]` in
+  `crates/servicrab-core/src/runtime/`, with a stub that returns
+  `RuntimeError::UnsupportedPlatform` elsewhere. Windows must keep compiling —
+  CI checks it — so a new runtime entry point needs a stub alongside it.
 - Add unit tests in the same file as the code under test (in a `#[cfg(test)] mod tests { … }` block).
 - Add integration tests under `tests/` in the relevant crate only when you need to exercise the binary.
 
@@ -95,13 +120,18 @@ cargo +1.85 check --workspace --all-features --all-targets --locked
 
 ## Commit messages
 
-Use short imperative sentences:
+A subject line is a short imperative sentence saying what the commit does, and
+preferably why. There is no `type:` prefix convention — the history is plain
+sentences, and a `feat:`/`fix:` prefix would be the odd one out:
 
 ```
 Add restart-policy validation
-Fix: handle empty command in run subcommand
-Docs: update README roadmap
+Handle an empty command in the run subcommand
+Read the config version before the parse that its own keys would fail
 ```
+
+Use the body for the reasoning that will not be obvious in six months. That is
+where this project puts the *why*, in prose.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +354,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "servicrab"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "servicrab-core"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "humantime",
  "nix",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "servicrab-protocol"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["servicrab contributors"]
 license = "MIT OR Apache-2.0"
@@ -57,5 +57,5 @@ thiserror = "2"
 anyhow = "1"
 
 # Internal crates
-servicrab-core = { path = "crates/servicrab-core", version = "0.3.0" }
-servicrab-protocol = { path = "crates/servicrab-protocol", version = "0.3.0" }
+servicrab-core = { path = "crates/servicrab-core", version = "1.0.0" }
+servicrab-protocol = { path = "crates/servicrab-protocol", version = "1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,9 @@ toml = "1"
 # Duration parsing
 humantime = "2"
 
-# Unix process/signal APIs (used only by the Unix runtime module)
-nix = { version = "0.31", features = ["signal", "process"] }
+# Unix process/signal APIs (used only by the Unix runtime module).  `fs` is
+# there for the `flock` that gives one project one daemon.
+nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
 # Logging / tracing
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ humantime = "2"
 
 # Unix process/signal APIs (used only by the Unix runtime module).  `fs` is
 # there for the `flock` that gives one project one daemon.
-nix = { version = "0.31", features = ["signal", "process", "fs"] }
+nix = { version = "0.31", features = ["signal", "process", "fs", "socket", "user"] }
 
 # Logging / tracing
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -1193,13 +1193,25 @@ Every service runs in its own process group, so signalling the group id — the
 `pgid` in `status --json` and in the `started` event, which is the number the
 group was created with — reaches the service and its descendants together.
 
-This is not hypothetical: during development two test daemons escaped a killed
-harness and ran for nineteen hours before anyone noticed, which is the same
-class of orphan. If you need supervision that survives its own supervisor being
-killed, run `servicrab daemon` under something whose job that is — systemd or
-launchd, with `Restart=` set — and see
+This is not hypothetical. While this documentation was being written, a check of
+the development machine found **twenty** escaped `servicrab daemon` processes
+from three different worktrees, every one of them still supervising services
+whose configuration directory had long since been deleted, and the oldest of
+them more than **twenty-four hours** old. Orphans do not announce themselves;
+they are found by going to look. If you need supervision that survives its own
+supervisor being killed, run `servicrab daemon` under something whose job that
+is — systemd or launchd, with `Restart=` set — and see
 [Running under systemd or launchd](#running-under-systemd-or-launchd). Servicrab
 supervises your services; it does not supervise itself.
+
+A quick way to go and look:
+
+```bash
+pgrep -fl 'servicrab daemon'
+```
+
+Each line names the config the daemon was started with. A config path that no
+longer exists is a daemon nothing is going to reach.
 
 ### The socket protocol
 

--- a/README.md
+++ b/README.md
@@ -678,11 +678,23 @@ what you see in the terminal — the files are a copy, not a redirect.
 Read them back with `logs`:
 
 ```console
-$ servicrab logs -n 2
+$ servicrab logs
+db     | starting postgres
 db     | db up
+worker | worker ready
+worker | picked up job 41
+$ servicrab logs -n 1
 db     | db up
 worker | picked up job 41
-worker | picked up job 41
+```
+
+A single named service is printed without the prefix, since there is nothing to
+tell apart:
+
+```console
+$ servicrab logs db
+starting postgres
+db up
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ if you want shell semantics.
 | Command | Description |
 |---|---|
 | `servicrab init [--path PATH] [--force]` | Generate an example `servicrab.toml` |
-| `servicrab check [--config PATH]` | Parse and validate the config file |
+| `servicrab check [--config PATH] [--json]` | Parse and validate the config file |
 | `servicrab list [--config PATH] [--json]` | List all services with their restart policies |
 | `servicrab run <SERVICE> [--config PATH] [--no-restart]` | Supervise one service in the foreground |
 | `servicrab exec <SERVICE> [--config PATH] -- <COMMAND>...` | Run a command in a service's environment and working directory |
@@ -970,16 +970,44 @@ echo '{"type":"status"}' | nc -U .servicrab/daemon.sock
 | --- | --- |
 | `{"type":"ping"}` | `{"type":"pong","project":"…","pid":123}` |
 | `{"type":"status"}` | `{"type":"status","services":[…]}` |
-| `{"type":"shutdown"}` | `{"type":"ok","message":"stopping the stack"}` |
-| `{"type":"start_service","name":"api"}` | `{"type":"ok","message":"api started"}` |
-| `{"type":"stop_service","name":"api"}` | `{"type":"ok","message":"api stopped"}` |
-| `{"type":"restart_service","name":"api"}` | `{"type":"ok","message":"api restarted"}` |
-| `{"type":"reload"}` | `{"type":"ok","message":"reloaded demo: 1 added, 1 changed, 0 removed"}` |
-| `{"type":"subscribe"}` | `{"type":"ok"}`, then a `{"type":"event",…}` line per event |
+| `{"type":"shutdown"}` | `{"type":"ok","message":"…"}` |
+| `{"type":"start_service","name":"api"}` | `{"type":"ok","message":"…"}` |
+| `{"type":"stop_service","name":"api"}` | `{"type":"ok","message":"…"}` |
+| `{"type":"restart_service","name":"api"}` | `{"type":"ok","message":"…"}` |
+| `{"type":"reload"}` | `{"type":"ok","message":"…","changes":{"added":1,"changed":1,"removed":0}}` |
+| `{"type":"subscribe"}` | `{"type":"ok","schema_version":1}`, then a `{"type":"event",…}` line per event |
 
 `stop_service` and `restart_service` only answer once the service has actually
 stopped (and, for a restart, been replaced), so scripts can rely on the reply
 instead of polling.
+
+**`message` is for people, not for programs.** It is a sentence written for
+whoever is reading the terminal, and its wording may change in any release.
+Everything a program should act on is a field of its own: `changes` on a
+reload's `ok`, and on an `error`:
+
+```json
+{"type":"error","code":"validation_failed","message":"servicrab.toml has 2 error(s); the stack was left untouched","errors":["services.api: command must not be empty","services.web: unknown dependency \"nowhere\""]}
+```
+
+| `code` | Meaning |
+| --- | --- |
+| `unknown_service` | The request named a service this daemon does not supervise |
+| `busy` | Another command for that service has not finished yet |
+| `not_running` | Nothing is listening: no daemon is running for this project |
+| `already_running` | The service, or the daemon, is running already |
+| `validation_failed` | The configuration did not load, or did not validate — see `errors` |
+| `unsupported` | This daemon does not support that request |
+| `failed` | It failed for a reason with no code of its own |
+
+The set can grow, so treat an unfamiliar code as `failed`. A response from a
+0.x daemon has no `code` at all, which reads the same way.
+
+`ServiceInfo` entries carry the running process's group id as **`pgid`**.
+`pid` is a deprecated alias holding the same number: it always was a
+process-group id — every service runs in its own group, whose leader is the
+direct child — and signalling it as a pid would reach only that leader. `pgid`
+is the name `Event::Started` has always used for it.
 
 ### Live event streaming
 
@@ -990,17 +1018,18 @@ two optional fields — `services` (an allow-list; empty means all of them) and
 
 ```bash
 $ echo '{"type":"subscribe","services":["api"]}' | nc -U .servicrab/daemon.sock
-{"type":"ok"}
+{"type":"ok","schema_version":1}
 {"type":"event","service":"api","event":{"kind":"log","stream":"stdout","line":"listening on :8080"}}
 {"type":"event","service":"api","event":{"kind":"state","state":"stopping"}}
 ```
 
 `up --json` and `watch --json` print the very same lines without a daemon in
 sight, so a wrapper can consume a foreground stack the same way it consumes a
-background one:
+background one — handshake included:
 
 ```console
 $ servicrab up --json
+{"type":"ok","schema_version":1}
 {"type":"event","service":"api","event":{"kind":"state","state":"starting"}}
 {"type":"event","service":"api","event":{"kind":"log","stream":"stdout","line":"listening on :8080"}}
 ```
@@ -1031,6 +1060,76 @@ The stream is a live feed, not a backlog: a subscriber sees what happens from
 the moment it attaches (use `servicrab logs` for history). A client too slow to
 keep up gets a `{"type":"lagged","skipped":N}` notice instead of silently
 missing events, and the command exits cleanly when the daemon stops.
+
+### Machine-readable output
+
+Every `--json` output carries a `schema_version`. It is bumped only when a shape
+changes in a way an existing reader would misread — adding an optional field is
+not such a change — so a script can refuse a stream it was not written for
+instead of guessing.
+
+There are two shapes, and which one a command uses follows from what it is:
+
+- **A whole document**, pretty-printed, for the commands that answer a question
+  and exit: `check --json`, `list --json`, `status --json`. `schema_version` is
+  a key at the top level, alongside the payload. `list` keeps its services in an
+  array, but under a `services` key rather than as the top-level value — a bare
+  array has nowhere to put the version.
+- **NDJSON**, one object per line, for the commands that stream:
+  `up --json`, `watch --json`, `events --json`. Each opens with the same
+  `{"type":"ok","schema_version":1}` handshake the daemon answers `subscribe`
+  with, then writes one event per line. The version is not repeated on every
+  line: these streams can run for days.
+
+Errors are JSON too, on **stderr**, so stdout carries nothing but the document
+that was asked for:
+
+```console
+$ servicrab check --json
+{"schema_version":1,"error":{"code":"validation_failed","message":"servicrab.toml has 2 error(s)","errors":["services.api: command must not be empty","services.web: unknown dependency \"nowhere\""]}}
+```
+
+`code` is the same stable set the [socket protocol](#the-socket-protocol) uses.
+`message` is for people and may be reworded in any release.
+
+### Exit codes for every command
+
+Every command follows the same rules:
+
+| Situation | Exit code |
+|---|---|
+| It worked | `0` |
+| It failed | `1` |
+| No daemon is running for this project | `3` |
+| `up` / `watch` was interrupted (`SIGHUP` / Ctrl+C / `SIGTERM`) | `129` / `130` / `143` |
+| `exec` or `run` ran something | that process's own status (`128+N` for a signal, `126`/`127` for `exec`) |
+
+`3` is the one worth knowing about. It means "there was nothing to talk to",
+which is a thing scripts routinely want to handle rather than report:
+
+```bash
+servicrab down
+case $? in
+  0) echo "stopped it" ;;
+  3) echo "nothing was running" ;;  # not a failure
+  *) echo "something went wrong"; exit 1 ;;
+esac
+```
+
+`down` still never *fails* because nothing was running — running it twice is
+safe, which is the whole point of it — the code just distinguishes the two
+outcomes. The same `3` comes from `status`, `stop`, `restart`,
+`start SERVICE`, `reload` and `events`.
+
+Errors always go to **stderr**, prefixed with `error: `, with the individual
+problems as bullets below:
+
+```console
+$ servicrab check
+error: /srv/demo/servicrab.toml has 2 error(s)
+  • services.api: command must not be empty
+  • services.web: unknown dependency "nowhere"
+```
 
 ### Config hot-reload
 

--- a/README.md
+++ b/README.md
@@ -366,8 +366,12 @@ api   | listening on 0.0.0.0:3000
 
 A service's own stdout is written to Servicrab's stdout and its stderr to
 Servicrab's stderr, so `servicrab up > stack.log` keeps the two apart. Colour is
-disabled automatically when the output is not a terminal, when `NO_COLOR` is
-set, or when `TERM=dumb`.
+decided per stream: whichever of stdout and stderr is a terminal gets colour, so
+`servicrab up 2> stack.err` leaves the file free of escapes and
+`servicrab up | cat` still colours the progress on stderr. `--color=never` (or
+`--no-color`) turns colour off, `--color=always` forces it on both streams, and
+`CLICOLOR_FORCE` forces it for a redirected stream. `NO_COLOR` and `TERM=dumb`
+disable it; `--color` wins over all of them.
 
 ### Which services are started
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Servicrab
 
-A **lightweight, cross-platform process supervisor** for local development stacks, homelabs, and small servers — written in Rust.
+A **lightweight process supervisor** for local development stacks, homelabs, and
+small servers — written in Rust. Supervision is **Linux and macOS only**; the
+Windows build compiles but every runtime entry point reports
+`UnsupportedPlatform`.
 
-Think of it as a minimal, zero-dependency alternative to [overmind](https://github.com/DarthSim/overmind) or [Honcho](https://github.com/nicksylett/honcho), with a roadmap toward daemon-based management and a local API.
+Think of it as a smaller alternative to
+[overmind](https://github.com/DarthSim/overmind) or
+[Honcho](https://github.com/nicksylett/honcho): one binary, a declarative config
+file, a background daemon with a documented socket protocol, and `--json` on
+everything a script would want to read.
 
 [![CI](https://github.com/gaborini/servicrab/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/gaborini/servicrab/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/servicrab.svg)](https://crates.io/crates/servicrab)
@@ -10,22 +17,23 @@ Think of it as a minimal, zero-dependency alternative to [overmind](https://gith
 
 ---
 
-## Features (v0.2)
+## Features
 
 - Declare your entire local stack in one `servicrab.toml`, or split it across
   files with `include`
 - Profiles: group the optional services and ask for them with `--profile`
-- `${VAR}` substitution in every config value, strict about unset variables
+- `${VAR}` substitution in the string-valued config fields, strict about unset
+  variables
 - `servicrab init` — scaffold a config in seconds
 - `servicrab check` — validate your config before running anything
 - `servicrab list` — see all services and their restart policies at a glance
-- `servicrab run <service>` — supervise a single service in the foreground with live stdout/stderr, restart policy, and process-group shutdown (Linux/macOS)
+- `servicrab run <service>` — supervise a single service in the foreground with live stdout/stderr, restart policy, and process-group shutdown
 - `servicrab exec <service> -- <cmd>` — run anything in a service's environment and working directory, whether or not the service is up
-- `servicrab up` — run your whole stack in the foreground: dependency-ordered start, interleaved and colour-prefixed output, reverse-order shutdown (Linux/macOS)
+- `servicrab up` — run your whole stack in the foreground: dependency-ordered start, interleaved and colour-prefixed output, reverse-order shutdown
 - Health checks: `command`, `http` and `tcp` probes with readiness gating and automatic restart of unhealthy services
 - `servicrab watch` — restart a service as soon as its sources change, with ignore rules and debouncing
 - Log files: opt-in per-service capture with size-based rotation, plus `servicrab logs [-f]` to read and follow them
-- Background daemon: `servicrab start` / `status` / `stop` / `restart` / `down`, with a documented JSON-over-Unix-socket protocol (Linux/macOS)
+- Background daemon: `servicrab start` / `status` / `stop` / `restart` / `down`, with a documented JSON-over-Unix-socket protocol
 - `servicrab start --wait` — block until every service is ready (health checks included), with an exit code that says whether it worked
 - `servicrab reload` — apply config changes to a running stack without stopping the services you did not touch
 - `servicrab events` — follow a running stack live: logs, state changes, restarts and health verdicts, as text or JSON
@@ -163,7 +171,125 @@ if you want shell semantics.
 
 ---
 
+## Configuration reference
+
+Every field, its type, its default and its accepted range. The ranges are real:
+each one is checked at load time, and `servicrab check` reports a violation with
+the field name and the limit it broke.
+
+Durations use the [humantime](https://docs.rs/humantime) syntax — `500ms`, `10s`,
+`2m`, `1h30m`. Sizes accept `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB` and
+`TB`/`TiB`, all as powers of 1024.
+
+### Top level
+
+| Field | Type | Default | Range / notes |
+|---|---|---|---|
+| `version` | integer | — | Required, and must be `1`. A later number is reported as an unsupported schema version rather than as a typo in one of its keys. |
+| `include` | string or list of strings | none | Paths to files holding further `[services.<name>]` tables. Relative to the file that declares them. Not `${VAR}`-substituted. |
+
+### `[project]`
+
+| Field | Type | Default | Range / notes |
+|---|---|---|---|
+| `name` | string | — | Required. 1–64 bytes, ASCII only, must start alphanumeric, then alphanumerics `.` `_` `-`. Not `${VAR}`-substituted: it decides where the daemon keeps its socket. |
+| `env` | table of string → string | empty | Keys must be non-empty and contain no `=` or NUL. Values are substituted. |
+| `env_file` | string or list of strings | none | Dotenv files loaded for every service, in declaration order, before `[project.env]`. Relative to the config file. |
+
+### `[project.logs]`
+
+Absent by default, and its absence means no file capture at all.
+
+| Field | Type | Default | Range / notes |
+|---|---|---|---|
+| `dir` | string | `.servicrab/logs` | Relative paths resolve against the config file. An existing non-directory is a config error. |
+| `max_size` | size string | `10MB` | **1 KiB … 1 TiB** (`1024` … `1099511627776` bytes). |
+| `max_files` | integer | `3` | **0 … 100.** `0` truncates instead of keeping history. |
+
+### `[services.<name>]`
+
+The name follows the project-name rules with a **48-byte** limit rather than 64.
+
+| Field | Type | Default | Range / notes |
+|---|---|---|---|
+| `command` | list of strings | — | Required and non-empty. First element is the executable; no element may contain a NUL. Never run through a shell. |
+| `cwd` | string | the declaring file's directory | Must exist and be a directory. Relative paths resolve against the file that declared the service. |
+| `env` | table of string → string | empty | As `[project.env]`, and wins over it. |
+| `env_file` | string or list of strings | none | Loaded after the project's, before `[services.<name>.env]`. |
+| `depends_on` | list of names, or table of name → `{ condition }` | none | A service uses one form or the other, not both. Neither the names nor the conditions are substituted. |
+| `profiles` | list of strings | empty | Each follows the service-name rules (48 bytes). Duplicates are an error. Not substituted. |
+| `autostart` | boolean | `true` | Not a string, so not `${VAR}`-substitutable. |
+| `restart` | `never` \| `on-failure` \| `always` \| `unless-stopped` | `never` | An enum, so not substitutable. |
+| `restart_delay` | duration | `1s` | **100ms … 1h.** |
+| `restart_max_delay` | duration | `30s` | **100ms … 24h**, and must be ≥ `restart_delay`. |
+| `max_restarts` | integer | `10` | Any `u32`. `0` means unlimited, so there is no range to check. |
+| `stable_after` | duration | `60s` | **1s … 24h.** |
+| `shutdown_signal` | `term` \| `int` \| `quit` \| `hup` | `term` | A string field, so substitutable — but only these four values are accepted. |
+| `shutdown_timeout` | duration | `10s` | **100ms … 1h.** |
+
+`restart_delay`, `restart_max_delay`, `max_restarts` and `stable_after` are
+warned about — not rejected — when `restart = "never"`, because there they have
+nothing to do.
+
+### `[services.<name>.health]`
+
+Absent by default. Exactly one of `command`, `http` or `tcp` must be set.
+
+| Field | Type | Default | Range / notes |
+|---|---|---|---|
+| `command` | list of strings | — | Healthy when it exits `0`. Run with the service's environment and `cwd`. |
+| `http` | string | — | An `http://host[:port][/path]` URL; healthy on any 2xx or 3xx. No TLS, no redirects, no credentials. Port defaults to `80`, path to `/`. |
+| `tcp` | string | — | `host:port`, or `[::1]:port` for an IPv6 literal. Port must not be `0`. |
+| `interval` | duration | `2s` | **100ms … 1h.** |
+| `timeout` | duration | `5s` | **100ms … 1h.** |
+| `retries` | integer | `3` | **≥ 1.** `0` is rejected: a service cannot be declared unhealthy without one failed probe. |
+| `start_period` | duration | `0s` | **0s … 24h.** Failures inside it never count. |
+| `on_unhealthy` | `restart` \| `ignore` | `restart` | With `restart`, the service is stopped and its **restart policy** decides what happens next. |
+
+### `[services.<name>.watch]`
+
+Absent by default.
+
+| Field | Type | Default | Range / notes |
+|---|---|---|---|
+| `paths` | list of strings | — | Required and non-empty; every entry must exist. Relative to the service's `cwd`. |
+| `ignore` | list of strings | empty | Names, `dir/prefix` or `*.ext`. `.git` and `.servicrab` are always added. |
+| `interval` | duration | `1s` | **100ms … 1h.** |
+| `debounce` | duration | `300ms` | **50ms … 1h.** |
+
+### `[services.<name>.logs]`
+
+| Field | Type | Default | Range / notes |
+|---|---|---|---|
+| `enabled` | boolean | `true` | `false` keeps this one service out of the log files. Inert, with a warning, when there is no `[project.logs]`. |
+
+### What `${VAR}` reaches
+
+Substitution applies to **string-valued fields only**, which follows from where
+it happens: values are expanded before the TOML is turned into typed data, so a
+field that is not a string has no string for a `${VAR}` to live in.
+
+```toml
+shutdown_timeout = "${TIMEOUT:-10s}"   # a string field — expanded
+max_restarts     = "${MAX}"            # rejected: expected u32, got a string
+```
+
+The fields that cannot take a variable are therefore `version`, `autostart`,
+`restart`, `max_restarts`, `logs.max_files`, `logs.enabled` and `health.retries`
+(all non-strings), plus `include`, the project `name`, the service names, the
+`profiles` and the `depends_on` names and conditions — those last are strings,
+but are deliberately left literal so that the shape of a stack cannot depend on
+who started it.
+
+An unknown field anywhere is a hard error, not a warning: a misspelled `comand`
+that loaded quietly would be far worse than one that refuses.
+
+---
+
 ## Command reference
+
+`--config` may be spelled `-c`, and every command accepts the two global colour
+flags (`--color=auto|always|never`, `--no-color`); neither is repeated below.
 
 | Command | Description |
 |---|---|
@@ -172,20 +298,26 @@ if you want shell semantics.
 | `servicrab list [--config PATH] [--json]` | List all services with their restart policies |
 | `servicrab run <SERVICE> [--config PATH] [--no-restart]` | Supervise one service in the foreground |
 | `servicrab exec <SERVICE> [--config PATH] -- <COMMAND>...` | Run a command in a service's environment and working directory |
-| `servicrab up [SERVICE...] [--config PATH] [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure] [--json]` | Supervise a whole stack in the foreground |
-| `servicrab watch [SERVICE...] [--config PATH] [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure] [--json]` | Like `up`, and restart services when their watched files change |
+| `servicrab up [SERVICE...] [--config PATH] [--profile NAME]... [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure] [--json]` | Supervise a whole stack in the foreground |
+| `servicrab watch [SERVICE...] [--config PATH] [--profile NAME]... [--no-restart] [--no-prefix] [--timestamps] [--abort-on-failure] [--json]` | Like `up`, and restart services when their watched files change |
 | `servicrab logs [SERVICE...] [--config PATH] [-f] [-n N] [--no-prefix]` | Show (and follow) the captured log files |
-| `servicrab start [SERVICE...] [--config PATH] [--no-restart] [--wait] [--timeout DUR]` | Start the stack in the background, optionally waiting until it is ready |
+| `servicrab start [SERVICE...] [--config PATH] [--profile NAME]... [--no-restart] [--wait] [--timeout DUR]` | Start the stack in the background, optionally waiting until it is ready |
 | `servicrab status [--config PATH] [--json]` | Show what the background daemon is doing |
 | `servicrab stop <SERVICE...> [--config PATH]` | Stop individual services in the running daemon |
 | `servicrab restart <SERVICE...> [--config PATH]` | Restart individual services |
 | `servicrab reload [--config PATH]` | Re-read the config and apply the difference to the running daemon |
 | `servicrab events [SERVICE...] [--config PATH] [--json] [--no-prefix] [--timestamps] [--no-logs]` | Follow the daemon's live event stream |
 | `servicrab down [--config PATH]` | Stop the daemon and every service it supervises |
-| `servicrab daemon [--config PATH] [--no-restart]` | Run the daemon in the foreground (for systemd/launchd/containers) |
-| `servicrab generate <systemd\|launchd> [--config PATH] [--scope system\|user] [-o PATH] [--user NAME]` | Generate an init-system unit that runs the stack |
+| `servicrab daemon [--config PATH] [--profile NAME]... [--no-restart]` | Run the daemon in the foreground (for systemd/launchd/containers) |
+| `servicrab generate <systemd\|launchd> [--config PATH] [--scope system\|user] [-o PATH] [--user NAME] [--profile NAME]...` | Generate an init-system unit that runs the stack |
 | `servicrab completions <SHELL>` | Print a completion script for bash, zsh, fish, PowerShell or elvish |
 | `servicrab man [-o DIR]` | Print the man page in roff, or write one page per command into `DIR` |
+
+`--profile` is repeatable, and the five commands that take it are `up`, `watch`,
+`start`, `daemon` and `generate` — the ones that decide which services make up a
+stack. On `up`, `watch` and `start` it cannot be combined with naming services,
+because that would be two answers to one question; `daemon` and `generate` take
+no service names, so there is nothing to conflict with.
 
 If `--config` is omitted, Servicrab discovers `servicrab.toml` by walking up
 from the current directory.
@@ -356,11 +488,12 @@ servicrab up --abort-on-failure    # tear the stack down when a service fails
 Output is interleaved and prefixed with the service name, each service getting
 its own colour:
 
-```
+```console
+$ servicrab up
 servicrab up acme-stack → redis, api
-redis | ▶ started (pgid 41234)
+redis | ▶ started (pgid 30292)
+api   | ▶ started (pgid 30293)
 redis | Ready to accept connections
-api   | ▶ started (pgid 41235)
 api   | listening on 0.0.0.0:3000
 ```
 
@@ -416,13 +549,12 @@ backend, and the run is reported as failed.
 | SIGTERM | `143` |
 | A service failed or was skipped | `1` |
 
-### Platform support and current limitations
+### Platform support
 
-`servicrab up` supports **Linux and macOS**. Current limitations:
-
-- `up` runs in the foreground and stops with your shell — use `servicrab start` for a detached stack;
-- no `--json` event stream yet;
-- `servicrab down` does not exist yet (Ctrl+C is the way to stop a stack).
+`servicrab up` supports **Linux and macOS**; on Windows it reports an
+unsupported-platform error. `up` runs in the foreground and stops with your
+shell — use [`servicrab start`](#running-in-the-background) for a detached
+stack, and `servicrab down` to stop one.
 
 ---
 
@@ -545,18 +677,38 @@ what you see in the terminal — the files are a copy, not a redirect.
 
 Read them back with `logs`:
 
+```console
+$ servicrab logs -n 2
+db     | db up
+db     | db up
+worker | picked up job 41
+worker | picked up job 41
+```
+
 ```bash
 servicrab logs                 # last 50 lines of every service, prefixed
 servicrab logs api -n 200      # last 200 lines of one service, unprefixed
 servicrab logs -f              # follow new output (Ctrl+C to stop)
 ```
 
-`logs -f` notices rotation and keeps following the fresh file. Without a
-`[project.logs]` table the command tells you how to enable capture rather than
-printing nothing.
+`logs -f` notices rotation and keeps following the fresh file, prints each line
+once and whole — a file that ends mid-line has the fragment held back until its
+newline arrives — and tolerates output that is not UTF-8, replacing the
+undecodable bytes rather than failing the command. Without `--follow` there is no
+next pass, so a trailing fragment is shown.
+
+Three outcomes are worth knowing, because two of them are failures and one is
+not:
+
+| Situation | Exit code |
+|---|---|
+| The log directory is empty | `0` — a stack that has not run yet is a state of the world, not a failed command |
+| The config has no `[project.logs]` table | `1`, with a note saying how to enable capture |
+| A **named** service has `[logs] enabled = false` | `1` — there is no file, so the command asked for something that cannot exist |
 
 Sizes accept `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB` and `TB`/`TiB` suffixes;
-all of them are powers of 1024.
+all of them are powers of 1024. The accepted range is
+[in the configuration reference](#projectlogs).
 
 ---
 
@@ -584,10 +736,13 @@ servicrab start          # so does the background daemon
 ```
 
 ```console
-api | ▶ started (pgid 40311)
+$ servicrab watch
+servicrab watch demo → api
+watching for changes: api
+api | ▶ started (pgid 30315)
 api | ↻ server.js changed; restarting
 api | ◼ stopping: stopped on request
-api | ▶ started (pgid 40388)
+api | ▶ started (pgid 30327)
 ```
 
 `.git` and `.servicrab` are always ignored. The watcher polls rather than
@@ -752,9 +907,9 @@ name is not: which files make up a config should not depend on who ran it.
 
 ## Variables in the config
 
-Every value in `servicrab.toml` can refer to the environment of whoever runs
-`servicrab`, so one committed config can serve checkouts that disagree about
-where things live:
+Every **string-valued** field in `servicrab.toml` can refer to the environment of
+whoever runs `servicrab`, so one committed config can serve checkouts that
+disagree about where things live:
 
 ```toml
 [services.api]
@@ -774,22 +929,27 @@ DATABASE_URL = "postgres://localhost:${PG_PORT:-5432}/app"
 
 An unset variable stops the load and names itself:
 
-```
-error: ✗ servicrab.toml has 1 error(s):
-  • service "api": cwd refers to ${WORKSPACE}, which is not set;
-    use ${WORKSPACE:-default} if it may be absent
+```console
+$ servicrab check
+error: /srv/demo/servicrab.toml has 1 error(s)
+  • service "api": cwd refers to ${WORKSPACE}, which is not set; use ${WORKSPACE:-default} if it may be absent
 ```
 
 That is the point of the feature: a `cwd` that quietly became `/`, or a
 `command` that quietly lost an argument, is harder to diagnose than a config
 that refuses to start.
 
-Three details are worth knowing:
+Four details are worth knowing:
 
 - **The braces are required.** A bare `$` is never special, so the shell
   snippets that fill a process manager's config keep working —
   `command = ["sh", "-c", "echo $HOME; echo $$"]` reaches the shell verbatim.
   This is the one place the syntax narrows Docker Compose's.
+- **Only string fields are reached.** Expansion runs on the text of a value
+  before TOML turns it into typed data, so a field that is not a string has no
+  string for a `${VAR}` to live in: `max_restarts = "${MAX}"` is rejected as a
+  string where a `u32` belongs. See
+  [What `${VAR}` reaches](#what-var-reaches) for the full list.
 - **Values come from the environment only**, not from `[project.env]`,
   `[services.<name>.env]` or an `env_file`. Those describe what the *service*
   will see; substitution happens earlier, while the config is still being read.
@@ -858,13 +1018,25 @@ servicrab restart api db    # stop and start, one service at a time
 A service stopped this way stays stopped — the restart policy does not bring
 it back, because the stop was deliberate.
 
-```
+```console
+$ servicrab status
 SERVICE  STATE          PID    UPTIME  RESTARTS  HEALTH
-db       running      41231     4m30s         0  healthy
-api      running      41244     4m12s         1  -
-worker   backoff          -         -         3  -
-  worker: stopped (exit code 1), last status: exit code 1
+api      stopped          -         -         0  -
+db       running      83810        4s         0  -
+worker   failed           -         -         1  -
+  api: stopped (stopped on request), last status: exited with code 0
+  worker: service "worker": giving up after 1 restart attempt(s)
 ```
+
+The rows are the table; the indented lines below it are the last noteworthy
+thing that happened to a service, and only services that have one get a line.
+They are written for a person, so treat them as prose and not as a format to
+parse — `status --json` carries the same field as `message`.
+
+The `PID` column holds the service's **process group** id — every service runs
+in its own group — so `kill -TERM -<that number>` reaches the service and its
+descendants together. `status --json` calls the same number `pgid`, with `pid` as
+a deprecated alias.
 
 ### Services you stopped by hand
 
@@ -953,13 +1125,69 @@ The daemon keeps its runtime state next to the config file, in
 and `stopped` (the services you stopped by hand). Add `.servicrab/` to your
 `.gitignore`.
 
-Each project gets its own daemon, so several stacks can run side by side.
-`start` refuses to launch a second daemon for the same config, and both the
-socket and the pidfile are removed when the daemon exits, however it exits.
+**The socket is the one file that can move out of the project directory.** A
+Unix socket path has a hard length limit — 107 bytes on Linux, 103 on macOS —
+and a deeply nested project can exceed it. When that happens the socket moves to
+the first directory that is genuinely private to this user (`$XDG_RUNTIME_DIR`,
+then the temp directory), under a name derived from the project directory, and
+`servicrab start` prints the path it chose. Plain `/tmp` is refused: a
+predictable name in a shared directory is exactly what the mode-`0600` socket is
+protecting against. With nowhere private to move to, the long path stays and
+`bind` fails, saying which candidates were rejected and why.
+
+Each project gets its own daemon, so several stacks can run side by side, and
+`start` refuses to launch a second daemon for the same config.
 
 `servicrab daemon` runs the same thing in the foreground, which is what you
 want under systemd, launchd, or in a container: it supervises the stack, serves
 the socket, and stops the whole stack cleanly on `SIGTERM`.
+
+### What survives a daemon that is killed, and what does not
+
+On the graceful path — `servicrab down`, `SIGTERM`, `SIGINT` — the daemon stops
+every service in reverse dependency order, reaps them, and unlinks its socket
+and pidfile. That is the path worth relying on, and it is the only one.
+
+**After `SIGKILL`, an OOM kill or a panic, the daemon's children are not
+reconciled.** This is a deliberate 1.0 decision rather than an oversight, and
+the consequences are worth stating plainly:
+
+- **The services keep running, reparented to init.** Nothing stops them and
+  nothing is supervising them any more. Their restart policies, health checks
+  and log capture are all gone with the daemon.
+- **The socket and the pidfile are left behind.** They are unlinked by the
+  daemon's own shutdown code, which by definition did not run.
+- **A later `servicrab start` succeeds and runs a second copy.** The stale
+  pidfile is not an obstacle: the `flock` on it is released by the kernel when
+  the process dies, so the next daemon takes the lock, removes the stale socket
+  and starts the stack again — beside the orphans, not instead of them. Two
+  copies of a service that binds a port will not both come up; two copies of a
+  worker will both consume from the queue.
+
+`servicrab status` and `servicrab down` both exit `3` in this state, because
+there is genuinely no daemon to talk to. Neither one will find the orphans:
+`down` has nothing to send a request to.
+
+So the operator's job after a killed daemon is the part servicrab does not do:
+
+```bash
+servicrab status                     # exits 3 — confirms the daemon is gone
+ps -eo pid,pgid,command | grep <something from your commands>
+kill -TERM -<PGID>                   # the leading `-` signals the whole group
+servicrab start                      # only once the orphans are gone
+```
+
+Every service runs in its own process group, so signalling the group id — the
+`pgid` in `status --json` and in the `started` event, which is the number the
+group was created with — reaches the service and its descendants together.
+
+This is not hypothetical: during development two test daemons escaped a killed
+harness and ran for nineteen hours before anyone noticed, which is the same
+class of orphan. If you need supervision that survives its own supervisor being
+killed, run `servicrab daemon` under something whose job that is — systemd or
+launchd, with `Restart=` set — and see
+[Running under systemd or launchd](#running-under-systemd-or-launchd). Servicrab
+supervises your services; it does not supervise itself.
 
 ### The socket protocol
 
@@ -991,7 +1219,7 @@ Everything a program should act on is a field of its own: `changes` on a
 reload's `ok`, and on an `error`:
 
 ```json
-{"type":"error","code":"validation_failed","message":"servicrab.toml has 2 error(s); the stack was left untouched","errors":["services.api: command must not be empty","services.web: unknown dependency \"nowhere\""]}
+{"type":"error","code":"validation_failed","message":"/srv/demo/servicrab.toml has 2 error(s); the stack was left untouched","errors":["service \"api\": command must not be empty","service \"web\": depends on unknown service \"nowhere\""]}
 ```
 
 | `code` | Meaning |
@@ -1114,12 +1342,37 @@ There are two shapes, and which one a command uses follows from what it is:
   with, then writes one event per line. The version is not repeated on every
   line: these streams can run for days.
 
+**An absent value is an absent key, not a null.** A service that is not running
+has no `pgid`, `pid` or `uptime_secs` in `status --json`, and one with nothing
+noteworthy to report has no `message` — the keys are simply not there:
+
+```console
+$ servicrab status --json
+{
+  "schema_version": 1,
+  "running": true,
+  "services": [
+    {
+      "name": "worker",
+      "state": "failed",
+      "restarts": 1,
+      "health": "none",
+      "message": "service \"worker\": giving up after 1 restart attempt(s)"
+    }
+  ]
+}
+```
+
+So read these fields as optional. `jq -r '.services[].pgid'` prints `null` for a
+stopped service, which is usually what you want; `.pgid | tonumber` fails, which
+is usually not.
+
 Errors are JSON too, on **stderr**, so stdout carries nothing but the document
 that was asked for:
 
 ```console
 $ servicrab check --json
-{"schema_version":1,"error":{"code":"validation_failed","message":"servicrab.toml has 2 error(s)","errors":["services.api: command must not be empty","services.web: unknown dependency \"nowhere\""]}}
+{"schema_version":1,"error":{"code":"validation_failed","message":"/srv/demo/servicrab.toml has 2 error(s)","errors":["service \"api\": command must not be empty","service \"web\": depends on unknown service \"nowhere\""]}}
 ```
 
 `code` is the same stable set the [socket protocol](#the-socket-protocol) uses.
@@ -1127,32 +1380,55 @@ $ servicrab check --json
 
 ### Exit codes for every command
 
-Every command follows the same rules:
+This is the same set the man page's `EXIT STATUS` section documents, and it is
+frozen for 1.x.
 
-| Situation | Exit code |
+| Exit code | Meaning |
 |---|---|
-| It worked | `0` |
-| It failed | `1` |
-| No daemon is running for this project | `3` |
-| `up` / `watch` was interrupted (`SIGHUP` / Ctrl+C / `SIGTERM`) | `129` / `130` / `143` |
-| `exec` or `run` ran something | that process's own status (`128+N` for a signal, `126`/`127` for `exec`) |
+| `0` | Success. For `run` and `up` that means the services were shut down as asked, not that they never failed. `down` uses it when a daemon was there and stopped. |
+| `1` | The command failed: an invalid configuration, an unknown service, a service that exhausted its restart budget, a per-service command the daemon refused, or a `start --wait` that timed out. |
+| `3` | No daemon is running for this project. |
+| `126`, `127` | `exec` could not run the command: found but not executable (`126`), or not found (`127`), as a shell would report it. |
+| `129`, `130`, `143` | `up` and `watch` were cut short by a signal and shut the stack down cleanly: `SIGHUP` (129), Ctrl+C (130), `SIGTERM` (143). A clean shutdown, not a failure. |
+| anything else | `exec` and `run` pass through the status of the process they ran: its own exit code, or `128+N` when a signal *N* killed it. |
 
-`3` is the one worth knowing about. It means "there was nothing to talk to",
-which is a thing scripts routinely want to handle rather than report:
+A few `1`s are worth spelling out, because "it failed" is not obvious for a
+command whose job is to report:
+
+- `check` exits `1` on a config that does not load or does not validate. The
+  report is the output; the code is what a CI step reads.
+- `logs` exits `1` when the config has no `[project.logs]` table, and when a
+  named service has `[logs] enabled = false` — in both cases there is no file to
+  read, which is a mistake in the command rather than a state of the stack. An
+  **empty** log directory is a state of the stack, so that exits `0`.
+
+#### `3`, and the one breaking change in it
+
+`3` means "there was nothing to talk to", which is a thing scripts routinely
+want to handle rather than report. It comes from `status`, `down`, `reload`,
+`stop`, `restart`, `start SERVICE` and `events`.
+
+**`down` used to exit `0` when no daemon was running, and now exits `3`.** That
+is deliberate, and it is a breaking change for anything chaining off it:
 
 ```bash
-servicrab down
-case $? in
+servicrab down && echo "ok"     # prints nothing on a stopped stack, as of 1.0
+```
+
+`down` still never *fails* because nothing was running — running it twice is
+safe, which is the whole point of it — the code just distinguishes the two
+outcomes, and its note goes to stderr with no `error: ` prefix for the same
+reason. If you want the old behaviour, say so:
+
+```bash
+servicrab down; case $? in
   0) echo "stopped it" ;;
   3) echo "nothing was running" ;;  # not a failure
   *) echo "something went wrong"; exit 1 ;;
 esac
 ```
 
-`down` still never *fails* because nothing was running — running it twice is
-safe, which is the whole point of it — the code just distinguishes the two
-outcomes. The same `3` comes from `status`, `stop`, `restart`,
-`start SERVICE`, `reload` and `events`.
+### One error format
 
 Errors always go to **stderr**, prefixed with `error: `, with the individual
 problems as bullets below:
@@ -1160,8 +1436,31 @@ problems as bullets below:
 ```console
 $ servicrab check
 error: /srv/demo/servicrab.toml has 2 error(s)
-  • services.api: command must not be empty
-  • services.web: unknown dependency "nowhere"
+  • service "api": command must not be empty
+  • service "web": depends on unknown service "nowhere"
+```
+
+Under `--json` the same error is a JSON object, still on stderr, so a caller
+parsing stdout sees only the document it asked for.
+
+There is exactly one exception to the `error: ` prefix, and it is deliberate:
+
+```console
+$ servicrab down
+no daemon is running for demo
+$ echo $?
+3
+```
+
+`down` asks for a stack to be stopped, and a stack that is already stopped is a
+state of the world rather than a failure, so the note is a plain sentence. It
+still goes to stderr, and the exit code is still `3`, because a script needs to
+be able to tell the two situations apart. `status` moved to stderr in the same
+release but kept the prefix and the suggestion:
+
+```console
+$ servicrab status
+error: no daemon is running for demo — start one with `servicrab start`
 ```
 
 ### Config hot-reload
@@ -1171,7 +1470,7 @@ apply only what changed:
 
 ```console
 $ servicrab reload
-✓ reloaded demo: 1 added, 1 changed, 1 removed
+✓ reloaded demo: 1 added, 1 changed, 0 removed
   from /srv/demo/servicrab.toml
 ```
 
@@ -1192,8 +1491,8 @@ untouched, so a typo can never take a stack down:
 
 ```console
 $ servicrab reload
-✗ servicrab.toml has 1 error(s); the stack was left untouched:
-  • service "api": depends on unknown service "ghost"
+error: /srv/demo/servicrab.toml has 1 error(s)
+  • service "broken": depends on unknown service "ghost"
 ```
 
 Project-level settings — `[project.logs]`, the log directory and rotation
@@ -1249,9 +1548,12 @@ servicrab/
 │   ├── servicrab-cli/      # Binary crate — clap CLI + Tokio async runtime
 │   ├── servicrab-core/     # Library — config models, validation, lifecycle + process runtime
 │   └── servicrab-protocol/ # Library — daemon request/response wire types
-├── Cargo.toml              # Workspace manifest
-└── servicrab.toml          # (generated by servicrab init)
+└── Cargo.toml              # Workspace manifest
 ```
+
+There is no `servicrab.toml` in this repository: `servicrab init` writes one
+into *your* project, and a personal config here would be committed by accident,
+so it is in `.gitignore`.
 
 ---
 
@@ -1259,7 +1561,7 @@ servicrab/
 
 ```sh
 # Format
-cargo fmt --all
+cargo fmt --all -- --check
 
 # Lint (warnings are errors in CI)
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
@@ -1267,78 +1569,141 @@ cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 # Test
 cargo test --workspace --all-features --locked
 
+# Documentation (a broken intra-doc link is an error in CI)
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
+
+# Packaging, as crates.io will see it
+cargo package --workspace --locked
+
 # Run a specific test
 cargo test -p servicrab-core config::tests
 
 # Check against the minimum supported Rust version
 rustup toolchain install 1.85
 cargo +1.85 check --workspace --all-features --all-targets --locked
+```
 
-# Audit the dependency tree (licences, advisories, sources)
+Those are the six checks the `CI` workflow runs on every pull request:
+`fmt + clippy + test` on Linux **and** macOS (one job, a two-way matrix), the
+MSRV check, the Windows stub build, the crates.io packaging dry run, and the
+rustdoc build. `--locked` is on every one of them, because without it cargo may
+resolve a newer transitive dependency and CI stops testing what `Cargo.lock`
+ships.
+
+The dependency audit is **not** one of them:
+
+```sh
 cargo deny check
 ```
 
-The commands above are exactly what CI runs, so a clean local sweep means a
-green pipeline.
+It lives in its own `Audit` workflow, which runs on a schedule, on pushes to
+`main`, and on release tags — and on a pull request only when `Cargo.toml`,
+`Cargo.lock`, `deny.toml` or the workflow itself changed. Advisories are
+published on the RustSec calendar rather than ours, so a new one should not fail
+an unrelated documentation change, and it should be found in a week when nobody
+opens a pull request at all.
+
+---
+
+## What 1.0 promises
+
+Three surfaces are stable in 1.x. Additions are allowed; breaking any of these
+means 2.0.
+
+**1. The CLI surface.** The command and flag inventory, what each one does, and
+the exit codes. A 1.x release may add a command, add a flag, or add a value to an
+existing flag; it may not remove one, rename one, or change what one means.
+
+**2. The socket protocol.** The request and response types, their field names,
+and the `code` set on an error. A 1.x release may add a request type, a response
+field, or an event kind — which is safe precisely because every enum on the wire
+has an `unknown` fallback, so an older client skips what it cannot name instead
+of failing the line. See
+[Reading a stream from a newer servicrab](#reading-a-stream-from-a-newer-servicrab).
+
+**3. The `--json` output.** The shapes described under
+[Machine-readable output](#machine-readable-output), and the `schema_version`
+that identifies them. An optional field may be added without a bump; a change an
+existing reader would misread bumps the version.
+
+### What is not stable
+
+- **`servicrab-core` and `servicrab-protocol` carry no semver guarantee.** They
+  are published so that `servicrab` can be, and their version numbers move with
+  the workspace, but they are internal crates: their Rust API may change in any
+  release, including a patch. If you depend on either directly, pin an exact
+  version. The stable interface for a third-party program is the socket protocol
+  and the `--json` output, both of which are contracts on the wire rather than in
+  Rust.
+- **The `message` field of a socket response, and the prose of any human-readable
+  output.** Both are written for whoever is reading the terminal and may be
+  reworded in any release. Everything a program should act on is a field of its
+  own, or an exit code.
+- **The exact bytes of `--help`.** The inventory and the wording of each flag's
+  description are frozen; the *whitespace and column alignment* are not. `clap`
+  aligns the description column to the longest flag on a page, so adding a flag
+  necessarily shifts every other line on that page — and adding a flag is exactly
+  what 1.x is allowed to do. A byte-exact snapshot would forbid what semver
+  permits.
+
+  That distinction is not a matter of interpretation:
+  `crates/servicrab-cli/tests/help.rs` enforces it. It records every page's flag
+  list and every description with runs of whitespace collapsed to one space, so a
+  reword or a dropped flag fails the build while a realignment does not. That
+  file is the specification of this paragraph — if the two ever disagree, the test
+  is right.
+
+### The line to script against
+
+```bash
+servicrab status --json | jq -e '.schema_version == 1' >/dev/null || exit 1
+```
+
+Read `schema_version`, refuse what you were not written for, and treat an
+unfamiliar `type`, `kind` or `code` as something to skip rather than an error.
+That is the whole forward-compatibility contract, and it is enough.
 
 ---
 
 ## Roadmap
 
-### Phase 1 (current) — Minimal CLI ✅
-- [x] Cargo workspace setup
-- [x] `servicrab.toml` config format
-- [x] `init` / `check` / `list` commands
-- [x] Restart policy types
-- [x] Dependency declarations and deterministic start order
-- [x] CI on Linux + macOS
+### 1.0 — what is in it
 
-### Phase 1.5 (current) — Foreground runner ✅
-- [x] `servicrab run <SERVICE>` on Linux + macOS
-- [x] Per-service process groups and group-wide shutdown
-- [x] Restart policy enforcement with exponential backoff
-- [x] Graceful shutdown with `SIGKILL` escalation
+Everything documented above:
 
-### Phase 1.6 (current) — Stack runner ✅
-- [x] `servicrab up` — concurrent supervision of the whole stack
-- [x] Dependency ordering on start, reverse order on shutdown
-- [x] Interleaved, prefixed, colourised output
+- **Config**: one `servicrab.toml` or several via `include`, `${VAR}`
+  substitution in string fields, profiles, `env_file` layering, dependency
+  conditions, health checks, log capture with rotation, file watching.
+- **Foreground**: `run` for one service, `up` for a stack, `watch` for a stack
+  that restarts on change, `exec` for a one-off in a service's environment.
+- **Background**: a daemon per project over a Unix socket, with `start`,
+  `status`, `stop`, `restart`, `reload`, `events`, `down` and `daemon`, plus
+  `start --wait` for CI.
+- **Machine-readable**: `--json` on `check`, `list`, `status`, `up`, `watch` and
+  `events`, all carrying `schema_version`; one error format, on stderr, JSON
+  under `--json`.
+- **Integration**: `generate systemd|launchd`, shell completions for five
+  shells, man pages, prebuilt Linux and macOS binaries for `x86_64` and
+  `aarch64`, published on crates.io.
+- **Forward compatibility**: an `unknown` fallback on every wire enum, an
+  optional `version` on `ping`/`pong`, and a refusal that names the request it
+  did not recognise.
 
-### Phase 1.7 (current) — Health checks ✅
-- [x] `command`, `http` and `tcp` probes
-- [x] Readiness gating: dependents wait for a healthy dependency
-- [x] Unhealthy services are stopped and restarted by policy
+### Deferred to 1.1
 
-### Phase 1.8 (current) — Log files ✅
-- [x] Opt-in capture to `<dir>/<service>.log` with size-based rotation
-- [x] `servicrab logs [SERVICE...] [-f] [-n N]`
-- [x] Per-service opt-out via `[services.<name>.logs] enabled = false`
+- **An event envelope.** Every event would carry `timestamp`, `seq` and
+  `schema_version` of its own, so a consumer could order, deduplicate and
+  version-check a stream without inferring any of it. Deferred on purpose:
+  adding fields to an existing shape is an additive change semver permits, so
+  1.1 can do it without a break, and shipping it in 1.0 would have meant
+  freezing a design that has not yet met a second consumer.
+- **`status` from a killed daemon.** Reconciling orphaned children after a
+  `SIGKILL` needs state on disk that survives the process, which is a design
+  question rather than a patch — see
+  [What survives a daemon that is killed](#what-survives-a-daemon-that-is-killed-and-what-does-not)
+  for what an operator does today.
 
-### Phase 2 — Background daemon ✅
-- [x] Detached daemon per project with a Unix-socket JSON API
-- [x] `servicrab start` / `status` / `down` / `daemon`
-- [x] Status snapshot: state, pid, uptime, restarts, health
-- [x] Per-service `start` / `stop` / `restart` through the daemon
-- [x] Live event streaming over the socket
-
-### Phase 3 — Stack management ✅
-- [x] `.env` file support per project and per service
-- [x] Shell completions (`servicrab completions <SHELL>`)
-- [x] `servicrab watch` — restart on file changes, with ignore rules and debouncing
-- [x] Config hot-reload (`servicrab reload`)
-
-### Phase 4 — Platform integration ✅
-- [x] systemd unit generation (`servicrab generate systemd`)
-- [x] launchd plist generation (`servicrab generate launchd`)
-- [x] Live event streaming over the socket (`servicrab events`, `subscribe`)
-- [x] `--json` event stream for `up` and `watch`
-
-### Phase 5 — Release engineering ✅
-- [x] Publishable crate metadata and a `CHANGELOG.md`
-- [x] Tagged releases with prebuilt Linux and macOS binaries (x86_64 + aarch64)
-- [x] Man pages (`servicrab man`), shipped in the release tarballs
-- [x] Dependency audit (`cargo-deny`) and automated dependency updates
-- [x] Published to crates.io
+Windows supervision remains a non-goal.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,14 @@ Write your own client the same way: ignore a `type` or `kind` you do not
 recognise rather than treating it as an error, and do not give a field the value
 `unknown` — it is reserved for exactly this.
 
+A request the daemon does not recognise is named back to you, with the set it
+does accept, so a typo in a hand-rolled client is one round trip to diagnose:
+
+```console
+$ echo '{"type":"strat"}' | nc -U .servicrab/daemon.sock
+{"type":"error","message":"this daemon does not support the request \"strat\"; it supports: ping, status, shutdown, start_service, stop_service, restart_service, reload, subscribe"}
+```
+
 ### Live event streaming
 
 `subscribe` is the one request that turns a connection one-way: the daemon

--- a/README.md
+++ b/README.md
@@ -968,7 +968,7 @@ echo '{"type":"status"}' | nc -U .servicrab/daemon.sock
 
 | Request | Response |
 | --- | --- |
-| `{"type":"ping"}` | `{"type":"pong","project":"…","pid":123}` |
+| `{"type":"ping"}` | `{"type":"pong","project":"…","pid":123,"version":1}` |
 | `{"type":"status"}` | `{"type":"status","services":[…]}` |
 | `{"type":"shutdown"}` | `{"type":"ok","message":"stopping the stack"}` |
 | `{"type":"start_service","name":"api"}` | `{"type":"ok","message":"api started"}` |
@@ -980,6 +980,26 @@ echo '{"type":"status"}' | nc -U .servicrab/daemon.sock
 `stop_service` and `restart_service` only answer once the service has actually
 stopped (and, for a restart, been replaced), so scripts can rely on the reply
 instead of polling.
+
+#### Reading a stream from a newer servicrab
+
+`version` in the `ping`/`pong` exchange says which revision of this protocol
+each side speaks. It is optional in both directions: a client from before it
+existed sends nothing, and is answered normally. Nothing refuses to talk on the
+strength of the number — it is there so that a version mismatch can be reported
+rather than guessed at.
+
+That is possible because both ends decode leniently instead. Anything a build
+cannot name — a request type, a response type, an event `kind`, a service
+`state`, a `health` verdict, a log `stream` — reads back as `unknown` rather than
+failing the line. A client skips what it does not understand and keeps reading,
+so a later release can add an event type without ending every older client's
+stream, and one unfamiliar state does not cost you the rest of a `status`
+snapshot.
+
+Write your own client the same way: ignore a `type` or `kind` you do not
+recognise rather than treating it as an error, and do not give a field the value
+`unknown` — it is reserved for exactly this.
 
 ### Live event streaming
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,13 +26,19 @@ credits you unless you prefer otherwise.
 
 ## Supported versions
 
-Servicrab is pre-1.0. Fixes go onto `main` and into the next release; there are
-no long-lived maintenance branches. Only the latest release is supported.
+Only the latest release is supported. Fixes go onto `main` and into the next
+release; there are no long-lived maintenance branches, and there is no backport
+to an older line.
 
 | Version | Supported |
 | ------- | --------- |
-| 0.1.x   | yes       |
-| < 0.1   | no        |
+| 1.0.x   | yes       |
+| 0.x     | no        |
+
+From 1.0 onwards the CLI surface, the socket protocol and the JSON output follow
+semver, so upgrading to the current release to pick up a fix should not require a
+change to your configuration or your scripts. See
+[what 1.0 promises](README.md#what-10-promises).
 
 ## What is in scope
 

--- a/crates/servicrab-cli/Cargo.toml
+++ b/crates/servicrab-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servicrab"
-description = "A lightweight cross-platform process supervisor for local development stacks, homelabs, and small servers"
+description = "A lightweight process supervisor for local development stacks, homelabs, and small servers (Linux and macOS)"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/servicrab-cli/Cargo.toml
+++ b/crates/servicrab-cli/Cargo.toml
@@ -41,4 +41,6 @@ assert_cmd = "2"
 predicates = "3"
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = { workspace = true }
+# `term` is only for the tests: a colour decision is about whether a stream is a
+# terminal, so proving it needs a real one on one stream and a pipe on the other.
+nix = { workspace = true, features = ["term"] }

--- a/crates/servicrab-cli/README.md
+++ b/crates/servicrab-cli/README.md
@@ -1,8 +1,10 @@
 # servicrab
 
-A lightweight cross-platform process supervisor for local development stacks,
-homelabs, and small servers — one `servicrab.toml`, one binary, no daemon
-required.
+A lightweight process supervisor for local development stacks, homelabs, and
+small servers — one `servicrab.toml`, one binary, no daemon required.
+
+Supervision runs on Linux and macOS. On other platforms the config commands
+work and the runtime reports `UnsupportedPlatform`.
 
 ```toml
 version = 1
@@ -22,20 +24,22 @@ depends_on = ["api"]
 ```console
 $ servicrab up
 servicrab up myapp → api, web
+api | ▶ started (pgid 30292)
+web | ▶ started (pgid 30293)
 api | listening on :8080
 web | ready on :3000
 ```
 
 - Dependency-ordered start, reverse-order shutdown, per-service process groups
-- Restart policies (`never`, `on-failure`, `always`) with exponential backoff
+- Restart policies (`never`, `on-failure`, `always`, `unless-stopped`) with
+  exponential backoff
 - Health checks (`command`, `http`, `tcp`) with readiness gating
 - Log files with rotation, plus `servicrab logs -f`
 - A background daemon with a documented JSON-over-Unix-socket API, live event
   streaming, and config hot-reload
 - systemd unit and launchd plist generation
 
-Supervision runs on Linux and macOS. See the
-[project README](https://github.com/gaborini/servicrab#readme) for the full
-documentation.
+See the [project README](https://github.com/gaborini/servicrab#readme) for the
+full documentation.
 
 Dual-licensed under MIT OR Apache-2.0.

--- a/crates/servicrab-cli/src/commands/check.rs
+++ b/crates/servicrab-cli/src/commands/check.rs
@@ -3,55 +3,88 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use serde::Serialize;
 use servicrab_core::{load, resolve_config_path, Config};
+use servicrab_protocol::ErrorCode;
 
-/// Run the `check` subcommand.
-pub fn run(config: Option<&Path>) -> Result<(), String> {
-    let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
+use crate::output::{self, CliError};
 
-    match load(&path) {
-        Ok((cfg, warnings)) => {
-            let svc_count = cfg.services.len();
-            println!("✓ {} — project: {}", path.display(), cfg.project.name);
-            println!(
-                "  {} service{}",
-                svc_count,
-                if svc_count == 1 { "" } else { "s" }
-            );
-
-            let order: Vec<&str> = cfg.start_order.iter().map(|n| n.as_str()).collect();
-            println!("  start order: {}", order.join(" → "));
-
-            // The order above lists every service, profiled ones included, so
-            // say which of them wait to be asked for.
-            for line in profile_lines(&cfg) {
-                println!("  {line}");
-            }
-
-            if !warnings.is_empty() {
-                println!("  {} warning(s):", warnings.len());
-                for w in &warnings {
-                    println!("    ⚠  {w}");
-                }
-            }
-            Ok(())
-        }
-        Err(errors) => {
-            eprintln!("✗ {} has {} error(s):", path.display(), errors.len());
-            for err in &errors {
-                eprintln!("  • {err}");
-            }
-            Err(format!(
-                "configuration validation failed ({} error(s))",
-                errors.len()
-            ))
-        }
-    }
+/// What `check --json` reports about a configuration that loaded.
+///
+/// The start order and the profile membership are the two things a script
+/// actually asks `check` for — "will this config work, and what will run" — so
+/// they are fields rather than the prose the human report renders them as.
+#[derive(Serialize)]
+struct CheckJson<'a> {
+    ok: bool,
+    config: String,
+    project: &'a str,
+    services: usize,
+    start_order: Vec<&'a str>,
+    profiles: BTreeMap<&'a str, Vec<&'a str>>,
+    warnings: Vec<String>,
 }
 
-/// One line per profile, naming the services it holds. Empty when the config
-/// uses no profiles.
-fn profile_lines(cfg: &Config) -> Vec<String> {
+/// Run the `check` subcommand.
+pub fn run(config: Option<&Path>, json: bool) -> Result<(), CliError> {
+    let path = resolve_config_path(config)
+        .map_err(|e| CliError::from(format!("could not find config: {e}")).in_json(json))?;
+
+    let (cfg, warnings) = match load(&path) {
+        Ok(loaded) => loaded,
+        Err(errors) => {
+            // Reported once: the errors used to be printed here *and* summarized
+            // again by the `error:` line main prints for a failed command, which
+            // told the operator the same thing twice.
+            return Err(CliError::new(
+                ErrorCode::ValidationFailed,
+                format!("{} has {} error(s)", path.display(), errors.len()),
+            )
+            .with_errors(errors.iter().map(ToString::to_string).collect())
+            .in_json(json));
+        }
+    };
+
+    if json {
+        return output::print_document(CheckJson {
+            ok: true,
+            config: path.display().to_string(),
+            project: cfg.project.name.as_str(),
+            services: cfg.services.len(),
+            start_order: cfg.start_order.iter().map(|n| n.as_str()).collect(),
+            profiles: profile_members(&cfg),
+            warnings: warnings.iter().map(ToString::to_string).collect(),
+        });
+    }
+
+    let svc_count = cfg.services.len();
+    println!("✓ {} — project: {}", path.display(), cfg.project.name);
+    println!(
+        "  {} service{}",
+        svc_count,
+        if svc_count == 1 { "" } else { "s" }
+    );
+
+    let order: Vec<&str> = cfg.start_order.iter().map(|n| n.as_str()).collect();
+    println!("  start order: {}", order.join(" → "));
+
+    // The order above lists every service, profiled ones included, so
+    // say which of them wait to be asked for.
+    for line in profile_lines(&cfg) {
+        println!("  {line}");
+    }
+
+    if !warnings.is_empty() {
+        println!("  {} warning(s):", warnings.len());
+        for w in &warnings {
+            println!("    ⚠  {w}");
+        }
+    }
+    Ok(())
+}
+
+/// Which services each profile holds. Empty when the config uses no profiles.
+fn profile_members(cfg: &Config) -> BTreeMap<&str, Vec<&str>> {
     let mut members: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
     for name in &cfg.start_order {
         let service = &cfg.services[name];
@@ -62,8 +95,13 @@ fn profile_lines(cfg: &Config) -> Vec<String> {
                 .push(name.as_str());
         }
     }
-
     members
+}
+
+/// One line per profile, naming the services it holds. Empty when the config
+/// uses no profiles.
+fn profile_lines(cfg: &Config) -> Vec<String> {
+    profile_members(cfg)
         .into_iter()
         .map(|(profile, services)| format!("profile {profile}: {}", services.join(", ")))
         .collect()

--- a/crates/servicrab-cli/src/commands/completions.rs
+++ b/crates/servicrab-cli/src/commands/completions.rs
@@ -13,9 +13,22 @@ use clap::CommandFactory;
 use clap_complete::Shell;
 
 /// Write the completion script for `shell` to stdout.
+///
+/// Rendered into memory first because the generator writes straight to the
+/// stream and panics if a write fails: a reader that closes the pipe early —
+/// `servicrab completions bash | head` — would otherwise take the process down
+/// over something that is not an error at all.
 pub fn run<C: CommandFactory>(shell: Shell) -> Result<(), String> {
+    use std::io::Write;
+
     let mut command = C::command();
     let name = command.get_name().to_string();
-    clap_complete::generate(shell, &mut command, name, &mut std::io::stdout());
-    Ok(())
+    let mut script: Vec<u8> = Vec::new();
+    clap_complete::generate(shell, &mut command, name, &mut script);
+
+    match std::io::stdout().write_all(&script) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(err) => Err(format!("failed to write the completion script: {err}")),
+    }
 }

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -13,6 +13,8 @@ use crate::daemon::{stopped, DaemonPaths};
 
 /// How long to wait for a freshly spawned daemon to answer.
 const START_TIMEOUT: Duration = Duration::from_secs(15);
+/// How often to check on a daemon that has not answered yet.
+const START_POLL: Duration = Duration::from_millis(50);
 /// How long to wait for a stopping daemon to disappear.
 const STOP_TIMEOUT: Duration = Duration::from_secs(30);
 /// How long `--wait` waits for readiness when `--timeout` is not given.
@@ -105,6 +107,10 @@ mod imp {
 
         let (cfg, config_path, paths) = setup(config)?;
 
+        // An advisory fast path for a friendly message.  It cannot be
+        // authoritative — another `start` may be between this check and its
+        // daemon's lock — so the daemon takes the pidfile lock and this code
+        // reports whatever it says.
         if client::is_running(&paths.socket) {
             return Err(format!(
                 "a daemon is already running for {} — use `servicrab status` or `servicrab down`",
@@ -153,16 +159,7 @@ mod imp {
             .spawn()
             .map_err(|e| format!("could not start the daemon: {e}"))?;
 
-        if !client::wait_until_running(&paths.socket, START_TIMEOUT) {
-            // Reap it so a failed start does not leave a zombie behind.
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(format!(
-                "the daemon did not come up within {}s — see {}",
-                START_TIMEOUT.as_secs(),
-                paths.log.display()
-            ));
-        }
+        wait_for_the_daemon(&mut child, &paths)?;
 
         let color = style::color_enabled();
         println!(
@@ -195,8 +192,54 @@ mod imp {
         Ok(0)
     }
 
-    /// What a status snapshot says about one service's readiness.
+    /// Wait for the spawned daemon to answer, or to tell us why it will not.
     ///
+    /// Two starts can race here, and only one of them gets the project lock.
+    /// The loser exits straight away — while the *winner's* socket is up, so
+    /// only the child's own exit status can tell the two apart.  Watching it
+    /// also turns a 15-second timeout into an immediate, accurate message, and
+    /// reaps the process either way.
+    fn wait_for_the_daemon(
+        child: &mut std::process::Child,
+        paths: &DaemonPaths,
+    ) -> Result<(), String> {
+        let deadline = std::time::Instant::now() + START_TIMEOUT;
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) if !status.success() => {
+                    return Err(format!(
+                        "the daemon we started exited with {} — see {}",
+                        status
+                            .code()
+                            .map(|code| code.to_string())
+                            .unwrap_or_else(|| "a signal".to_string()),
+                        paths.log.display()
+                    ))
+                }
+                // A stack of nothing but one-shot services can be finished
+                // before we look, and that is a start that worked.
+                Ok(Some(_)) => return Ok(()),
+                Ok(None) => {}
+                Err(err) => return Err(format!("could not watch the daemon: {err}")),
+            }
+            if client::is_running(&paths.socket) {
+                return Ok(());
+            }
+            if std::time::Instant::now() >= deadline {
+                // Reap it so a failed start does not leave a zombie behind.
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "the daemon did not come up within {}s — see {}",
+                    START_TIMEOUT.as_secs(),
+                    paths.log.display()
+                ));
+            }
+            std::thread::sleep(START_POLL);
+        }
+    }
+
+    /// What a status snapshot says about one service's readiness.    ///
     /// The same three answers the supervisor's own dependency gating uses under
     /// its *default* condition, so `--wait` returns when a dependent that did
     /// not spell out a condition would have been allowed to start.  A spelled

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -498,7 +498,10 @@ mod imp {
                 if json {
                     println!("{{\"running\":false,\"services\":[]}}");
                 } else {
-                    println!(
+                    // Diagnostics, not output: `servicrab status > snapshot`
+                    // should leave the file empty when there is no snapshot to
+                    // take, rather than filling it with prose.
+                    eprintln!(
                         "no daemon is running for {} — start one with `servicrab start`",
                         cfg.project.name
                     );
@@ -507,10 +510,10 @@ mod imp {
                     // looking for one.  Said only when it is somewhere
                     // surprising, so the ordinary output does not change.
                     if !paths.socket_is_in_place() {
-                        println!(
+                        eprintln!(
                             "{}",
                             style::paint(
-                                style::color_enabled_for(Stream::Stdout),
+                                style::color_enabled_for(Stream::Stderr),
                                 DIM,
                                 &format!(
                                     "  its socket would be {} (the project's path is too long to hold one)",
@@ -553,7 +556,9 @@ mod imp {
             Ok(Response::Error { message }) => return Err(message),
             Ok(other) => return Err(format!("unexpected response from the daemon: {other:?}")),
             Err(client::ClientError::NotRunning) => {
-                println!("no daemon is running for {}", cfg.project.name);
+                // Nothing was stopped, so there is nothing to report as output;
+                // saying so is a diagnostic.
+                eprintln!("no daemon is running for {}", cfg.project.name);
                 return Ok(0);
             }
             Err(err) => return Err(err.to_string()),

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -122,11 +122,17 @@ mod imp {
         // authoritative — another `start` may be between this check and its
         // daemon's lock — so the daemon takes the pidfile lock and this code
         // reports whatever it says.
-        if client::is_running(&paths.socket) {
-            return Err(format!(
+        match client::check_running(&paths.socket) {
+            Ok(()) => {
+                return Err(format!(
                 "a daemon is already running for {} — use `servicrab status` or `servicrab down`",
                 cfg.project.name
-            ));
+            ))
+            }
+            // A daemon that refuses us is still a daemon, and spawning another
+            // one over its socket would fail in a much less obvious way.
+            Err(client::ClientError::Failed(why)) => return Err(why),
+            Err(client::ClientError::NotRunning) => {}
         }
         paths.ensure_dir()?;
 
@@ -385,6 +391,24 @@ mod imp {
         control(config, services, |name| Request::StopService { name })
     }
 
+    /// Refuse to go on unless a daemon we may talk to is there.
+    ///
+    /// "Is one running" and "will it talk to us" are different questions, and
+    /// the second one has an answer worth repeating: a daemon belonging to
+    /// another user refuses the connection and says so, and reporting that as
+    /// "no daemon is running" would send the operator looking for one that is
+    /// already there.
+    fn expect_a_daemon(cfg: &Config, paths: &DaemonPaths) -> Result<(), String> {
+        match client::check_running(&paths.socket) {
+            Ok(()) => Ok(()),
+            Err(client::ClientError::NotRunning) => Err(format!(
+                "no daemon is running for {} — start one with `servicrab start`",
+                cfg.project.name
+            )),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
     /// Restart individual services.
     pub fn restart(config: Option<&Path>, services: &[String]) -> Result<i32, String> {
         control(config, services, |name| Request::RestartService { name })
@@ -393,12 +417,7 @@ mod imp {
     /// Ask the daemon to re-read the configuration file.
     pub fn reload(config: Option<&Path>) -> Result<i32, String> {
         let (cfg, config_path, paths) = setup(config)?;
-        if !client::is_running(&paths.socket) {
-            return Err(format!(
-                "no daemon is running for {} — start one with `servicrab start`",
-                cfg.project.name
-            ));
-        }
+        expect_a_daemon(&cfg, &paths)?;
 
         let color = style::color_enabled();
         match client::send(&paths.socket, &Request::Reload) {
@@ -430,12 +449,7 @@ mod imp {
         build: impl Fn(String) -> Request,
     ) -> Result<i32, String> {
         let (cfg, _, paths) = setup(config)?;
-        if !client::is_running(&paths.socket) {
-            return Err(format!(
-                "no daemon is running for {} — start one with `servicrab start`",
-                cfg.project.name
-            ));
-        }
+        expect_a_daemon(&cfg, &paths)?;
 
         let color = style::color_enabled();
         let mut failed = false;

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -212,10 +212,12 @@ mod imp {
     /// Wait for the spawned daemon to answer, or to tell us why it will not.
     ///
     /// Two starts can race here, and only one of them gets the project lock.
-    /// The loser exits straight away — while the *winner's* socket is up, so
-    /// only the child's own exit status can tell the two apart.  Watching it
-    /// also turns a 15-second timeout into an immediate, accurate message, and
-    /// reaps the process either way.
+    /// The loser exits straight away — while the *winner's* socket is up, so a
+    /// live socket alone proves nothing about the child we spawned.  The lock
+    /// holder records its pid before it binds, so the pidfile is what identifies
+    /// whose daemon is answering; the child's exit status then turns a
+    /// 15-second timeout into an immediate, accurate message, and reaps the
+    /// process either way.
     fn wait_for_the_daemon(
         child: &mut std::process::Child,
         paths: &DaemonPaths,
@@ -239,7 +241,7 @@ mod imp {
                 Ok(None) => {}
                 Err(err) => return Err(format!("could not watch the daemon: {err}")),
             }
-            if client::is_running(&paths.socket) {
+            if daemon_is_ours(child, paths) && client::is_running(&paths.socket) {
                 return Ok(());
             }
             if std::time::Instant::now() >= deadline {
@@ -254,6 +256,18 @@ mod imp {
             }
             std::thread::sleep(START_POLL);
         }
+    }
+
+    /// Whether the daemon holding this project's lock is the child we spawned.
+    ///
+    /// The pid in the file is written under the lock and before the socket is
+    /// bound, so a socket that answers while this says "not ours" belongs to a
+    /// daemon somebody else started.
+    fn daemon_is_ours(child: &std::process::Child, paths: &DaemonPaths) -> bool {
+        std::fs::read_to_string(&paths.pid)
+            .ok()
+            .and_then(|text| text.trim().parse::<u32>().ok())
+            .is_some_and(|pid| pid == child.id())
     }
 
     /// What a status snapshot says about one service's readiness.    ///

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -460,6 +460,23 @@ mod imp {
                         "no daemon is running for {} — start one with `servicrab start`",
                         cfg.project.name
                     );
+                    // Nothing else would lead them to a relocated socket, and
+                    // "not running" is exactly the moment someone starts
+                    // looking for one.  Said only when it is somewhere
+                    // surprising, so the ordinary output does not change.
+                    if !paths.socket_is_in_place() {
+                        println!(
+                            "{}",
+                            style::paint(
+                                style::color_enabled(),
+                                DIM,
+                                &format!(
+                                    "  its socket would be {} (the project's path is too long to hold one)",
+                                    paths.socket.display()
+                                )
+                            )
+                        );
+                    }
                 }
                 return Ok(1);
             }

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -55,6 +55,17 @@ pub(crate) fn setup(config: Option<&Path>) -> Result<(Config, PathBuf, DaemonPat
     }
 
     let paths = DaemonPaths::for_config(&path);
+    // Nothing here can work if the socket path cannot be bound, and every
+    // command would otherwise report it differently and unhelpfully: the daemon
+    // as `ENAMETOOLONG` from `bind`, every client as `SUN_LEN` from `connect`.
+    // Said once, with the reason each candidate directory was refused.
+    if !paths.socket_advice().is_empty() {
+        return Err(format!(
+            "the socket for {} cannot be created{}",
+            cfg.project.name,
+            paths.socket_advice()
+        ));
+    }
     Ok((cfg, path, paths))
 }
 

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -8,8 +8,10 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use servicrab_core::{load, plan_stack, resolve_config_path, Config, Selection, ServiceName};
+use servicrab_protocol::ErrorCode;
 
 use crate::daemon::{stopped, DaemonPaths};
+use crate::output::{self, CliError};
 
 /// How long to wait for a freshly spawned daemon to answer.
 const START_TIMEOUT: Duration = Duration::from_secs(15);
@@ -38,17 +40,16 @@ pub struct StartOptions {
 }
 
 /// Load the config the daemon commands all need.
-pub(crate) fn setup(config: Option<&Path>) -> Result<(Config, PathBuf, DaemonPaths), String> {
-    let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
+pub(crate) fn setup(config: Option<&Path>) -> Result<(Config, PathBuf, DaemonPaths), CliError> {
+    let path = resolve_config_path(config)
+        .map_err(|e| CliError::from(format!("could not find config: {e}")))?;
 
     let (cfg, warnings) = load(&path).map_err(|errors| {
-        let msgs: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
-        format!(
-            "✗ {} has {} error(s):\n{}",
-            path.display(),
-            errors.len(),
-            msgs.join("\n")
+        CliError::new(
+            ErrorCode::ValidationFailed,
+            format!("{} has {} error(s)", path.display(), errors.len()),
         )
+        .with_errors(errors.iter().map(ToString::to_string).collect())
     })?;
     for warning in &warnings {
         eprintln!("⚠  {warning}");
@@ -64,7 +65,8 @@ pub(crate) fn setup(config: Option<&Path>) -> Result<(Config, PathBuf, DaemonPat
             "the socket for {} cannot be created{}",
             cfg.project.name,
             paths.socket_advice()
-        ));
+        )
+        .into());
     }
     Ok((cfg, path, paths))
 }
@@ -78,6 +80,7 @@ mod imp {
     use servicrab_protocol::{Request, Response, ServiceInfo};
 
     use crate::daemon::{client, server};
+    use crate::output::no_daemon;
     use crate::style::{self, BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
     /// Run the daemon in the foreground (this is the process `start` spawns).
@@ -85,7 +88,7 @@ mod imp {
         config: Option<&Path>,
         no_restart: bool,
         profiles: &[String],
-    ) -> Result<i32, String> {
+    ) -> Result<i32, CliError> {
         let (cfg, config_path, paths) = setup(config)?;
         server::serve(
             &cfg,
@@ -96,6 +99,7 @@ mod imp {
                 profiles: profiles.to_vec(),
             },
         )
+        .map_err(CliError::from)
     }
 
     /// Start the daemon, or individual services inside a running one.
@@ -103,7 +107,7 @@ mod imp {
         config: Option<&Path>,
         selection: Selection<'_>,
         options: StartOptions,
-    ) -> Result<i32, String> {
+    ) -> Result<i32, CliError> {
         let services = selection.services;
         if !services.is_empty() {
             let code = control(config, services, |name| Request::StartService { name })?;
@@ -124,14 +128,17 @@ mod imp {
         // reports whatever it says.
         match client::check_running(&paths.socket) {
             Ok(()) => {
-                return Err(format!(
+                return Err(CliError::new(
+                    ErrorCode::AlreadyRunning,
+                    format!(
                 "a daemon is already running for {} — use `servicrab status` or `servicrab down`",
                 cfg.project.name
-            ))
+            ),
+                ))
             }
             // A daemon that refuses us is still a daemon, and spawning another
             // one over its socket would fail in a much less obvious way.
-            Err(client::ClientError::Failed(why)) => return Err(why),
+            Err(client::ClientError::Failed(why)) => return Err(why.into()),
             Err(client::ClientError::NotRunning) => {}
         }
         paths.ensure_dir()?;
@@ -140,13 +147,13 @@ mod imp {
             .create(true)
             .append(true)
             .open(&paths.log)
-            .map_err(|e| format!("could not open {}: {e}", paths.log.display()))?;
+            .map_err(|e| CliError::from(format!("could not open {}: {e}", paths.log.display())))?;
         let errors = log
             .try_clone()
-            .map_err(|e| format!("could not open {}: {e}", paths.log.display()))?;
+            .map_err(|e| CliError::from(format!("could not open {}: {e}", paths.log.display())))?;
 
         let exe = std::env::current_exe()
-            .map_err(|e| format!("could not find the servicrab executable: {e}"))?;
+            .map_err(|e| CliError::from(format!("could not find the servicrab executable: {e}")))?;
         let mut command = std::process::Command::new(exe);
         command
             .arg("daemon")
@@ -174,7 +181,7 @@ mod imp {
 
         let mut child = command
             .spawn()
-            .map_err(|e| format!("could not start the daemon: {e}"))?;
+            .map_err(|e| CliError::from(format!("could not start the daemon: {e}")))?;
 
         wait_for_the_daemon(&mut child, &paths)?;
 
@@ -221,7 +228,7 @@ mod imp {
     fn wait_for_the_daemon(
         child: &mut std::process::Child,
         paths: &DaemonPaths,
-    ) -> Result<(), String> {
+    ) -> Result<(), CliError> {
         let deadline = std::time::Instant::now() + START_TIMEOUT;
         loop {
             match child.try_wait() {
@@ -233,13 +240,14 @@ mod imp {
                             .map(|code| code.to_string())
                             .unwrap_or_else(|| "a signal".to_string()),
                         paths.log.display()
-                    ))
+                    )
+                    .into())
                 }
                 // A stack of nothing but one-shot services can be finished
                 // before we look, and that is a start that worked.
                 Ok(Some(_)) => return Ok(()),
                 Ok(None) => {}
-                Err(err) => return Err(format!("could not watch the daemon: {err}")),
+                Err(err) => return Err(format!("could not watch the daemon: {err}").into()),
             }
             if daemon_is_ours(child, paths) && client::is_running(&paths.socket) {
                 return Ok(());
@@ -252,7 +260,8 @@ mod imp {
                     "the daemon did not come up within {}s — see {}",
                     START_TIMEOUT.as_secs(),
                     paths.log.display()
-                ));
+                )
+                .into());
             }
             std::thread::sleep(START_POLL);
         }
@@ -330,7 +339,7 @@ mod imp {
         only: &[String],
         skip: &BTreeSet<ServiceName>,
         timeout: Option<Duration>,
-    ) -> Result<i32, String> {
+    ) -> Result<i32, CliError> {
         let timeout = timeout.unwrap_or(WAIT_TIMEOUT);
         let deadline = std::time::Instant::now() + timeout;
         let color = style::color_enabled();
@@ -338,12 +347,20 @@ mod imp {
         loop {
             let services = match client::send(socket, &Request::Status) {
                 Ok(Response::Status { services }) => services,
-                Ok(Response::Error { message }) => return Err(message),
-                Ok(other) => return Err(format!("unexpected response from the daemon: {other:?}")),
-                Err(client::ClientError::NotRunning) => {
-                    return Err("the daemon stopped while waiting for the stack".to_string())
+                Ok(Response::Error { code, message, .. }) => {
+                    return Err(CliError::new(code, message))
                 }
-                Err(err) => return Err(err.to_string()),
+                Ok(other) => {
+                    return Err(format!("unexpected response from the daemon: {other:?}").into())
+                }
+                Err(client::ClientError::NotRunning) => {
+                    return Err(CliError::new(
+                        ErrorCode::NotRunning,
+                        "the daemon stopped while waiting for the stack",
+                    )
+                    .with_exit(output::EXIT_NO_DAEMON))
+                }
+                Err(err) => return Err(err.to_string().into()),
             };
 
             let watched: Vec<&ServiceInfo> = services
@@ -401,7 +418,7 @@ mod imp {
     }
 
     /// Stop individual services without touching the rest of the stack.
-    pub fn stop(config: Option<&Path>, services: &[String]) -> Result<i32, String> {
+    pub fn stop(config: Option<&Path>, services: &[String]) -> Result<i32, CliError> {
         control(config, services, |name| Request::StopService { name })
     }
 
@@ -412,30 +429,29 @@ mod imp {
     /// another user refuses the connection and says so, and reporting that as
     /// "no daemon is running" would send the operator looking for one that is
     /// already there.
-    fn expect_a_daemon(cfg: &Config, paths: &DaemonPaths) -> Result<(), String> {
+    fn expect_a_daemon(cfg: &Config, paths: &DaemonPaths) -> Result<(), CliError> {
         match client::check_running(&paths.socket) {
             Ok(()) => Ok(()),
-            Err(client::ClientError::NotRunning) => Err(format!(
-                "no daemon is running for {} — start one with `servicrab start`",
-                cfg.project.name
-            )),
-            Err(err) => Err(err.to_string()),
+            Err(client::ClientError::NotRunning) => {
+                Err(no_daemon(cfg.project.name.as_str(), false))
+            }
+            Err(err) => Err(err.to_string().into()),
         }
     }
 
     /// Restart individual services.
-    pub fn restart(config: Option<&Path>, services: &[String]) -> Result<i32, String> {
+    pub fn restart(config: Option<&Path>, services: &[String]) -> Result<i32, CliError> {
         control(config, services, |name| Request::RestartService { name })
     }
 
     /// Ask the daemon to re-read the configuration file.
-    pub fn reload(config: Option<&Path>) -> Result<i32, String> {
+    pub fn reload(config: Option<&Path>) -> Result<i32, CliError> {
         let (cfg, config_path, paths) = setup(config)?;
         expect_a_daemon(&cfg, &paths)?;
 
         let color = style::color_enabled();
         match client::send(&paths.socket, &Request::Reload) {
-            Ok(Response::Ok { message }) => {
+            Ok(Response::Ok { message, .. }) => {
                 println!(
                     "{} {}",
                     style::paint(color, GREEN, "✓"),
@@ -447,12 +463,15 @@ mod imp {
                 );
                 Ok(0)
             }
-            Ok(Response::Error { message }) => {
-                eprintln!("{} {message}", style::paint(color, RED, "✗"));
-                Ok(1)
-            }
-            Ok(other) => Err(format!("unexpected response from the daemon: {other:?}")),
-            Err(err) => Err(err.to_string()),
+            // A config the daemon refused is the operator's problem to fix, and
+            // it is reported the way every other error is.
+            Ok(Response::Error {
+                code,
+                message,
+                errors,
+            }) => Err(CliError::new(code, message).with_errors(errors)),
+            Ok(other) => Err(format!("unexpected response from the daemon: {other:?}").into()),
+            Err(err) => Err(err.to_string().into()),
         }
     }
 
@@ -461,7 +480,7 @@ mod imp {
         config: Option<&Path>,
         services: &[String],
         build: impl Fn(String) -> Request,
-    ) -> Result<i32, String> {
+    ) -> Result<i32, CliError> {
         let (cfg, _, paths) = setup(config)?;
         expect_a_daemon(&cfg, &paths)?;
 
@@ -469,91 +488,125 @@ mod imp {
         let mut failed = false;
         for name in services {
             match client::send(&paths.socket, &build(name.clone())) {
-                Ok(Response::Ok { message }) => println!(
+                Ok(Response::Ok { message, .. }) => println!(
                     "{} {}",
                     style::paint(color, GREEN, "✓"),
                     message.unwrap_or_else(|| format!("{name} done"))
                 ),
-                Ok(Response::Error { message }) => {
-                    eprintln!("{} {message}", style::paint(color, RED, "✗"));
+                // Reported like every other error, and the loop carries on so
+                // the remaining names are still attempted.
+                Ok(Response::Error {
+                    code,
+                    message,
+                    errors,
+                }) => {
+                    CliError::new(code, message).with_errors(errors).report();
                     failed = true;
                 }
-                Ok(other) => return Err(format!("unexpected response from the daemon: {other:?}")),
-                Err(err) => return Err(err.to_string()),
+                Ok(other) => {
+                    return Err(format!("unexpected response from the daemon: {other:?}").into())
+                }
+                Err(err) => return Err(err.to_string().into()),
             }
         }
         Ok(if failed { 1 } else { 0 })
     }
 
     /// Print what the daemon is doing.
-    pub fn status(config: Option<&Path>, json: bool) -> Result<i32, String> {
-        let (cfg, _, paths) = setup(config)?;
+    pub fn status(config: Option<&Path>, json: bool) -> Result<i32, CliError> {
+        let (cfg, _, paths) = setup(config).map_err(|e| e.in_json(json))?;
 
         let response = match client::send(&paths.socket, &Request::Status) {
             Ok(response) => response,
             Err(client::ClientError::NotRunning) => {
                 if json {
-                    println!("{{\"running\":false,\"services\":[]}}");
-                } else {
-                    println!(
-                        "no daemon is running for {} — start one with `servicrab start`",
-                        cfg.project.name
-                    );
-                    // Nothing else would lead them to a relocated socket, and
-                    // "not running" is exactly the moment someone starts
-                    // looking for one.  Said only when it is somewhere
-                    // surprising, so the ordinary output does not change.
-                    if !paths.socket_is_in_place() {
-                        println!(
-                            "{}",
-                            style::paint(
-                                style::color_enabled(),
-                                DIM,
-                                &format!(
-                                    "  its socket would be {} (the project's path is too long to hold one)",
-                                    paths.socket.display()
-                                )
-                            )
-                        );
-                    }
+                    // Through serde like the running case, rather than a
+                    // hand-written string that could drift from it.
+                    output::print_document(StatusJson {
+                        running: false,
+                        services: Vec::new(),
+                    })?;
+                    return Ok(output::EXIT_NO_DAEMON);
                 }
-                return Ok(1);
+                let mut error = no_daemon(cfg.project.name.as_str(), false);
+                // Nothing else would lead them to a relocated socket, and
+                // "not running" is exactly the moment someone starts
+                // looking for one.  Said only when it is somewhere
+                // surprising, so the ordinary output does not change.
+                if !paths.socket_is_in_place() {
+                    error = error.with_hint(format!(
+                        "its socket would be {} (the project's path is too long to hold one)",
+                        paths.socket.display()
+                    ));
+                }
+                return Err(error);
             }
-            Err(err) => return Err(err.to_string()),
+            Err(err) => return Err(CliError::from(err.to_string()).in_json(json)),
         };
 
         let services = match response {
             Response::Status { services } => services,
-            Response::Error { message } => return Err(message),
-            other => return Err(format!("unexpected response from the daemon: {other:?}")),
+            Response::Error {
+                code,
+                message,
+                errors,
+            } => {
+                return Err(CliError::new(code, message)
+                    .with_errors(errors)
+                    .in_json(json))
+            }
+            other => {
+                return Err(CliError::from(format!(
+                    "unexpected response from the daemon: {other:?}"
+                ))
+                .in_json(json))
+            }
         };
 
         if json {
-            let payload = serde_json::json!({ "running": true, "services": services });
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&payload)
-                    .map_err(|e| format!("could not render JSON: {e}"))?
-            );
+            output::print_document(StatusJson {
+                running: true,
+                services,
+            })?;
         } else {
             print_table(&services);
         }
         Ok(0)
     }
 
+    /// The `status --json` document, for both the running and the absent case.
+    ///
+    /// One type for both, so the "not running" answer cannot drift away from
+    /// the running one: it used to be a hand-written `{"running":false,
+    /// "services":[]}` that never went through serde at all.
+    #[derive(serde::Serialize)]
+    struct StatusJson {
+        running: bool,
+        services: Vec<ServiceInfo>,
+    }
+
     /// Ask the daemon to stop the stack and exit.
-    pub fn down(config: Option<&Path>) -> Result<i32, String> {
+    pub fn down(config: Option<&Path>) -> Result<i32, CliError> {
         let (cfg, _, paths) = setup(config)?;
 
         match client::send(&paths.socket, &Request::Shutdown) {
             Ok(Response::Ok { .. }) => {}
-            Ok(Response::Error { message }) => return Err(message),
-            Ok(other) => return Err(format!("unexpected response from the daemon: {other:?}")),
-            Err(client::ClientError::NotRunning) => {
-                println!("no daemon is running for {}", cfg.project.name);
-                return Ok(0);
+            Ok(Response::Error {
+                code,
+                message,
+                errors,
+            }) => return Err(CliError::new(code, message).with_errors(errors)),
+            Ok(other) => {
+                return Err(format!("unexpected response from the daemon: {other:?}").into())
             }
-            Err(err) => return Err(err.to_string()),
+            Err(client::ClientError::NotRunning) => {
+                // Not a failure — `down` on an already stopped stack is meant
+                // to be safe to run twice — but the exit code says there was
+                // nothing to do, so a script can tell the two apart.
+                println!("no daemon is running for {}", cfg.project.name);
+                return Ok(output::EXIT_NO_DAEMON);
+            }
+            Err(err) => return Err(err.to_string().into()),
         }
 
         if !client::wait_until_stopped(&paths.socket, STOP_TIMEOUT) {
@@ -561,7 +614,8 @@ mod imp {
                 "the daemon did not stop within {}s — see {}",
                 STOP_TIMEOUT.as_secs(),
                 paths.log.display()
-            ));
+            )
+            .into());
         }
 
         let color = style::color_enabled();
@@ -608,8 +662,9 @@ mod imp {
                 service.name,
                 style::paint(color, tint, &state),
                 service
-                    .pid
-                    .map(|pid| pid.to_string())
+                    .pgid
+                    .or(service.pid)
+                    .map(|pgid| pgid.to_string())
                     .unwrap_or_else(|| "-".to_string()),
                 service
                     .uptime_secs
@@ -659,42 +714,48 @@ mod imp {
 mod imp {
     use super::*;
 
+    use servicrab_protocol::ErrorCode;
+
     const UNSUPPORTED: &str = "the background daemon is only supported on Linux and macOS";
+
+    fn unsupported() -> CliError {
+        CliError::new(ErrorCode::Unsupported, UNSUPPORTED)
+    }
 
     pub fn daemon(
         _config: Option<&Path>,
         _no_restart: bool,
         _profiles: &[String],
-    ) -> Result<i32, String> {
-        Err(UNSUPPORTED.to_string())
+    ) -> Result<i32, CliError> {
+        Err(unsupported())
     }
 
     pub fn start(
         _config: Option<&Path>,
         _selection: Selection<'_>,
         _options: StartOptions,
-    ) -> Result<i32, String> {
-        Err(UNSUPPORTED.to_string())
+    ) -> Result<i32, CliError> {
+        Err(unsupported())
     }
 
-    pub fn stop(_config: Option<&Path>, _services: &[String]) -> Result<i32, String> {
-        Err(UNSUPPORTED.to_string())
+    pub fn stop(_config: Option<&Path>, _services: &[String]) -> Result<i32, CliError> {
+        Err(unsupported())
     }
 
-    pub fn restart(_config: Option<&Path>, _services: &[String]) -> Result<i32, String> {
-        Err(UNSUPPORTED.to_string())
+    pub fn restart(_config: Option<&Path>, _services: &[String]) -> Result<i32, CliError> {
+        Err(unsupported())
     }
 
-    pub fn reload(_config: Option<&Path>) -> Result<i32, String> {
-        Err(UNSUPPORTED.to_string())
+    pub fn reload(_config: Option<&Path>) -> Result<i32, CliError> {
+        Err(unsupported())
     }
 
-    pub fn status(_config: Option<&Path>, _json: bool) -> Result<i32, String> {
-        Err(UNSUPPORTED.to_string())
+    pub fn status(_config: Option<&Path>, json: bool) -> Result<i32, CliError> {
+        Err(unsupported().in_json(json))
     }
 
-    pub fn down(_config: Option<&Path>) -> Result<i32, String> {
-        Err(UNSUPPORTED.to_string())
+    pub fn down(_config: Option<&Path>) -> Result<i32, CliError> {
+        Err(unsupported())
     }
 }
 

--- a/crates/servicrab-cli/src/commands/daemon.rs
+++ b/crates/servicrab-cli/src/commands/daemon.rs
@@ -78,7 +78,7 @@ mod imp {
     use servicrab_protocol::{Request, Response, ServiceInfo};
 
     use crate::daemon::{client, server};
-    use crate::style::{self, BOLD, DIM, GREEN, RED, RESET, YELLOW};
+    use crate::style::{self, Stream, BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
     /// Run the daemon in the foreground (this is the process `start` spawns).
     pub fn daemon(
@@ -178,7 +178,7 @@ mod imp {
 
         wait_for_the_daemon(&mut child, &paths)?;
 
-        let color = style::color_enabled();
+        let color = style::color_enabled_for(Stream::Stdout);
         println!(
             "{} daemon started for {} ({} service(s))",
             style::paint(color, GREEN, "✓"),
@@ -333,7 +333,8 @@ mod imp {
     ) -> Result<i32, String> {
         let timeout = timeout.unwrap_or(WAIT_TIMEOUT);
         let deadline = std::time::Instant::now() + timeout;
-        let color = style::color_enabled();
+        let color_out = style::color_enabled_for(Stream::Stdout);
+        let color_err = style::color_enabled_for(Stream::Stderr);
 
         loop {
             let services = match client::send(socket, &Request::Status) {
@@ -364,7 +365,7 @@ mod imp {
 
             if !gone.is_empty() {
                 for (name, why) in &gone {
-                    eprintln!("{} {name}: {why}", style::paint(color, RED, "✗"));
+                    eprintln!("{} {name}: {why}", style::paint(color_err, RED, "✗"));
                 }
                 return Ok(1);
             }
@@ -372,7 +373,7 @@ mod imp {
             if waiting.is_empty() {
                 println!(
                     "{} {} service(s) ready",
-                    style::paint(color, GREEN, "✓"),
+                    style::paint(color_out, GREEN, "✓"),
                     watched.len()
                 );
                 return Ok(0);
@@ -381,14 +382,14 @@ mod imp {
             if std::time::Instant::now() >= deadline {
                 eprintln!(
                     "{} timed out after {}: still waiting for {}",
-                    style::paint(color, RED, "✗"),
+                    style::paint(color_err, RED, "✗"),
                     humantime::format_duration(timeout),
                     waiting.join(", ")
                 );
                 eprintln!(
                     "{}",
                     style::paint(
-                        color,
+                        color_err,
                         DIM,
                         "  the daemon is still running — see `servicrab status` and `servicrab logs`"
                     )
@@ -433,22 +434,23 @@ mod imp {
         let (cfg, config_path, paths) = setup(config)?;
         expect_a_daemon(&cfg, &paths)?;
 
-        let color = style::color_enabled();
+        let color_out = style::color_enabled_for(Stream::Stdout);
+        let color_err = style::color_enabled_for(Stream::Stderr);
         match client::send(&paths.socket, &Request::Reload) {
             Ok(Response::Ok { message }) => {
                 println!(
                     "{} {}",
-                    style::paint(color, GREEN, "✓"),
+                    style::paint(color_out, GREEN, "✓"),
                     message.unwrap_or_else(|| "reloaded".to_string())
                 );
                 println!(
                     "{}",
-                    style::paint(color, DIM, &format!("  from {}", config_path.display()))
+                    style::paint(color_out, DIM, &format!("  from {}", config_path.display()))
                 );
                 Ok(0)
             }
             Ok(Response::Error { message }) => {
-                eprintln!("{} {message}", style::paint(color, RED, "✗"));
+                eprintln!("{} {message}", style::paint(color_err, RED, "✗"));
                 Ok(1)
             }
             Ok(other) => Err(format!("unexpected response from the daemon: {other:?}")),
@@ -465,17 +467,18 @@ mod imp {
         let (cfg, _, paths) = setup(config)?;
         expect_a_daemon(&cfg, &paths)?;
 
-        let color = style::color_enabled();
+        let color_out = style::color_enabled_for(Stream::Stdout);
+        let color_err = style::color_enabled_for(Stream::Stderr);
         let mut failed = false;
         for name in services {
             match client::send(&paths.socket, &build(name.clone())) {
                 Ok(Response::Ok { message }) => println!(
                     "{} {}",
-                    style::paint(color, GREEN, "✓"),
+                    style::paint(color_out, GREEN, "✓"),
                     message.unwrap_or_else(|| format!("{name} done"))
                 ),
                 Ok(Response::Error { message }) => {
-                    eprintln!("{} {message}", style::paint(color, RED, "✗"));
+                    eprintln!("{} {message}", style::paint(color_err, RED, "✗"));
                     failed = true;
                 }
                 Ok(other) => return Err(format!("unexpected response from the daemon: {other:?}")),
@@ -507,7 +510,7 @@ mod imp {
                         println!(
                             "{}",
                             style::paint(
-                                style::color_enabled(),
+                                style::color_enabled_for(Stream::Stdout),
                                 DIM,
                                 &format!(
                                     "  its socket would be {} (the project's path is too long to hold one)",
@@ -564,7 +567,7 @@ mod imp {
             ));
         }
 
-        let color = style::color_enabled();
+        let color = style::color_enabled_for(Stream::Stdout);
         println!(
             "{} stopped {}",
             style::paint(color, GREEN, "✓"),
@@ -574,7 +577,7 @@ mod imp {
     }
 
     fn print_table(services: &[ServiceInfo]) {
-        let color = style::color_enabled();
+        let color = style::color_enabled_for(Stream::Stdout);
         let width = services
             .iter()
             .map(|s| s.name.len())

--- a/crates/servicrab-cli/src/commands/events.rs
+++ b/crates/servicrab-cli/src/commands/events.rs
@@ -29,7 +29,7 @@ mod imp {
     use servicrab_protocol::{Event, Request, Response, Stream};
 
     use crate::daemon::client;
-    use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
+    use crate::style::{self, BOLD, DIM, SERVICE_COLORS};
 
     /// Attach to the daemon and render its events.
     pub fn events(
@@ -78,13 +78,17 @@ mod imp {
     struct Printer {
         colors: BTreeMap<String, &'static str>,
         width: usize,
-        color: bool,
+        /// Whether the stdout half — a service's captured stdout — is coloured.
+        color_out: bool,
+        /// Whether the stderr half — status lines and notes — is coloured.
+        color_err: bool,
         options: EventsOptions,
     }
 
     impl Printer {
         fn new(services: &[String], options: EventsOptions) -> Self {
-            let color = style::color_enabled();
+            let color_out = style::color_enabled_for(style::Stream::Stdout);
+            let color_err = style::color_enabled_for(style::Stream::Stderr);
             let width = services.iter().map(String::len).max().unwrap_or(0);
             let colors = services
                 .iter()
@@ -94,7 +98,8 @@ mod imp {
             Self {
                 colors,
                 width,
-                color,
+                color_out,
+                color_err,
                 options,
             }
         }
@@ -107,7 +112,7 @@ mod imp {
             };
             eprintln!(
                 "{} {project} → {scope}",
-                style::paint(self.color, BOLD, "servicrab events")
+                style::paint(self.color_err, BOLD, "servicrab events")
             );
         }
 
@@ -115,26 +120,26 @@ mod imp {
         ///
         /// Colours are handed out as services first show up, so a stream that
         /// was not filtered still gets stable, distinct prefixes.
-        fn prefix(&mut self, service: &str) -> String {
+        fn prefix(&mut self, service: &str, color: bool) -> String {
             if self.options.no_prefix {
                 return String::new();
             }
             let next = SERVICE_COLORS[self.colors.len() % SERVICE_COLORS.len()];
-            let color = *self
+            let tint = *self
                 .colors
                 .entry(service.to_string())
                 .or_insert_with(|| next);
             self.width = self.width.max(service.len());
             let label = format!("{:width$}", service, width = self.width);
-            format!("{} {} ", style::paint(self.color, color, &label), "|")
+            format!("{} {} ", style::paint(color, tint, &label), "|")
         }
 
-        fn timestamp(&self) -> String {
+        fn timestamp(&self, color: bool) -> String {
             if !self.options.timestamps {
                 return String::new();
             }
             let now = style::utc_hms(std::time::SystemTime::now());
-            format!("{} ", style::paint(self.color, DIM, &now))
+            format!("{} ", style::paint(color, DIM, &now))
         }
 
         fn response(&mut self, response: &Response) {
@@ -224,14 +229,25 @@ mod imp {
         }
 
         fn log(&mut self, service: &str, stream: Stream, line: &str) {
-            let text = format!("{}{}{}", self.timestamp(), self.prefix(service), line);
             match stream {
                 Stream::Stderr => {
+                    let text = format!(
+                        "{}{}{}",
+                        self.timestamp(self.color_err),
+                        self.prefix(service, self.color_err),
+                        line
+                    );
                     let mut err = std::io::stderr().lock();
                     let _ = writeln!(err, "{text}");
                     let _ = err.flush();
                 }
                 _ => {
+                    let text = format!(
+                        "{}{}{}",
+                        self.timestamp(self.color_out),
+                        self.prefix(service, self.color_out),
+                        line
+                    );
                     let mut out = std::io::stdout().lock();
                     let _ = writeln!(out, "{text}");
                     let _ = out.flush();
@@ -242,9 +258,9 @@ mod imp {
         fn status(&mut self, service: &str, symbol: &str, message: &str) {
             let text = format!(
                 "{}{}{}",
-                self.timestamp(),
-                self.prefix(service),
-                style::paint(self.color, DIM, &format!("{symbol} {message}"))
+                self.timestamp(self.color_err),
+                self.prefix(service, self.color_err),
+                style::paint(self.color_err, DIM, &format!("{symbol} {message}"))
             );
             let mut err = std::io::stderr().lock();
             let _ = writeln!(err, "{text}");
@@ -253,13 +269,10 @@ mod imp {
 
         /// Report something about the stream itself, not about a service.
         fn note(&self, message: &str) {
-            eprintln!("{}⚠  {message}{}", if self.color { DIM } else { "" }, {
-                if self.color {
-                    RESET
-                } else {
-                    ""
-                }
-            });
+            eprintln!(
+                "{}",
+                style::paint(self.color_err, DIM, &format!("⚠  {message}"))
+            );
         }
     }
 
@@ -289,12 +302,12 @@ mod imp {
         #[test]
         fn prefixes_are_padded_and_stable() {
             let mut printer = Printer::new(&[], EventsOptions::default());
-            let first = printer.prefix("api");
-            let second = printer.prefix("worker");
+            let first = printer.prefix("api", false);
+            let second = printer.prefix("worker", false);
             assert!(first.contains("api"));
             assert!(second.contains("worker"));
             // The second, longer name widens the column for later lines.
-            assert!(printer.prefix("api").contains("api   "));
+            assert!(printer.prefix("api", false).contains("api   "));
             // A name keeps the colour it was first given.
             assert_eq!(printer.colors["api"], SERVICE_COLORS[0]);
             assert_eq!(printer.colors["worker"], SERVICE_COLORS[1]);
@@ -309,7 +322,7 @@ mod imp {
                     ..EventsOptions::default()
                 },
             );
-            assert_eq!(printer.prefix("api"), "");
+            assert_eq!(printer.prefix("api", false), "");
         }
     }
 }

--- a/crates/servicrab-cli/src/commands/events.rs
+++ b/crates/servicrab-cli/src/commands/events.rs
@@ -46,7 +46,7 @@ mod imp {
         }
 
         let request = Request::Subscribe {
-            services: services.to_vec(),
+            services: services.iter().cloned().collect(),
             logs: !options.no_logs,
         };
 

--- a/crates/servicrab-cli/src/commands/events.rs
+++ b/crates/servicrab-cli/src/commands/events.rs
@@ -210,6 +210,11 @@ mod imp {
                         "watch: more than {limit} files; narrow `paths` or add `ignore` entries"
                     ),
                 ),
+                Event::LogLinesDropped { count } => self.status(
+                    service,
+                    "!",
+                    &format!("dropped {count} output line(s): faster than they could be consumed"),
+                ),
                 // Unlike `up`, a client that just attached has no idea what
                 // the services are doing, so state changes are worth showing.
                 Event::State { state } => self.status(service, "·", &state.to_string()),

--- a/crates/servicrab-cli/src/commands/events.rs
+++ b/crates/servicrab-cli/src/commands/events.rs
@@ -29,6 +29,7 @@ mod imp {
     use servicrab_protocol::{Event, Request, Response, Stream};
 
     use crate::daemon::client;
+    use crate::output::{self, no_daemon, CliError};
     use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
 
     /// Attach to the daemon and render its events.
@@ -36,12 +37,17 @@ mod imp {
         services: &[String],
         config: Option<&Path>,
         options: EventsOptions,
-    ) -> Result<i32, String> {
-        let (cfg, _, paths) = crate::commands::daemon::setup(config)?;
+    ) -> Result<i32, CliError> {
+        let (cfg, _, paths) =
+            crate::commands::daemon::setup(config).map_err(|e| e.in_json(options.json))?;
 
         for name in services {
             if !cfg.services.keys().any(|known| known.as_str() == name) {
-                return Err(format!("unknown service: {name}"));
+                return Err(CliError::new(
+                    servicrab_protocol::ErrorCode::UnknownService,
+                    format!("unknown service: {name}"),
+                )
+                .in_json(options.json));
             }
         }
 
@@ -51,7 +57,12 @@ mod imp {
         };
 
         let mut printer = Printer::new(services, options);
-        if !options.json {
+        if options.json {
+            // The same handshake `up --json` prints, and the same one the
+            // daemon answers a subscription with, so all three streams open
+            // identically.
+            output::print_stream_header();
+        } else {
             printer.banner(cfg.project.name.as_str(), services);
         }
 
@@ -66,11 +77,10 @@ mod imp {
             true
         }) {
             Ok(()) => Ok(0),
-            Err(client::ClientError::NotRunning) => Err(format!(
-                "no daemon is running for {} — start one with `servicrab start`",
-                cfg.project.name
-            )),
-            Err(err) => Err(err.to_string()),
+            Err(client::ClientError::NotRunning) => {
+                Err(no_daemon(cfg.project.name.as_str(), options.json))
+            }
+            Err(err) => Err(CliError::from(err.to_string()).in_json(options.json)),
         }
     }
 
@@ -143,7 +153,7 @@ mod imp {
                 Response::Lagged { skipped } => {
                     self.note(&format!("dropped {skipped} event(s): too slow to keep up"))
                 }
-                Response::Error { message } => self.note(message),
+                Response::Error { message, .. } => self.note(message),
                 _ => {}
             }
         }
@@ -318,12 +328,18 @@ mod imp {
 mod imp {
     use super::*;
 
+    use crate::output::CliError;
+
     pub fn events(
         _services: &[String],
         _config: Option<&Path>,
-        _options: EventsOptions,
-    ) -> Result<i32, String> {
-        Err("the background daemon is only supported on Linux and macOS".to_string())
+        options: EventsOptions,
+    ) -> Result<i32, CliError> {
+        Err(CliError::new(
+            servicrab_protocol::ErrorCode::Unsupported,
+            "the background daemon is only supported on Linux and macOS",
+        )
+        .in_json(options.json))
     }
 }
 

--- a/crates/servicrab-cli/src/commands/init.rs
+++ b/crates/servicrab-cli/src/commands/init.rs
@@ -76,7 +76,8 @@ name = "my-project"
 #                 `servicrab down` and `servicrab start`
 #   restart_delay         Minimum backoff before first restart (default: 1s)
 #   restart_max_delay     Maximum backoff cap (default: 30s)
-#   max_restarts          Give up after this many attempts (default: 10)
+#   max_restarts          Give up after this many attempts (default: 10,
+#                         0 means never give up)
 #   stable_after          Consider stable after running this long (default: 60s)
 #   shutdown_signal       term | int | quit | hup  (default: term)
 #   shutdown_timeout      Wait this long before forcibly killing (default: 10s)

--- a/crates/servicrab-cli/src/commands/list.rs
+++ b/crates/servicrab-cli/src/commands/list.rs
@@ -4,19 +4,22 @@ use std::path::Path;
 
 use serde::Serialize;
 use servicrab_core::{load, resolve_config_path, Service, ServiceName};
+use servicrab_protocol::ErrorCode;
+
+use crate::output::{self, CliError};
 
 /// Run the `list` subcommand.
-pub fn run(config: Option<&Path>, json: bool) -> Result<(), String> {
-    let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
+pub fn run(config: Option<&Path>, json: bool) -> Result<(), CliError> {
+    let path = resolve_config_path(config)
+        .map_err(|e| CliError::from(format!("could not find config: {e}")).in_json(json))?;
 
     let (cfg, warnings) = load(&path).map_err(|errors| {
-        let msgs: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
-        format!(
-            "✗ {} has {} error(s):\n{}",
-            path.display(),
-            errors.len(),
-            msgs.join("\n")
+        CliError::new(
+            ErrorCode::ValidationFailed,
+            format!("{} has {} error(s)", path.display(), errors.len()),
         )
+        .with_errors(errors.iter().map(ToString::to_string).collect())
+        .in_json(json)
     })?;
 
     for warning in &warnings {
@@ -24,15 +27,25 @@ pub fn run(config: Option<&Path>, json: bool) -> Result<(), String> {
     }
 
     if json {
-        print_json(&cfg.services);
-    } else {
-        print_table(&cfg.services, &cfg.project.name.to_string());
+        return print_json(&cfg.project.name.to_string(), &cfg.services);
     }
+    print_table(&cfg.services, &cfg.project.name.to_string());
 
     Ok(())
 }
 
 // ── JSON output ────────────────────────────────────────────────────────────
+
+/// The `list --json` document.
+///
+/// An envelope rather than the bare array this used to print: every `--json`
+/// document carries a `schema_version`, and an array has nowhere to put one.
+/// The services themselves are still an array, under `services`.
+#[derive(Serialize)]
+struct ListJson<'a> {
+    project: &'a str,
+    services: Vec<ServiceJson<'a>>,
+}
 
 #[derive(Serialize)]
 struct ServiceJson<'a> {
@@ -59,7 +72,10 @@ struct DependencyJson<'a> {
     condition: String,
 }
 
-fn print_json(services: &std::collections::BTreeMap<ServiceName, Service>) {
+fn print_json(
+    project: &str,
+    services: &std::collections::BTreeMap<ServiceName, Service>,
+) -> Result<(), CliError> {
     let list: Vec<ServiceJson<'_>> = services
         .values()
         .map(|svc| {
@@ -83,10 +99,10 @@ fn print_json(services: &std::collections::BTreeMap<ServiceName, Service>) {
         })
         .collect();
 
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&list).expect("JSON serialization")
-    );
+    output::print_document(ListJson {
+        project,
+        services: list,
+    })
 }
 
 /// The dependencies of one service, each with its effective condition.

--- a/crates/servicrab-cli/src/commands/list.rs
+++ b/crates/servicrab-cli/src/commands/list.rs
@@ -198,7 +198,7 @@ mod tests {
     fn a_multi_byte_command_is_cut_on_a_character_boundary() {
         // Byte 29 lands inside the last '€', which is what used to panic.
         let cmd = "echo x€€€€€€€€€";
-        assert_eq!(truncate(cmd, 30), cmd, "16 characters is under the limit");
+        assert_eq!(truncate(cmd, 30), cmd, "15 characters is under the limit");
 
         // Long enough to be cut, with the cut point inside a multi-byte
         // character: the result must stay valid UTF-8 and count characters.

--- a/crates/servicrab-cli/src/commands/list.rs
+++ b/crates/servicrab-cli/src/commands/list.rs
@@ -9,7 +9,7 @@ use servicrab_core::{load, resolve_config_path, Service, ServiceName};
 pub fn run(config: Option<&Path>, json: bool) -> Result<(), String> {
     let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
 
-    let (cfg, _) = load(&path).map_err(|errors| {
+    let (cfg, warnings) = load(&path).map_err(|errors| {
         let msgs: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
         format!(
             "✗ {} has {} error(s):\n{}",
@@ -18,6 +18,10 @@ pub fn run(config: Option<&Path>, json: bool) -> Result<(), String> {
             msgs.join("\n")
         )
     })?;
+
+    for warning in &warnings {
+        eprintln!("⚠  {warning}");
+    }
 
     if json {
         print_json(&cfg.services);

--- a/crates/servicrab-cli/src/commands/list.rs
+++ b/crates/servicrab-cli/src/commands/list.rs
@@ -107,6 +107,26 @@ fn dependencies<'a>(
 
 // ── Human-readable table ───────────────────────────────────────────────────
 
+/// Shorten a command line to at most `max` characters, marking the cut with
+/// an ellipsis.
+///
+/// The width is counted in characters and the slice is taken at a character
+/// boundary: `len()` is in bytes, so slicing on a byte offset panics as soon as
+/// a command contains an accented path, an emoji or any other multi-byte
+/// character.  Grapheme clusters can still be split — this is a column preview,
+/// not a faithful rendering — but the output is always valid UTF-8.
+fn truncate(cmd: &str, max: usize) -> String {
+    debug_assert!(max > 0, "a preview needs room for at least the ellipsis");
+    // The character *after* the last one that fits, plus whatever follows it.
+    let mut rest = cmd.char_indices().skip(max - 1);
+    match (rest.next(), rest.next()) {
+        // Only `max` characters at most: the ellipsis would cost more than the
+        // one character it would hide.
+        (Some((cut, _)), Some(_)) => format!("{}…", &cmd[..cut]),
+        _ => cmd.to_string(),
+    }
+}
+
 fn print_table(services: &std::collections::BTreeMap<ServiceName, Service>, project: &str) {
     println!("Project: {project}");
     println!();
@@ -123,11 +143,7 @@ fn print_table(services: &std::collections::BTreeMap<ServiceName, Service>, proj
         let mut cmd_parts = vec![svc.executable.as_str()];
         cmd_parts.extend(svc.args.iter().map(String::as_str));
         let cmd_str = cmd_parts.join(" ");
-        let cmd_preview = if cmd_str.len() > 30 {
-            format!("{}…", &cmd_str[..29])
-        } else {
-            cmd_str
-        };
+        let cmd_preview = truncate(&cmd_str, 30);
         println!(
             "{:<24} {:<12} {:<8} {}",
             svc.name.as_str(),
@@ -152,5 +168,39 @@ fn print_table(services: &std::collections::BTreeMap<ServiceName, Service>, proj
                 humantime::format_duration(health.interval)
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_short_command_is_left_alone() {
+        assert_eq!(truncate("echo hi", 30), "echo hi");
+        // Exactly at the limit, so nothing is hidden and no ellipsis is needed.
+        assert_eq!(truncate(&"a".repeat(30), 30), "a".repeat(30));
+    }
+
+    #[test]
+    fn a_long_command_is_cut_with_an_ellipsis() {
+        assert_eq!(
+            truncate(&"a".repeat(31), 30),
+            format!("{}…", "a".repeat(29))
+        );
+    }
+
+    #[test]
+    fn a_multi_byte_command_is_cut_on_a_character_boundary() {
+        // Byte 29 lands inside the last '€', which is what used to panic.
+        let cmd = "echo x€€€€€€€€€";
+        assert_eq!(truncate(cmd, 30), cmd, "16 characters is under the limit");
+
+        // Long enough to be cut, with the cut point inside a multi-byte
+        // character: the result must stay valid UTF-8 and count characters.
+        let long = format!("echo {}", "€".repeat(40));
+        let cut = truncate(&long, 30);
+        assert_eq!(cut.chars().count(), 30, "29 characters plus the ellipsis");
+        assert!(cut.ends_with('…'), "{cut}");
     }
 }

--- a/crates/servicrab-cli/src/commands/logs.rs
+++ b/crates/servicrab-cli/src/commands/logs.rs
@@ -4,7 +4,7 @@
 //! without it this command explains how to turn file logging on rather than
 //! silently printing nothing.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::time::Duration;
@@ -32,7 +32,7 @@ pub struct LogsOptions {
 /// Services that set `[services.<name>.logs] enabled = false` are excluded.
 pub fn router_for(cfg: &Config) -> Option<LogRouter> {
     let settings = cfg.project.logs.clone()?;
-    let excluded: Vec<ServiceName> = cfg
+    let excluded: BTreeSet<ServiceName> = cfg
         .services
         .values()
         .filter(|svc| !svc.log_to_file)

--- a/crates/servicrab-cli/src/commands/logs.rs
+++ b/crates/servicrab-cli/src/commands/logs.rs
@@ -229,7 +229,7 @@ impl Printer {
         Self {
             colors,
             width,
-            color: style::color_enabled(),
+            color: style::color_enabled_for(style::Stream::Stdout),
             // A single service needs no prefix to tell its lines apart.
             no_prefix: no_prefix || services.len() < 2,
         }

--- a/crates/servicrab-cli/src/commands/logs.rs
+++ b/crates/servicrab-cli/src/commands/logs.rs
@@ -45,7 +45,7 @@ pub fn router_for(cfg: &Config) -> Option<LogRouter> {
 pub fn run(services: &[String], config: Option<&Path>, options: LogsOptions) -> Result<(), String> {
     let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
 
-    let (cfg, _) = load(&path).map_err(|errors| {
+    let (cfg, warnings) = load(&path).map_err(|errors| {
         let msgs: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
         format!(
             "✗ {} has {} error(s):\n{}",
@@ -54,6 +54,10 @@ pub fn run(services: &[String], config: Option<&Path>, options: LogsOptions) -> 
             msgs.join("\n")
         )
     })?;
+
+    for warning in &warnings {
+        eprintln!("⚠  {warning}");
+    }
 
     let Some(settings) = cfg.project.logs.clone() else {
         return Err(format!(

--- a/crates/servicrab-cli/src/commands/logs.rs
+++ b/crates/servicrab-cli/src/commands/logs.rs
@@ -70,30 +70,33 @@ pub fn run(services: &[String], config: Option<&Path>, options: LogsOptions) -> 
     let mut sources: Vec<Source> = Vec::new();
     for name in &selected {
         let file = settings.file_for(name);
-        let tail = read_tail(&file, options.lines)?;
+        let tail = read_tail(&file, options.lines, options.follow)?;
         sources.push(Source {
             service: name.clone(),
             path: file,
-            offset: 0,
-            tail,
+            offset: tail.end,
+            lines: tail.lines,
         });
     }
 
-    if sources.iter().all(|s| s.tail.is_empty()) && !options.follow {
-        return Err(format!(
+    // An empty log directory is what every stack looks like before it has run,
+    // so this is a state of the world to report rather than a way for the
+    // command to fail: `servicrab logs && echo ok` should not stop here.
+    if sources.iter().all(|s| s.lines.is_empty()) && !options.follow {
+        eprintln!(
             "no log output yet in {} — start the stack with `servicrab up` first",
             settings.dir.display()
-        ));
+        );
+        return Ok(());
     }
 
     let printer = Printer::new(&selected, options.no_prefix);
     // Interleaving files by line count is meaningless, so each service's tail
     // is printed as a block; following then merges new lines as they arrive.
     for source in &mut sources {
-        for line in std::mem::take(&mut source.tail) {
+        for line in std::mem::take(&mut source.lines) {
             printer.line(&source.service, &line);
         }
-        source.offset = file_len(&source.path);
     }
 
     if options.follow {
@@ -140,33 +143,113 @@ fn select_services(cfg: &Config, requested: &[String]) -> Result<Vec<ServiceName
 struct Source {
     service: ServiceName,
     path: std::path::PathBuf,
+    /// Where reading stopped: the byte just past the last complete line that
+    /// was printed.  It is the position a read actually reached, never a
+    /// separately sampled file length — sampling the length and then reading
+    /// are two different moments, and a log file grows in between.
     offset: u64,
-    tail: Vec<String>,
+    lines: Vec<String>,
 }
 
 fn file_len(path: &Path) -> u64 {
     std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
 }
 
-/// Read the last `count` lines of a file, tolerating a missing file.
-fn read_tail(path: &Path, count: usize) -> Result<Vec<String>, String> {
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(err) => return Err(format!("could not read {}: {err}", path.display())),
-    };
+/// What one read of a log file yielded.
+struct Chunk {
+    /// The complete lines, newline stripped.
+    lines: Vec<String>,
+    /// The byte just past the last complete line.
+    ///
+    /// A line still being written stays unread, so the next read picks it up
+    /// once its newline has arrived and prints it once, whole.
+    end: u64,
+    /// The unterminated remainder, if the file ended mid-line.
+    partial: Option<String>,
+}
 
-    let mut lines: std::collections::VecDeque<String> = std::collections::VecDeque::new();
-    for line in BufReader::new(file).lines() {
-        let line = line.map_err(|e| format!("could not read {}: {e}", path.display()))?;
-        if count > 0 && lines.len() == count {
-            lines.pop_front();
+/// Read every complete line from `offset` to the end of the file.
+///
+/// Log files hold whatever the services printed, and a service is free to print
+/// a stray byte that is not UTF-8 — a binary blob, a half-written multi-byte
+/// character, output in another encoding.  That is not a reason to refuse to
+/// show the log, so the undecodable bytes are replaced and the rest is
+/// readable.
+fn read_lines(path: &Path, offset: u64) -> Result<Chunk, String> {
+    let mut file =
+        std::fs::File::open(path).map_err(|e| format!("could not read {}: {e}", path.display()))?;
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|e| format!("could not read {}: {e}", path.display()))?;
+
+    let mut reader = BufReader::new(file);
+    let mut lines = Vec::new();
+    let mut end = offset;
+    let mut buffer = Vec::new();
+    loop {
+        buffer.clear();
+        let read = reader
+            .read_until(b'\n', &mut buffer)
+            .map_err(|e| format!("could not read {}: {e}", path.display()))?;
+        if read == 0 {
+            return Ok(Chunk {
+                lines,
+                end,
+                partial: None,
+            });
         }
-        if count > 0 {
-            lines.push_back(line);
+        if buffer.last() != Some(&b'\n') {
+            return Ok(Chunk {
+                lines,
+                end,
+                partial: Some(decode(&buffer)),
+            });
         }
+        end += read as u64;
+        lines.push(decode(&buffer));
     }
-    Ok(lines.into())
+}
+
+/// Turn one raw line into text, dropping the line ending.
+fn decode(raw: &[u8]) -> String {
+    let text = String::from_utf8_lossy(raw);
+    let text = text.strip_suffix('\n').unwrap_or(&text);
+    text.strip_suffix('\r').unwrap_or(text).to_string()
+}
+
+/// The last `count` lines of a file, and where they end.
+struct Tail {
+    lines: Vec<String>,
+    end: u64,
+}
+
+/// Read the last `count` lines of a file, tolerating a missing file.
+///
+/// A file that ends mid-line is the normal state of a log a service is writing
+/// to.  Without `--follow` the half line is all there will ever be to show, so
+/// it is shown; with it, the line is left for the pass that finds it finished,
+/// which is the only way to print it once rather than twice.
+fn read_tail(path: &Path, count: usize, follow: bool) -> Result<Tail, String> {
+    if !path.exists() {
+        return Ok(Tail {
+            lines: Vec::new(),
+            end: 0,
+        });
+    }
+    let chunk = read_lines(path, 0)?;
+
+    let mut lines = chunk.lines;
+    if !follow {
+        lines.extend(chunk.partial);
+    }
+    if count == 0 {
+        lines.clear();
+    } else if lines.len() > count {
+        lines.drain(..lines.len() - count);
+    }
+    Ok(Tail {
+        lines,
+        end: chunk.end,
+    })
 }
 
 /// Print new lines as they are appended, until interrupted.
@@ -184,19 +267,14 @@ fn follow(sources: &mut [Source], printer: &Printer) -> Result<(), String> {
                 continue;
             }
 
-            let mut file = match std::fs::File::open(&source.path) {
-                Ok(file) => file,
-                Err(_) => continue,
-            };
-            if file.seek(SeekFrom::Start(source.offset)).is_err() {
+            let Ok(chunk) = read_lines(&source.path, source.offset) else {
                 continue;
-            }
-            for line in BufReader::new(&mut file).lines() {
-                let Ok(line) = line else { break };
-                printer.line(&source.service, &line);
+            };
+            for line in &chunk.lines {
+                printer.line(&source.service, line);
                 printed = true;
             }
-            source.offset = len;
+            source.offset = chunk.end;
         }
 
         if !printed {
@@ -253,12 +331,14 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn tail(path: &Path, count: usize) -> Vec<String> {
+        read_tail(path, count, false).unwrap().lines
+    }
+
     #[test]
     fn the_tail_of_a_missing_file_is_empty() {
         let dir = TempDir::new().unwrap();
-        assert!(read_tail(&dir.path().join("nope.log"), 10)
-            .unwrap()
-            .is_empty());
+        assert!(tail(&dir.path().join("nope.log"), 10).is_empty());
     }
 
     #[test]
@@ -267,11 +347,8 @@ mod tests {
         let path = dir.path().join("api.log");
         std::fs::write(&path, "one\ntwo\nthree\nfour\n").unwrap();
 
-        assert_eq!(read_tail(&path, 2).unwrap(), vec!["three", "four"]);
-        assert_eq!(
-            read_tail(&path, 10).unwrap(),
-            vec!["one", "two", "three", "four"]
-        );
+        assert_eq!(tail(&path, 2), vec!["three", "four"]);
+        assert_eq!(tail(&path, 10), vec!["one", "two", "three", "four"]);
     }
 
     #[test]
@@ -280,6 +357,77 @@ mod tests {
         let path = dir.path().join("api.log");
         std::fs::write(&path, "one\ntwo\n").unwrap();
 
-        assert!(read_tail(&path, 0).unwrap().is_empty());
+        assert!(tail(&path, 0).is_empty());
+    }
+
+    #[test]
+    fn a_line_that_is_not_utf8_is_shown_with_replacements_rather_than_refused() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.log");
+        std::fs::write(&path, b"before\n\xffbad\nafter\n").unwrap();
+
+        let lines = tail(&path, 10);
+        assert_eq!(lines.len(), 3, "{lines:?}");
+        assert_eq!(lines[0], "before");
+        assert_eq!(lines[1], "\u{fffd}bad");
+        assert_eq!(lines[2], "after");
+    }
+
+    #[test]
+    fn a_read_stops_after_the_last_complete_line() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.log");
+        std::fs::write(&path, "done\nhalf").unwrap();
+
+        let chunk = read_lines(&path, 0).unwrap();
+        assert_eq!(chunk.lines, vec!["done"]);
+        assert_eq!(chunk.partial.as_deref(), Some("half"));
+        // Just past "done\n", so the half line is read again once it is whole.
+        assert_eq!(chunk.end, 5);
+    }
+
+    #[test]
+    fn a_half_written_line_is_left_for_the_next_pass_while_following() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.log");
+        std::fs::write(&path, "done\nhalf").unwrap();
+
+        let followed = read_tail(&path, 10, true).unwrap();
+        assert_eq!(followed.lines, vec!["done"]);
+        assert_eq!(followed.end, 5);
+
+        // Without --follow there is no next pass, so the fragment is all there
+        // will be to show and it is shown.
+        let once = read_tail(&path, 10, false).unwrap();
+        assert_eq!(once.lines, vec!["done", "half"]);
+    }
+
+    #[test]
+    fn following_resumes_where_the_last_read_stopped_even_when_the_file_grew() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.log");
+        std::fs::write(&path, "one\n").unwrap();
+
+        let first = read_lines(&path, 0).unwrap();
+        assert_eq!(first.lines, vec!["one"]);
+
+        // What an append between the sample and the read used to cost: the old
+        // code rewound to a length taken before reading, so everything appended
+        // meanwhile came out a second time.
+        std::fs::write(&path, "one\ntwo\n").unwrap();
+        let second = read_lines(&path, first.end).unwrap();
+        assert_eq!(second.lines, vec!["two"]);
+
+        let third = read_lines(&path, second.end).unwrap();
+        assert!(third.lines.is_empty(), "{:?}", third.lines);
+    }
+
+    #[test]
+    fn a_windows_line_ending_is_not_shown_as_a_stray_carriage_return() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.log");
+        std::fs::write(&path, "one\r\n").unwrap();
+
+        assert_eq!(tail(&path, 10), vec!["one"]);
     }
 }

--- a/crates/servicrab-cli/src/commands/man.rs
+++ b/crates/servicrab-cli/src/commands/man.rs
@@ -57,7 +57,12 @@ services.
 .TP
 \fBNO_COLOR\fR
 Set to any value to disable coloured output.  Colour is also disabled when
-\fBTERM\fR is \fBdumb\fR, and whenever stdout is not a terminal.
+\fBTERM\fR is \fBdumb\fR, and for whichever of stdout and stderr is not a
+terminal.
+.TP
+\fBCLICOLOR_FORCE\fR
+Set to anything other than \fB0\fR to colour output even when it is redirected
+to a pipe or a file.  \fBNO_COLOR\fR wins over it; \fB--color\fR wins over both.
 .SH EXIT STATUS
 .TP
 \fB0\fR
@@ -111,9 +116,14 @@ pub fn run<C: CommandFactory>(output: Option<&Path>) -> Result<(), String> {
     let page = page::<C>().map_err(|e| format!("failed to render the man page: {e}"))?;
 
     let Some(dir) = output else {
-        return std::io::stdout()
-            .write_all(&page)
-            .map_err(|e| format!("failed to write the man page: {e}"));
+        return match std::io::stdout().write_all(&page) {
+            Ok(()) => Ok(()),
+            // `servicrab man | head` closes the pipe partway through the page,
+            // and that is the reader saying it has seen enough — not a failure
+            // to report and not a reason to exit non-zero.
+            Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+            Err(err) => Err(format!("failed to write the man page: {err}")),
+        };
     };
 
     std::fs::create_dir_all(dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;

--- a/crates/servicrab-cli/src/commands/man.rs
+++ b/crates/servicrab-cli/src/commands/man.rs
@@ -62,20 +62,40 @@ Set to any value to disable coloured output.  Colour is also disabled when
 .TP
 \fB0\fR
 Success.  For \fBrun\fR and \fBup\fR this means the services were shut down as
-asked, not that they never failed.
+asked, not that they never failed.  \fBdown\fR uses it when a daemon was there
+and stopped.
 .TP
 \fB1\fR
-The command failed: an invalid configuration, no daemon running, an unknown
-service, or a service that exhausted its restart budget.
+The command failed: an invalid configuration, an unknown service, a service that
+exhausted its restart budget, a per-service command the daemon refused, or a
+\fBstart --wait\fR that timed out.
+.TP
+\fB3\fR
+No daemon is running for this project.  Its own status so that a script can tell
+"there is nothing to talk to" from a real failure, and it is what \fBstatus\fR,
+\fBstop\fR, \fBrestart\fR, \fBstart\fR \fISERVICE\fR, \fBreload\fR,
+\fBevents\fR and \fBdown\fR all report.  \fBdown\fR still does not \fIfail\fR
+because nothing was running — this only says there was nothing to do.
 .TP
 \fB126\fR, \fB127\fR
 \fBexec\fR could not run the command: found but not executable (126), or not
 found (127).  These follow the shell convention, so a script can tell a missing
 command from one that ran and failed.
 .TP
+\fB129\fR, \fB130\fR, \fB143\fR
+\fBup\fR and \fBwatch\fR were cut short by a signal and shut the stack down
+cleanly: \fBSIGHUP\fR (129), Ctrl+C (130), or \fBSIGTERM\fR (143).  These follow
+the \fB128+N\fR convention, and a clean shutdown is what they mean — not a
+failure.
+.TP
 \fBanything else\fR
 \fBexec\fR and \fBrun\fR pass through the status of the process they ran: its own
 exit code, or \fB128+N\fR when a signal \fIN\fR killed it.
+.PP
+Every error is written to standard error, prefixed with \fBerror: \fR, with the
+individual problems as bullets below it.  Under \fB--json\fR it is a JSON object
+on standard error instead, carrying \fBschema_version\fR and a stable \fBcode\fR,
+so that standard output holds nothing but the document that was asked for.
 .SH SEE ALSO
 Full documentation, including the configuration reference, at
 \fBhttps://github.com/gaborini/servicrab\fR

--- a/crates/servicrab-cli/src/commands/run.rs
+++ b/crates/servicrab-cli/src/commands/run.rs
@@ -109,7 +109,7 @@ async fn tee_output(mut events: EventReceiver, router: LogRouter) {
         let EventKind::Log { stream, line } = &event.kind else {
             continue;
         };
-        if let Some(problem) = sink.record(&event.service, line).await {
+        if let Some(problem) = sink.record(&event.service, line) {
             eprintln!("⚠  {problem}");
         }
         match stream {

--- a/crates/servicrab-cli/src/commands/run.rs
+++ b/crates/servicrab-cli/src/commands/run.rs
@@ -17,6 +17,8 @@ use servicrab_core::{
 const EXIT_SIGINT: i32 = 130;
 /// Exit code used when the supervisor itself was terminated (`128 + SIGTERM`).
 const EXIT_SIGTERM: i32 = 143;
+/// Exit code used when the controlling terminal went away (`128 + SIGHUP`).
+const EXIT_SIGHUP: i32 = 129;
 
 /// Run the `run` subcommand, returning the process exit code to use.
 pub fn run(service: &str, config: Option<&Path>, no_restart: bool) -> Result<i32, String> {
@@ -131,6 +133,7 @@ fn exit_code(outcome: RunOutcome) -> i32 {
         RunOutcome::Stopped { reason } => match reason {
             ShutdownReason::UserInterrupt => EXIT_SIGINT,
             ShutdownReason::Terminated => EXIT_SIGTERM,
+            ShutdownReason::HangUp => EXIT_SIGHUP,
             // `run` supervises a single service with no daemon around it, so
             // nobody can ask for a targeted stop; treat it as a clean one.
             ShutdownReason::Requested => 0,
@@ -187,6 +190,12 @@ mod tests {
                 reason: ShutdownReason::Terminated
             }),
             143
+        );
+        assert_eq!(
+            exit_code(RunOutcome::Stopped {
+                reason: ShutdownReason::HangUp
+            }),
+            129
         );
         assert_eq!(
             exit_code(RunOutcome::Stopped {

--- a/crates/servicrab-cli/src/commands/run.rs
+++ b/crates/servicrab-cli/src/commands/run.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use servicrab_core::runtime::{lookup_service, OutputMode, RunOptions, RunOutcome};
 use servicrab_core::{
     event_channel, load, resolve_config_path, EventKind, EventReceiver, ExitReason,
-    ForegroundRunner, LogRouter, ShutdownReason, Stream,
+    ForegroundRunner, LogRouter, LogSink, ShutdownReason, Stream,
 };
 
 /// Exit code used when a run is cut short by Ctrl+C (`128 + SIGINT`).
@@ -99,12 +99,17 @@ fn foreground(
 }
 
 /// Echo captured output verbatim while copying it into the log file.
-async fn tee_output(mut events: EventReceiver, mut router: LogRouter) {
+///
+/// The file work runs on a blocking task, so a slow disk cannot stall the
+/// runtime that is waiting on the child.
+async fn tee_output(mut events: EventReceiver, router: LogRouter) {
+    let sink = LogSink::spawn(router);
+
     while let Some(event) = events.recv().await {
         let EventKind::Log { stream, line } = &event.kind else {
             continue;
         };
-        if let Some(problem) = router.record(&event.service, line) {
+        if let Some(problem) = sink.record(&event.service, line).await {
             eprintln!("⚠  {problem}");
         }
         match stream {
@@ -119,6 +124,11 @@ async fn tee_output(mut events: EventReceiver, mut router: LogRouter) {
                 let _ = err.flush();
             }
         }
+    }
+
+    // The run is over; the queued lines still have to reach the file.
+    if let Some(problem) = sink.shutdown().await {
+        eprintln!("⚠  {problem}");
     }
 }
 

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -308,6 +308,11 @@ impl Printer {
                 "!",
                 &format!("watch: more than {limit} files; narrow `paths` or add `ignore` entries"),
             ),
+            EventKind::LogLinesDropped { count } => self.status(
+                service,
+                "!",
+                &format!("dropped {count} output line(s): faster than they could be consumed"),
+            ),
             // State transitions and the final summary are already conveyed by
             // the events above; showing them too would only add noise.
             EventKind::State(_) | EventKind::Finished { .. } => {}

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -153,7 +153,7 @@ async fn render(mut events: EventReceiver, printer: Printer, logs: Option<LogRou
 
     while let Some(event) = events.recv().await {
         if let (Some(sink), EventKind::Log { line, .. }) = (sink.as_ref(), &event.kind) {
-            if let Some(problem) = sink.record(&event.service, line).await {
+            if let Some(problem) = sink.record(&event.service, line) {
                 printer.warn(&problem);
             }
         }

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -25,6 +25,8 @@ use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
 const EXIT_SIGINT: i32 = 130;
 /// Exit code used when the supervisor itself was terminated (`128 + SIGTERM`).
 const EXIT_SIGTERM: i32 = 143;
+/// Exit code used when the controlling terminal went away (`128 + SIGHUP`).
+const EXIT_SIGHUP: i32 = 129;
 
 /// Command-line options for `up`.
 #[derive(Debug, Clone, Copy, Default)]
@@ -134,6 +136,7 @@ pub fn run(
     Ok(match outcome.shutdown {
         Some(ShutdownReason::UserInterrupt) => EXIT_SIGINT,
         Some(ShutdownReason::Terminated) => EXIT_SIGTERM,
+        Some(ShutdownReason::HangUp) => EXIT_SIGHUP,
         Some(_) => 1,
         None => 0,
     })

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -21,6 +21,7 @@ use servicrab_core::{
     SignalWatcher, Stream,
 };
 
+use crate::output::{self, CliError};
 use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
 
 /// Exit code used when a run is cut short by Ctrl+C (`128 + SIGINT`).
@@ -70,36 +71,38 @@ pub fn run(
     selection: Selection<'_>,
     config: Option<&Path>,
     options: UpOptions,
-) -> Result<i32, String> {
-    let path = resolve_config_path(config).map_err(|e| format!("could not find config: {e}"))?;
+) -> Result<i32, CliError> {
+    let path = resolve_config_path(config)
+        .map_err(|e| CliError::from(format!("could not find config: {e}")).in_json(options.json))?;
 
     let (cfg, warnings) = load(&path).map_err(|errors| {
-        let msgs: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
-        format!(
-            "✗ {} has {} error(s):\n{}",
-            path.display(),
-            errors.len(),
-            msgs.join("\n")
+        CliError::new(
+            servicrab_protocol::ErrorCode::ValidationFailed,
+            format!("{} has {} error(s)", path.display(), errors.len()),
         )
+        .with_errors(errors.iter().map(ToString::to_string).collect())
+        .in_json(options.json)
     })?;
 
     for warning in &warnings {
         eprintln!("⚠  {warning}");
     }
 
-    let plan = plan_stack(&cfg, selection).map_err(|e| e.to_string())?;
+    let plan = plan_stack(&cfg, selection)
+        .map_err(|e| CliError::from(e.to_string()).in_json(options.json))?;
 
     let watched = watched_services(&cfg, &plan);
     if options.require_watch && watched.is_empty() {
         let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();
-        return Err(format!(
+        return Err(CliError::from(format!(
             "nothing to watch: none of {} declares a [watch] block.\n\
              Add one, for example:\n\n\
              \x20 [services.{}.watch]\n\
              \x20 paths = [\"src\"]",
             names.join(", "),
             names.first().copied().unwrap_or("api"),
-        ));
+        ))
+        .in_json(options.json));
     }
 
     let printer = Arc::new(Printer::new(&plan, options));
@@ -117,7 +120,7 @@ pub fn run(
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .map_err(|e| format!("failed to start the async runtime: {e}"))?;
+        .map_err(|e| CliError::from(format!("failed to start the async runtime: {e}")))?;
 
     let outcome = runtime.block_on({
         let printer = Arc::clone(&printer);
@@ -157,7 +160,7 @@ pub fn run(
         }
     });
 
-    let (outcome, drawn) = outcome.map_err(|e| e.to_string())?;
+    let (outcome, drawn) = outcome.map_err(|e| CliError::from(e.to_string()))?;
     if drawn {
         printer.summary(&outcome);
     }
@@ -242,6 +245,10 @@ impl Printer {
 
     fn banner(&self, config: &Config, plan: &[ServiceName]) {
         if self.options.json {
+            // The stream's own opening line, in place of the human banner:
+            // `events --json` and a raw `subscribe` both start this way, so a
+            // reader can treat all three identically.
+            output::print_stream_header();
             return;
         }
         let names: Vec<&str> = plan.iter().map(|n| n.as_str()).collect();

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -9,6 +9,8 @@
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
 
 use servicrab_core::runtime::stack::{
     control_channel, ServiceResult, StackOptions, StackSupervisor,
@@ -27,6 +29,22 @@ const EXIT_SIGINT: i32 = 130;
 const EXIT_SIGTERM: i32 = 143;
 /// Exit code used when the controlling terminal went away (`128 + SIGHUP`).
 const EXIT_SIGHUP: i32 = 129;
+
+/// How long the shutdown waits for the renderer to draw what is still queued.
+///
+/// Writing to the operator's stdout and stderr blocks while the other end is
+/// not keeping up, and while the stack is running that is exactly right: a
+/// terminal read slowly should slow the drawing down, not lose lines.  Once the
+/// stack has stopped, though, the only thing left to do is draw — and if
+/// nothing is reading at all, the write never returns.  Waiting for the
+/// renderer then means never exiting: the services are already stopped, the
+/// exit code is already decided, and the operator's Ctrl+C has to be worth
+/// something anyway.
+///
+/// Overrunning this costs the tail of the terminal output.  It does not cost
+/// the log files: lines reach `LogSink` before they are drawn, and its writer
+/// is a separate task that flushes whenever it catches up.
+const RENDER_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Command-line options for `up`.
 #[derive(Debug, Clone, Copy, Default)]
@@ -84,7 +102,7 @@ pub fn run(
         ));
     }
 
-    let printer = Printer::new(&plan, options);
+    let printer = Arc::new(Printer::new(&plan, options));
     printer.banner(&cfg, &plan);
     printer.watching(&watched);
 
@@ -101,34 +119,55 @@ pub fn run(
         .build()
         .map_err(|e| format!("failed to start the async runtime: {e}"))?;
 
-    let outcome = runtime.block_on(async move {
-        let signals = SignalWatcher::install(cfg.project.name.as_str())?;
-        let mut shutdown = signals.subscribe();
+    let outcome = runtime.block_on({
+        let printer = Arc::clone(&printer);
+        async move {
+            let signals = SignalWatcher::install(cfg.project.name.as_str())?;
+            let mut shutdown = signals.subscribe();
 
-        let (events_tx, events_rx) = event_channel();
-        let renderer = tokio::spawn(render(events_rx, printer, logs));
+            let (events_tx, events_rx) = event_channel();
+            let renderer = tokio::spawn(render(events_rx, printer, logs));
 
-        let (control_tx, control_rx) = control_channel();
-        let watchers = spawn_watchers(&cfg, &plan, &control_tx, &events_tx);
-        drop(control_tx);
+            let (control_tx, control_rx) = control_channel();
+            let watchers = spawn_watchers(&cfg, &plan, &control_tx, &events_tx);
+            drop(control_tx);
 
-        let supervisor =
-            StackSupervisor::new(&cfg, plan, stack_options, events_tx).with_control(control_rx);
-        let outcome = supervisor.run(&mut shutdown).await;
+            let supervisor =
+                StackSupervisor::new(&cfg, plan, stack_options, events_tx).with_control(control_rx);
+            let outcome = supervisor.run(&mut shutdown).await;
 
-        for watcher in watchers {
-            watcher.abort();
+            for watcher in watchers {
+                watcher.abort();
+            }
+
+            // The supervisor owned the last sender, so the renderer stops as
+            // soon as it has drained the queue — unless the far end of stdout or
+            // stderr has stopped reading, in which case it is parked in a write
+            // that will never return.  The stack is already stopped by now, so
+            // the wait for the drawing to finish is bounded and the exit does
+            // not depend on anyone consuming the output.
+            let drawn = tokio::time::timeout(RENDER_DRAIN_TIMEOUT, renderer).await;
+            if let Ok(joined) = &drawn {
+                // A renderer that panicked is a bug worth surfacing; one that
+                // could not finish drawing is not.
+                assert!(joined.is_ok(), "renderer task");
+            }
+
+            Ok::<_, servicrab_core::RuntimeError>((outcome, drawn.is_ok()))
         }
-
-        // The supervisor owned the last sender, so the renderer stops as soon
-        // as it has drained the queue.
-        let printer = renderer.await.expect("renderer task");
-        printer.summary(&outcome);
-
-        Ok::<_, servicrab_core::RuntimeError>(outcome)
     });
 
-    let outcome = outcome.map_err(|e| e.to_string())?;
+    let (outcome, drawn) = outcome.map_err(|e| e.to_string())?;
+    if drawn {
+        printer.summary(&outcome);
+    }
+    // A renderer still parked in a write cannot be joined — a blocking write is
+    // not an await point, so the task can be neither aborted nor waited out —
+    // and dropping the runtime would wait for that thread.  Nothing is left to
+    // schedule that anybody is reading, so let the process exit collect it.
+    if !drawn {
+        runtime.shutdown_background();
+    }
 
     if !outcome.is_success() {
         return Ok(1);
@@ -148,7 +187,12 @@ pub fn run(
 /// The file work happens on a blocking task behind [`LogSink`], so a slow disk
 /// delays the log rather than the async worker that is also driving child
 /// `wait()`s, health probes and the control channel.
-async fn render(mut events: EventReceiver, printer: Printer, logs: Option<LogRouter>) -> Printer {
+///
+/// Drawing itself is synchronous and *does* block when the operator's terminal
+/// is not keeping up, which is the right back-pressure while services are
+/// running.  It is the caller's job to make sure the shutdown does not depend on
+/// this task finishing; see the drain timeout in [`run`].
+async fn render(mut events: EventReceiver, printer: Arc<Printer>, logs: Option<LogRouter>) {
     let sink = logs.map(LogSink::spawn);
 
     while let Some(event) = events.recv().await {
@@ -161,13 +205,14 @@ async fn render(mut events: EventReceiver, printer: Printer, logs: Option<LogRou
     }
 
     // The stack has stopped; wait for the queued lines to reach the disk before
-    // the process goes away, so a graceful stop never loses output.
+    // the process goes away, so a graceful stop never loses output.  This comes
+    // first because it is the durable half: the terminal is best-effort, the log
+    // file is not.
     if let Some(sink) = sink {
         if let Some(problem) = sink.shutdown().await {
             printer.warn(&problem);
         }
     }
-    printer
 }
 
 /// Renders runtime events for a terminal.

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -15,8 +15,8 @@ use servicrab_core::runtime::stack::{
 };
 use servicrab_core::{
     event_channel, load, plan_stack, resolve_config_path, spawn_watchers, watched_services, Config,
-    EventKind, EventReceiver, LogRouter, Selection, ServiceName, ShutdownReason, SignalWatcher,
-    Stream,
+    EventKind, EventReceiver, LogRouter, LogSink, Selection, ServiceName, ShutdownReason,
+    SignalWatcher, Stream,
 };
 
 use crate::style::{self, BOLD, DIM, RESET, SERVICE_COLORS};
@@ -144,18 +144,28 @@ pub fn run(
 
 /// Drain the event stream, rendering everything as it arrives and copying
 /// captured output to the log files when file logging is enabled.
-async fn render(
-    mut events: EventReceiver,
-    printer: Printer,
-    mut logs: Option<LogRouter>,
-) -> Printer {
+///
+/// The file work happens on a blocking task behind [`LogSink`], so a slow disk
+/// delays the log rather than the async worker that is also driving child
+/// `wait()`s, health probes and the control channel.
+async fn render(mut events: EventReceiver, printer: Printer, logs: Option<LogRouter>) -> Printer {
+    let sink = logs.map(LogSink::spawn);
+
     while let Some(event) = events.recv().await {
-        if let (Some(router), EventKind::Log { line, .. }) = (logs.as_mut(), &event.kind) {
-            if let Some(problem) = router.record(&event.service, line) {
+        if let (Some(sink), EventKind::Log { line, .. }) = (sink.as_ref(), &event.kind) {
+            if let Some(problem) = sink.record(&event.service, line).await {
                 printer.warn(&problem);
             }
         }
         printer.event(&event.service, &event.kind);
+    }
+
+    // The stack has stopped; wait for the queued lines to reach the disk before
+    // the process goes away, so a graceful stop never loses output.
+    if let Some(sink) = sink {
+        if let Some(problem) = sink.shutdown().await {
+            printer.warn(&problem);
+        }
     }
     printer
 }

--- a/crates/servicrab-cli/src/commands/up.rs
+++ b/crates/servicrab-cli/src/commands/up.rs
@@ -219,13 +219,19 @@ async fn render(mut events: EventReceiver, printer: Arc<Printer>, logs: Option<L
 struct Printer {
     colors: BTreeMap<ServiceName, &'static str>,
     width: usize,
-    color: bool,
+    /// Whether the stdout half of the output is coloured.  Both halves are
+    /// asked separately, because a stack whose stdout is redirected into a file
+    /// still has a terminal on stderr to draw progress on.
+    color_out: bool,
+    /// Whether the stderr half of the output is coloured.
+    color_err: bool,
     options: UpOptions,
 }
 
 impl Printer {
     fn new(plan: &[ServiceName], options: UpOptions) -> Self {
-        let color = style::color_enabled();
+        let color_out = style::color_enabled_for(style::Stream::Stdout);
+        let color_err = style::color_enabled_for(style::Stream::Stderr);
         let width = plan.iter().map(|n| n.as_str().len()).max().unwrap_or(0);
         let colors = plan
             .iter()
@@ -235,7 +241,8 @@ impl Printer {
         Self {
             colors,
             width,
-            color,
+            color_out,
+            color_err,
             options,
         }
     }
@@ -252,7 +259,7 @@ impl Printer {
         };
         eprintln!(
             "{} {} → {}",
-            style::paint(self.color, BOLD, command),
+            style::paint(self.color_err, BOLD, command),
             config.project.name,
             names.join(", ")
         );
@@ -266,7 +273,7 @@ impl Printer {
         eprintln!(
             "{}",
             style::paint(
-                self.color,
+                self.color_err,
                 DIM,
                 &format!("watching for changes: {}", names.join(", "))
             )
@@ -274,21 +281,21 @@ impl Printer {
     }
 
     /// `api    | ` (or an empty string when prefixes are disabled).
-    fn prefix(&self, service: &ServiceName) -> String {
+    fn prefix(&self, service: &ServiceName, color: bool) -> String {
         if self.options.no_prefix {
             return String::new();
         }
-        let color = self.colors.get(service).copied().unwrap_or(RESET);
+        let tint = self.colors.get(service).copied().unwrap_or(RESET);
         let label = format!("{:width$}", service.as_str(), width = self.width);
-        format!("{} {} ", style::paint(self.color, color, &label), "|")
+        format!("{} {} ", style::paint(color, tint, &label), "|")
     }
 
-    fn timestamp(&self) -> String {
+    fn timestamp(&self, color: bool) -> String {
         if !self.options.timestamps {
             return String::new();
         }
         let now = style::utc_hms(std::time::SystemTime::now());
-        format!("{} ", style::paint(self.color, DIM, &now))
+        format!("{} ", style::paint(color, DIM, &now))
     }
 
     fn event(&self, service: &ServiceName, kind: &EventKind) {
@@ -380,14 +387,25 @@ impl Printer {
     }
 
     fn log(&self, service: &ServiceName, stream: Stream, line: &str) {
-        let text = format!("{}{}{}", self.timestamp(), self.prefix(service), line);
         match stream {
             Stream::Stdout => {
+                let text = format!(
+                    "{}{}{}",
+                    self.timestamp(self.color_out),
+                    self.prefix(service, self.color_out),
+                    line
+                );
                 let mut out = std::io::stdout().lock();
                 let _ = writeln!(out, "{text}");
                 let _ = out.flush();
             }
             Stream::Stderr => {
+                let text = format!(
+                    "{}{}{}",
+                    self.timestamp(self.color_err),
+                    self.prefix(service, self.color_err),
+                    line
+                );
                 let mut err = std::io::stderr().lock();
                 let _ = writeln!(err, "{text}");
                 let _ = err.flush();
@@ -400,9 +418,9 @@ impl Printer {
         let _ = writeln!(
             err,
             "{}{}{}",
-            self.timestamp(),
-            self.prefix(service),
-            style::paint(self.color, DIM, &format!("{symbol} {message}"))
+            self.timestamp(self.color_err),
+            self.prefix(service, self.color_err),
+            style::paint(self.color_err, DIM, &format!("{symbol} {message}"))
         );
         let _ = err.flush();
     }
@@ -421,7 +439,7 @@ impl Printer {
         if outcome.is_success() {
             eprintln!(
                 "{}",
-                style::paint(self.color, DIM, "all services stopped cleanly")
+                style::paint(self.color_err, DIM, "all services stopped cleanly")
             );
             return;
         }
@@ -481,7 +499,7 @@ mod tests {
     fn prefixes_are_padded_to_the_longest_name() {
         let plan = vec![service("api"), service("database")];
         let printer = Printer::new(&plan, UpOptions::default());
-        let prefix = printer.prefix(&plan[0]);
+        let prefix = printer.prefix(&plan[0], false);
         assert!(
             prefix.starts_with("api     "),
             "unexpected prefix {prefix:?}"
@@ -499,14 +517,22 @@ mod tests {
                 ..UpOptions::default()
             },
         );
-        assert_eq!(printer.prefix(&plan[0]), "");
+        assert_eq!(printer.prefix(&plan[0], false), "");
+    }
+
+    #[test]
+    fn a_prefix_is_only_coloured_for_the_stream_that_allows_it() {
+        let plan = vec![service("api")];
+        let printer = Printer::new(&plan, UpOptions::default());
+        assert!(printer.prefix(&plan[0], true).contains("\x1b["));
+        assert!(!printer.prefix(&plan[0], false).contains("\x1b["));
     }
 
     #[test]
     fn timestamps_are_only_added_when_requested() {
         let plan = vec![service("api")];
         let plain = Printer::new(&plan, UpOptions::default());
-        assert_eq!(plain.timestamp(), "");
+        assert_eq!(plain.timestamp(false), "");
 
         let stamped = Printer::new(
             &plan,
@@ -515,7 +541,7 @@ mod tests {
                 ..UpOptions::default()
             },
         );
-        let stamp = stamped.timestamp();
+        let stamp = stamped.timestamp(false);
         assert_eq!(stamp.trim().len(), 8, "expected HH:MM:SS, got {stamp:?}");
     }
 }

--- a/crates/servicrab-cli/src/daemon/client.rs
+++ b/crates/servicrab-cli/src/daemon/client.rs
@@ -92,7 +92,7 @@ where
     }
     match decode::<Response>(&first) {
         Ok(Response::Ok { .. }) => {}
-        Ok(Response::Error { message }) => return Err(ClientError::Failed(message)),
+        Ok(Response::Error { message, .. }) => return Err(ClientError::Failed(message)),
         Ok(other) => {
             return Err(ClientError::Failed(format!(
                 "unexpected response from the daemon: {other:?}"
@@ -152,7 +152,7 @@ pub fn is_running(socket: &Path) -> bool {
 pub fn check_running(socket: &Path) -> Result<(), ClientError> {
     match send(socket, &Request::Ping) {
         Ok(Response::Pong { .. }) => Ok(()),
-        Ok(Response::Error { message }) => Err(ClientError::Failed(message)),
+        Ok(Response::Error { message, .. }) => Err(ClientError::Failed(message)),
         Ok(other) => Err(ClientError::Failed(format!(
             "unexpected response from the daemon: {other:?}"
         ))),
@@ -186,9 +186,10 @@ mod tests {
             let Ok((mut stream, _)) = listener.accept() else {
                 return;
             };
-            let line = encode(&Response::Error {
-                message: message.to_string(),
-            })
+            let line = encode(&Response::error(
+                servicrab_protocol::ErrorCode::Failed,
+                message,
+            ))
             .expect("encode");
             let _ = stream.write_all(line.as_bytes());
             let _ = stream.flush();
@@ -228,9 +229,10 @@ mod tests {
             let Ok((mut stream, _)) = listener.accept() else {
                 return;
             };
-            let line = encode(&Response::Error {
-                message: "this daemon runs as uid 501; you are uid 0".to_string(),
-            })
+            let line = encode(&Response::error(
+                servicrab_protocol::ErrorCode::Failed,
+                "this daemon runs as uid 501; you are uid 0",
+            ))
             .expect("encode");
             let _ = stream.write_all(line.as_bytes());
             let _ = stream.flush();

--- a/crates/servicrab-cli/src/daemon/client.rs
+++ b/crates/servicrab-cli/src/daemon/client.rs
@@ -40,16 +40,19 @@ pub fn send(socket: &Path, request: &Request) -> Result<Response, ClientError> {
     let _ = stream.set_write_timeout(Some(TIMEOUT));
 
     let line = encode(request).map_err(|e| ClientError::Failed(e.to_string()))?;
-    stream
+    // A daemon that refuses us answers and closes without reading, so our write
+    // can fail with EPIPE while the reason is already waiting in the socket.
+    // Reading first and only reporting the write error if nothing came back
+    // keeps that reason instead of replacing it with "broken pipe".
+    let sent = stream
         .write_all(line.as_bytes())
-        .and_then(|()| stream.flush())
-        .map_err(|e| ClientError::Failed(format!("could not send the request: {e}")))?;
+        .and_then(|()| stream.flush());
 
     let mut reply = String::new();
-    BufReader::new(&stream)
-        .read_line(&mut reply)
-        .map_err(|e| ClientError::Failed(format!("could not read the response: {e}")))?;
+    let read = BufReader::new(&stream).read_line(&mut reply);
     if reply.trim().is_empty() {
+        sent.map_err(|e| ClientError::Failed(format!("could not send the request: {e}")))?;
+        read.map_err(|e| ClientError::Failed(format!("could not read the response: {e}")))?;
         return Err(ClientError::Failed(
             "the daemon closed the connection without answering".to_string(),
         ));
@@ -70,16 +73,23 @@ where
     let _ = stream.set_write_timeout(Some(TIMEOUT));
 
     let line = encode(request).map_err(|e| ClientError::Failed(e.to_string()))?;
-    stream
+    // Same reasoning as in `send`: a refusal is written and the connection
+    // closed without reading, so the write can fail with the answer already in
+    // flight.
+    let sent = stream
         .write_all(line.as_bytes())
-        .and_then(|()| stream.flush())
-        .map_err(|e| ClientError::Failed(format!("could not send the request: {e}")))?;
+        .and_then(|()| stream.flush());
 
     let mut reader = BufReader::new(&stream);
     let mut first = String::new();
-    reader
-        .read_line(&mut first)
-        .map_err(|e| ClientError::Failed(format!("could not read the response: {e}")))?;
+    let read = reader.read_line(&mut first);
+    if first.trim().is_empty() {
+        sent.map_err(|e| ClientError::Failed(format!("could not send the request: {e}")))?;
+        read.map_err(|e| ClientError::Failed(format!("could not read the response: {e}")))?;
+        return Err(ClientError::Failed(
+            "the daemon closed the connection without answering".to_string(),
+        ));
+    }
     match decode::<Response>(&first) {
         Ok(Response::Ok { .. }) => {}
         Ok(Response::Error { message }) => return Err(ClientError::Failed(message)),
@@ -129,6 +139,27 @@ pub fn is_running(socket: &Path) -> bool {
     matches!(send(socket, &Request::Ping), Ok(Response::Pong { .. }))
 }
 
+/// Ask whether a daemon is there, keeping the reason when it will not talk to
+/// us.
+///
+/// [`is_running`] answers yes or no, which is all most callers want — but a
+/// daemon that refuses the connection because it belongs to another user is
+/// neither. Reported as "no daemon is running" it sends the operator looking for
+/// a daemon that is in fact right there, so the refusal has to survive the trip.
+///
+/// A `ping` can only be answered with an error for a reason the operator needs
+/// to hear, so every error is passed on as it stands.
+pub fn check_running(socket: &Path) -> Result<(), ClientError> {
+    match send(socket, &Request::Ping) {
+        Ok(Response::Pong { .. }) => Ok(()),
+        Ok(Response::Error { message }) => Err(ClientError::Failed(message)),
+        Ok(other) => Err(ClientError::Failed(format!(
+            "unexpected response from the daemon: {other:?}"
+        ))),
+        Err(err) => Err(err),
+    }
+}
+
 /// Poll until the daemon stops answering, or `timeout` elapses.
 pub fn wait_until_stopped(socket: &Path, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
@@ -139,4 +170,98 @@ pub fn wait_until_stopped(socket: &Path, timeout: Duration) -> bool {
         std::thread::sleep(Duration::from_millis(50));
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stand in for a daemon that refuses a peer: one error line, then close.
+    fn a_refusing_daemon(message: &'static str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let socket = dir.path().join("daemon.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket).expect("bind");
+
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let line = encode(&Response::Error {
+                message: message.to_string(),
+            })
+            .expect("encode");
+            let _ = stream.write_all(line.as_bytes());
+            let _ = stream.flush();
+        });
+
+        (dir, socket)
+    }
+
+    /// The whole point of the refusal is that the operator reads it, so it has
+    /// to survive the trip through the client.  This is the half of the peer
+    /// check a single-uid test suite can prove: the daemon's own decision needs
+    /// two users, but "the message is not swallowed" does not.
+    #[test]
+    fn a_refusal_reaches_the_caller() {
+        let (_dir, socket) = a_refusing_daemon("this daemon runs as uid 501; you are uid 0");
+
+        let why = check_running(&socket).expect_err("a refusing daemon is not a running one");
+
+        // Not `NotRunning`: there *is* a daemon, and saying otherwise would
+        // send the operator looking for one to start.
+        assert!(matches!(why, ClientError::Failed(_)), "{why:?}");
+        assert!(why.to_string().contains("uid 501"), "{why}");
+        assert!(why.to_string().contains("uid 0"), "{why}");
+    }
+
+    /// A daemon that refuses us answers and closes without reading, so our own
+    /// write can fail with `EPIPE` while the reason is already in the socket.
+    /// Reporting the write error would replace an actionable message with
+    /// "broken pipe".
+    #[test]
+    fn a_refusal_survives_a_broken_pipe_on_the_way_out() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let socket = dir.path().join("daemon.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket).expect("bind");
+
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let line = encode(&Response::Error {
+                message: "this daemon runs as uid 501; you are uid 0".to_string(),
+            })
+            .expect("encode");
+            let _ = stream.write_all(line.as_bytes());
+            let _ = stream.flush();
+            // Closed without ever reading, which is what makes our write fail.
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+        });
+
+        let why = check_running(&socket).expect_err("a refusing daemon");
+
+        assert!(why.to_string().contains("uid 501"), "{why}");
+        // Not the write error: "broken pipe" is true and useless.
+        assert!(!why.to_string().contains("Broken pipe"), "{why}");
+    }
+
+    /// A refused connection is not the same as an absent daemon, but
+    /// [`is_running`] has only two answers and "no" is the safe one for the
+    /// callers that just want to know whether to keep going.
+    #[test]
+    fn a_refusing_daemon_does_not_count_as_running() {
+        let (_dir, socket) = a_refusing_daemon("refused");
+
+        assert!(!is_running(&socket));
+    }
+
+    #[test]
+    fn an_absent_socket_is_simply_not_running() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+
+        let why =
+            check_running(&dir.path().join("absent.sock")).expect_err("nothing is listening there");
+
+        assert!(matches!(why, ClientError::NotRunning), "{why:?}");
+    }
 }

--- a/crates/servicrab-cli/src/daemon/client.rs
+++ b/crates/servicrab-cli/src/daemon/client.rs
@@ -116,6 +116,15 @@ where
         if line.trim().is_empty() {
             continue;
         }
+        // A line this build cannot name is the thing this loop must not die on:
+        // an event stream is read until the daemon goes away, so one new event
+        // kind from a newer daemon would otherwise end the whole stream with an
+        // error and a non-zero exit, mid-run.  It decodes to a fallback variant
+        // instead, and the raw line reaches the callback either way — so
+        // `--json` passes it through untouched and a consumer that knows more
+        // than this build does loses nothing.  An error here is left fatal
+        // because it is no longer version skew but a daemon writing something
+        // that is not JSON at all.
         let response = decode::<Response>(&line).map_err(|e| ClientError::Failed(e.to_string()))?;
         if !on_event(line.trim_end(), response) {
             return Ok(());
@@ -136,7 +145,7 @@ fn connect(socket: &Path) -> Result<UnixStream, ClientError> {
 
 /// Whether a daemon is listening and answering.
 pub fn is_running(socket: &Path) -> bool {
-    matches!(send(socket, &Request::Ping), Ok(Response::Pong { .. }))
+    matches!(send(socket, &Request::ping()), Ok(Response::Pong { .. }))
 }
 
 /// Ask whether a daemon is there, keeping the reason when it will not talk to
@@ -150,7 +159,7 @@ pub fn is_running(socket: &Path) -> bool {
 /// A `ping` can only be answered with an error for a reason the operator needs
 /// to hear, so every error is passed on as it stands.
 pub fn check_running(socket: &Path) -> Result<(), ClientError> {
-    match send(socket, &Request::Ping) {
+    match send(socket, &Request::ping()) {
         Ok(Response::Pong { .. }) => Ok(()),
         Ok(Response::Error { message }) => Err(ClientError::Failed(message)),
         Ok(other) => Err(ClientError::Failed(format!(

--- a/crates/servicrab-cli/src/daemon/client.rs
+++ b/crates/servicrab-cli/src/daemon/client.rs
@@ -129,18 +129,6 @@ pub fn is_running(socket: &Path) -> bool {
     matches!(send(socket, &Request::Ping), Ok(Response::Pong { .. }))
 }
 
-/// Poll until the daemon answers, or `timeout` elapses.
-pub fn wait_until_running(socket: &Path, timeout: Duration) -> bool {
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if is_running(socket) {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    false
-}
-
 /// Poll until the daemon stops answering, or `timeout` elapses.
 pub fn wait_until_stopped(socket: &Path, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;

--- a/crates/servicrab-cli/src/daemon/lock.rs
+++ b/crates/servicrab-cli/src/daemon/lock.rs
@@ -1,0 +1,185 @@
+//! One daemon per project, enforced by the pidfile.
+//!
+//! Checking whether the socket answers and then binding it is a
+//! time-of-check/time-of-use race: two `servicrab start` invocations can both
+//! find no daemon, both unlink the socket — the second one unlinking a *live*
+//! socket, leaving its owner listening on an unreachable inode — and both
+//! supervise the same stack.  Duplicate processes and duplicate port binds
+//! follow.
+//!
+//! An advisory `flock` on the pidfile closes the window: the kernel hands it to
+//! exactly one process, the daemon holds it for its entire life, and it is
+//! released by the kernel however the daemon dies — including `SIGKILL`, where
+//! no cleanup code of ours would run.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+
+use nix::errno::Errno;
+use nix::fcntl::{Flock, FlockArg};
+
+/// How many times to retry when the pidfile is replaced while we are opening
+/// it.
+///
+/// The exiting daemon unlinks the pidfile it holds, so a start that opened the
+/// old inode a moment earlier would take a lock nobody else can see.  Checking
+/// the inode and retrying is bounded work: each round needs another daemon to
+/// exit at exactly the wrong moment.
+const ATTEMPTS: usize = 8;
+
+/// Why the project lock could not be taken.
+#[derive(Debug)]
+pub enum LockError {
+    /// Another daemon holds it, which is the whole point.
+    Held,
+    /// The lock could not be evaluated at all.
+    Failed(String),
+}
+
+/// An exclusive claim on one project, released when this value is dropped or
+/// the process dies.
+#[derive(Debug)]
+pub struct ProjectLock {
+    /// Held only for its `Drop`: it unlocks and closes the pidfile.  The
+    /// underscore says the value is never read, only kept alive.
+    _file: Flock<File>,
+    path: PathBuf,
+}
+
+impl ProjectLock {
+    /// Take the lock and record our pid in the file.
+    ///
+    /// The pid is written for humans and for `ps`; nothing in servicrab reads
+    /// it, because the lock — not its contents — is what says a daemon is
+    /// alive.
+    pub fn acquire(path: &Path) -> Result<Self, LockError> {
+        for _ in 0..ATTEMPTS {
+            let file = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                // Not truncated on open: we may be looking at a pidfile another
+                // daemon still holds, and emptying it before losing the race
+                // would erase a live pid.  `write_pid` truncates once the lock
+                // is ours.
+                .truncate(false)
+                // The pid is not a secret, but the lock is authority: only the
+                // owner may write the file that grants it.
+                .mode(0o600)
+                .open(path)
+                .map_err(|e| {
+                    LockError::Failed(format!("could not open {}: {e}", path.display()))
+                })?;
+
+            let mut file = match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+                Ok(locked) => locked,
+                Err((_, Errno::EWOULDBLOCK)) => return Err(LockError::Held),
+                Err((_, errno)) => {
+                    return Err(LockError::Failed(format!(
+                        "could not lock {}: {errno}",
+                        path.display()
+                    )))
+                }
+            };
+
+            // A lock on an unlinked inode excludes nobody: whoever creates the
+            // next pidfile would lock that one and run beside us.
+            if !still_at(&file, path) {
+                continue;
+            }
+
+            write_pid(&mut file).map_err(|e| {
+                LockError::Failed(format!("could not write {}: {e}", path.display()))
+            })?;
+
+            return Ok(Self {
+                _file: file,
+                path: path.to_path_buf(),
+            });
+        }
+
+        Err(LockError::Failed(format!(
+            "{} kept being replaced while taking the daemon lock",
+            path.display()
+        )))
+    }
+}
+
+impl Drop for ProjectLock {
+    fn drop(&mut self) {
+        // Unlinking before the lock is released keeps the next start from
+        // locking a file we are about to remove.  Our own `drop` body runs
+        // before the field that holds the lock is dropped.
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Whether the locked file is still the one living at `path`.
+fn still_at(file: &File, path: &Path) -> bool {
+    let Ok(locked) = file.metadata() else {
+        return false;
+    };
+    let Ok(current) = std::fs::metadata(path) else {
+        return false;
+    };
+    locked.dev() == current.dev() && locked.ino() == current.ino()
+}
+
+fn write_pid(file: &mut File) -> std::io::Result<()> {
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    file.write_all(format!("{}\n", std::process::id()).as_bytes())?;
+    file.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn the_lock_records_the_pid() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("daemon.pid");
+
+        let lock = ProjectLock::acquire(&path).expect("lock");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            format!("{}\n", std::process::id())
+        );
+
+        drop(lock);
+        assert!(!path.exists(), "the pidfile outlived the lock");
+    }
+
+    #[test]
+    fn the_pidfile_is_not_group_readable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("daemon.pid");
+        let _lock = ProjectLock::acquire(&path).expect("lock");
+
+        let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "pidfile mode is {mode:o}");
+    }
+
+    /// Two locks in one process is the weaker half of the guarantee — `flock`
+    /// is per open file description, so this exercises the same code path a
+    /// second daemon process takes.  The cross-process half is in
+    /// `tests/daemon.rs`.
+    #[test]
+    fn a_second_lock_on_the_same_path_is_refused() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("daemon.pid");
+
+        let first = ProjectLock::acquire(&path).expect("lock");
+        assert!(matches!(ProjectLock::acquire(&path), Err(LockError::Held)));
+
+        drop(first);
+        // And the claim is only as long-lived as its holder.
+        ProjectLock::acquire(&path).expect("lock after release");
+    }
+}

--- a/crates/servicrab-cli/src/daemon/mod.rs
+++ b/crates/servicrab-cli/src/daemon/mod.rs
@@ -12,6 +12,8 @@ pub mod client;
 #[cfg(unix)]
 pub mod lock;
 #[cfg(unix)]
+pub mod peer;
+#[cfg(unix)]
 pub mod server;
 
 pub use paths::DaemonPaths;

--- a/crates/servicrab-cli/src/daemon/mod.rs
+++ b/crates/servicrab-cli/src/daemon/mod.rs
@@ -10,6 +10,8 @@ pub mod stopped;
 #[cfg(unix)]
 pub mod client;
 #[cfg(unix)]
+pub mod lock;
+#[cfg(unix)]
 pub mod server;
 
 pub use paths::DaemonPaths;

--- a/crates/servicrab-cli/src/daemon/mod.rs
+++ b/crates/servicrab-cli/src/daemon/mod.rs
@@ -15,5 +15,7 @@ pub mod lock;
 pub mod peer;
 #[cfg(unix)]
 pub mod server;
+#[cfg(unix)]
+pub mod signals;
 
 pub use paths::DaemonPaths;

--- a/crates/servicrab-cli/src/daemon/paths.rs
+++ b/crates/servicrab-cli/src/daemon/paths.rs
@@ -5,17 +5,36 @@
 //! runtime state with it.
 //!
 //! The socket is the exception, because it has a hard path length limit that a
-//! deeply nested project can exceed.  When that happens it moves to
-//! `$XDG_RUNTIME_DIR`, which the system creates 0700 and per-user.  It never
-//! moves to the shared temp directory: a name there is predictable to every
-//! local user, and `/tmp` being sticky means a squatted path can be neither
-//! unlinked nor bound, so the project could never start a daemon at all.
+//! deeply nested project can exceed.  When that happens it moves to the first
+//! directory that is genuinely private to this user: `$XDG_RUNTIME_DIR`, then
+//! `$TMPDIR`.  Neither is trusted on the strength of its name — both are
+//! resolved and then inspected, and only a directory this user owns with no
+//! group or other bits at all is accepted.  That is what keeps the socket out
+//! of `/tmp`, where a name is predictable to every local user and the sticky
+//! bit means a squatted path can be neither unlinked nor bound.
+//!
+//! With no private directory to move to the long path stays put and `bind`
+//! fails, saying which candidates were rejected and why.
 
 use std::path::{Path, PathBuf};
 
-/// Unix sockets have a hard path limit (108 bytes on Linux, 104 on macOS);
-/// staying well below it leaves room for the file names themselves.
-const MAX_SOCKET_PATH: usize = 90;
+/// How much of a `sockaddr_un` the kernel gives us for a path.
+///
+/// A socket path has to fit in `sun_path` *including* its terminating NUL, so
+/// the longest bindable path is one byte shorter than this — which is what
+/// `std` enforces too, rejecting anything longer before it reaches the kernel.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const SUN_PATH: usize = 108;
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+const SUN_PATH: usize = 104;
+
+/// The longest socket path `bind` will accept.
+///
+/// This is the real limit rather than a margin below it.  The check runs on the
+/// finished, canonicalised path, so there is nothing left to append and nothing
+/// for headroom to protect: every byte held back only relocates a project that
+/// would have been happy with its socket next to its config.
+const MAX_SOCKET_PATH: usize = SUN_PATH - 1;
 
 /// Runtime file locations for one project's daemon.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,25 +53,60 @@ pub struct DaemonPaths {
     pub log: PathBuf,
     /// The services an operator stopped by hand, one name per line.
     pub stopped: PathBuf,
+    /// Why the socket could not be moved somewhere shorter, when it had to stay
+    /// on a path too long to bind.
+    ///
+    /// Empty in every ordinary case.  `bind` failing with `ENAMETOOLONG` is
+    /// otherwise indistinguishable from servicrab being broken, when the real
+    /// answer is usually one line long: `$TMPDIR` is group-readable.
+    pub socket_rejections: Vec<String>,
 }
 
 impl DaemonPaths {
     /// Derive the paths for a project from its config file.
     ///
     /// The socket lives next to the config like everything else.  Only when
-    /// that path would overflow the socket length limit does it move to
-    /// `$XDG_RUNTIME_DIR`, under a name derived from the project directory.
+    /// that path would overflow the socket length limit does it move to a
+    /// private directory, under a name derived from the project directory.
     pub fn for_config(config: &Path) -> Self {
         let dir = project_dir(config).join(".servicrab");
-        let socket = dir.join("daemon.sock");
+        let (socket, socket_rejections) = choose_socket(dir.join("daemon.sock"), &dir);
 
         Self {
-            socket: relocate_if_too_long(socket, &dir),
+            socket,
+            socket_rejections,
             pid: dir.join("daemon.pid"),
             log: dir.join("daemon.log"),
             stopped: dir.join("stopped"),
             dir,
         }
+    }
+
+    /// Whether the socket sits next to the rest of the project's state.
+    ///
+    /// When it does not, the path is worth telling the user about: nothing else
+    /// would lead them to it.
+    pub fn socket_is_in_place(&self) -> bool {
+        self.socket.starts_with(&self.dir)
+    }
+
+    /// Everything we know about why the socket is where it is, as one line per
+    /// rejected candidate, for an error that would otherwise say only
+    /// `ENAMETOOLONG`.
+    pub fn socket_advice(&self) -> String {
+        if self.socket_rejections.is_empty() {
+            return String::new();
+        }
+        format!(
+            "\nthe path is {} bytes and the limit is {MAX_SOCKET_PATH}; \
+             nowhere private was available to move it to:\n{}",
+            self.socket.as_os_str().len(),
+            self.socket_rejections
+                .iter()
+                .map(|why| format!("  • {why}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
     }
 
     /// Create the state directory if it does not exist yet.
@@ -101,40 +155,123 @@ fn normalize(path: &Path) -> PathBuf {
 
 /// Move the socket out of the project when its path is too long for `bind`.
 ///
-/// `$XDG_RUNTIME_DIR` is created by the system as 0700 and per-user, so a name
-/// in it is no more reachable than one inside the project.  The shared temp
-/// directory is not an option: `$TMPDIR` puts the location under an attacker's
-/// influence, the name would be predictable to every local user, and `/tmp`
-/// being sticky means a pre-created path can be neither unlinked nor bound.
+/// Returns the path to use and, when nothing worked, one line per rejected
+/// candidate.
 ///
-/// With nowhere private to go we keep the long path.  `bind` then fails with
-/// `ENAMETOOLONG`, which names the real problem, where a fallback into a shared
-/// directory would silently trade a startup failure for a spoofable socket.
-fn relocate_if_too_long(socket: PathBuf, dir: &Path) -> PathBuf {
+/// The candidates are `$XDG_RUNTIME_DIR` and then `$TMPDIR`, and each has to
+/// earn it: [`is_private_dir`] resolves the value and then checks that this
+/// user owns it and that it has no group or other bits at all.  Plain `/tmp`
+/// fails that last check, which is the whole point — it is the shared directory
+/// the old FNV-named socket lived in, where the name is predictable to every
+/// local user and the sticky bit means a squatted path can be neither unlinked
+/// nor bound.
+///
+/// With nowhere private to go we keep the long path.  `bind` then fails, and
+/// the rejections explain what to fix, which is the difference between
+/// "servicrab is broken" and "your `$TMPDIR` is group-readable".
+fn choose_socket(socket: PathBuf, dir: &Path) -> (PathBuf, Vec<String>) {
     if socket.as_os_str().len() <= MAX_SOCKET_PATH {
-        return socket;
+        return (socket, Vec::new());
     }
-    let Some(runtime) = runtime_dir() else {
-        return socket;
-    };
 
-    let moved = runtime.join(format!("servicrab-{}.sock", project_slug(dir)));
-    if moved.as_os_str().len() <= MAX_SOCKET_PATH {
-        moved
-    } else {
-        socket
+    let name = format!("servicrab-{}.sock", project_slug(dir));
+    let mut rejections = Vec::new();
+    for (label, value) in candidates() {
+        let Some(value) = value else {
+            rejections.push(format!("{label} is not set"));
+            continue;
+        };
+        let candidate = match is_private_dir(&value) {
+            Ok(resolved) => resolved,
+            Err(why) => {
+                rejections.push(format!("{label} ({}) {why}", value.display()));
+                continue;
+            }
+        };
+
+        let moved = candidate.join(&name);
+        if moved.as_os_str().len() <= MAX_SOCKET_PATH {
+            return (moved, Vec::new());
+        }
+        rejections.push(format!(
+            "{label} ({}) is itself too long to hold a socket",
+            candidate.display()
+        ));
     }
+
+    (socket, rejections)
 }
 
-/// `$XDG_RUNTIME_DIR`, if it is set to an absolute path.
+/// Where the socket may move to, best first, each labelled the way the user
+/// would recognise it.
 ///
-/// A relative value would resolve against whatever directory the command
-/// happened to start in, so two invocations for one project could disagree
-/// about where the socket is.
-fn runtime_dir() -> Option<PathBuf> {
-    let value = std::env::var_os("XDG_RUNTIME_DIR")?;
-    let path = PathBuf::from(value);
-    (path.is_absolute() && path.is_dir()).then_some(path)
+/// `$XDG_RUNTIME_DIR` first because a system that sets it means it: it is
+/// created 0700 per-user and cleaned up at logout.  It is unset on macOS,
+/// though, which is where the length limit bites hardest, so the per-user
+/// `$TMPDIR` there is the one that makes a deeply nested project work at all.
+///
+/// [`std::env::temp_dir`] rather than `$TMPDIR` directly, so that a system
+/// without the variable still gets a named candidate and therefore a named
+/// rejection — on Linux that is `/tmp`, and hearing why it was refused is more
+/// use than hearing that a variable is unset.
+fn candidates() -> Vec<(String, Option<PathBuf>)> {
+    vec![
+        (
+            "$XDG_RUNTIME_DIR".to_string(),
+            std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from),
+        ),
+        ("the temp directory".to_string(), Some(std::env::temp_dir())),
+    ]
+}
+
+/// Judge a directory we are considering putting the socket in, returning it
+/// resolved.
+///
+/// Anyone who can create a name in the directory holding the socket can
+/// pre-create it, so "private to this user" has to be checked rather than
+/// assumed from the variable's name — both of these are attacker-settable
+/// environment variables.
+///
+/// The checks, in the order a caller would want to hear about a failure:
+///
+/// * absolute, because a relative value would resolve against whatever
+///   directory each command happened to start in, so one project would get
+///   several sockets;
+/// * a directory, after `canonicalize`, so a symlinked `$TMPDIR` cannot smuggle
+///   in a world-writable target;
+/// * owned by this uid, so nobody else can rename or replace what is in it;
+/// * `mode & 0o077 == 0` — not merely "not world-writable": read or execute for
+///   a group is enough to enumerate the sockets, and connecting is the only
+///   capability an attacker needs.
+fn is_private_dir(path: &Path) -> Result<PathBuf, String> {
+    use std::os::unix::fs::MetadataExt;
+
+    if !path.is_absolute() {
+        return Err("is not an absolute path".to_string());
+    }
+    let resolved = path
+        .canonicalize()
+        .map_err(|e| format!("cannot be resolved: {e}"))?;
+    let meta = std::fs::metadata(&resolved).map_err(|e| format!("cannot be read: {e}"))?;
+    if !meta.is_dir() {
+        return Err("is not a directory".to_string());
+    }
+
+    let us = nix::unistd::getuid().as_raw();
+    if meta.uid() != us {
+        return Err(format!(
+            "is owned by uid {} and not by you (uid {us})",
+            meta.uid()
+        ));
+    }
+    let mode = meta.mode() & 0o7777;
+    if mode & 0o077 != 0 {
+        return Err(format!(
+            "is mode {mode:04o}, which lets other users in; \
+             it must have no group or other permissions at all"
+        ));
+    }
+    Ok(resolved)
 }
 
 /// A short, stable, filesystem-safe name for the project at `dir`.
@@ -157,31 +294,89 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    /// The socket location reads `$XDG_RUNTIME_DIR`, which is process-global,
-    /// so the tests that set it must not run beside each other.
+    /// The socket location reads the environment, which is process-global, so
+    /// the tests that set it must not run beside each other.
     static ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    /// Set `$XDG_RUNTIME_DIR` for the duration of `body`.
-    fn with_runtime_dir<T>(value: Option<&Path>, body: impl FnOnce() -> T) -> T {
+    /// Set `$XDG_RUNTIME_DIR` and `$TMPDIR` for the duration of `body`.
+    ///
+    /// `$TMPDIR` too, because [`std::env::temp_dir`] reads it: leaving the real
+    /// one in place would make the second candidate whatever the machine
+    /// running the tests happens to have, and these tests are about the
+    /// predicate, not about this machine.
+    fn with_env<T>(runtime: Option<&Path>, temp: Option<&Path>, body: impl FnOnce() -> T) -> T {
         let _guard = ENV.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        let previous = std::env::var_os("XDG_RUNTIME_DIR");
-        match value {
-            // Safety: the mutex above is what keeps this off other threads.
-            Some(path) => unsafe { std::env::set_var("XDG_RUNTIME_DIR", path) },
-            None => unsafe { std::env::remove_var("XDG_RUNTIME_DIR") },
+        let previous = [
+            ("XDG_RUNTIME_DIR", std::env::var_os("XDG_RUNTIME_DIR")),
+            ("TMPDIR", std::env::var_os("TMPDIR")),
+        ];
+        // Safety: the mutex above is what keeps this off other threads.
+        for (name, value) in [("XDG_RUNTIME_DIR", runtime), ("TMPDIR", temp)] {
+            match value {
+                Some(path) => unsafe { std::env::set_var(name, path) },
+                None => unsafe { std::env::remove_var(name) },
+            }
         }
         let out = body();
-        match previous {
-            Some(old) => unsafe { std::env::set_var("XDG_RUNTIME_DIR", old) },
-            None => unsafe { std::env::remove_var("XDG_RUNTIME_DIR") },
+        for (name, value) in previous {
+            match value {
+                Some(old) => unsafe { std::env::set_var(name, old) },
+                None => unsafe { std::env::remove_var(name) },
+            }
         }
         out
+    }
+
+    /// A short, already-canonical directory to build test directories under.
+    ///
+    /// Not `TempDir::new()`, which reads `$TMPDIR` — these tests set `$TMPDIR`,
+    /// and it is process-global, so a directory created while another test held
+    /// it would land somewhere that test is about to delete.  Canonical because
+    /// the code under test canonicalises its candidates, and `/tmp` is a symlink
+    /// to `/private/tmp` on macOS.  Short because a runtime directory is
+    /// `/run/user/1000`-sized in real life, and macOS's per-user temp directory
+    /// is 56 bytes before the socket name.
+    static TEMP_ROOT: std::sync::LazyLock<PathBuf> = std::sync::LazyLock::new(|| {
+        let short = Path::new("/tmp");
+        let root = if short.is_dir() {
+            short.to_path_buf()
+        } else {
+            std::env::temp_dir()
+        };
+        root.canonicalize().unwrap_or(root)
+    });
+
+    /// A directory to put a project or a socket in.
+    fn a_dir() -> TempDir {
+        TempDir::new_in(&*TEMP_ROOT).expect("temp dir")
+    }
+
+    /// A stand-in for `$XDG_RUNTIME_DIR`: short, ours, and 0700.
+    fn a_runtime_dir() -> TempDir {
+        a_dir_with_mode(0o700)
+    }
+
+    /// A directory with exactly `mode`, to feed the predicate.
+    fn a_dir_with_mode(mode: u32) -> TempDir {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = a_dir();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(mode))
+            .expect("set the mode");
+        dir
+    }
+
+    /// Set `$XDG_RUNTIME_DIR` for the duration of `body`, with a private temp
+    /// directory behind it so it is never the reason a test passes.
+    fn with_runtime_dir<T>(value: Option<&Path>, body: impl FnOnce() -> T) -> T {
+        let private = a_dir_with_mode(0o700);
+        with_env(value, Some(private.path()), body)
     }
 
     /// A directory nested deeply enough that the socket path inside it cannot
     /// fit, returned with the config file inside it.
     fn a_project_too_deep_for_a_socket() -> (TempDir, PathBuf) {
-        let root = TempDir::new().expect("temp dir");
+        let root = a_dir();
         let deep = root
             .path()
             .join("nested".repeat(12))
@@ -192,26 +387,10 @@ mod tests {
     }
 
     /// A stand-in for `$XDG_RUNTIME_DIR` that is short enough to hold a socket.
-    ///
-    /// A real one is `/run/user/1000`; macOS's per-user temp directory, which
-    /// is what `TempDir` uses by default, is 60 bytes on its own and would
-    /// leave no room for the socket name.
-    fn a_runtime_dir() -> TempDir {
-        let short = PathBuf::from("/tmp");
-        let root = if short.is_dir() {
-            short
-        } else {
-            std::env::temp_dir()
-        };
-        TempDir::new_in(root).expect("temp dir")
-    }
-
     #[test]
     fn state_lives_next_to_the_config() {
-        let dir = TempDir::new().expect("temp dir");
+        let dir = a_dir();
         let root = dir.path().canonicalize().expect("canonicalize");
-        // Pinned: macOS temp paths are long enough that whether the socket
-        // relocates depends on `$XDG_RUNTIME_DIR`, and that is process-global.
         let runtime = a_runtime_dir();
         let paths = with_runtime_dir(Some(runtime.path()), || {
             DaemonPaths::for_config(&root.join("servicrab.toml"))
@@ -231,7 +410,7 @@ mod tests {
     /// hashed differently, giving one project two sockets.
     #[test]
     fn the_same_project_spelled_two_ways_gets_one_socket() {
-        let dir = TempDir::new().expect("temp dir");
+        let dir = a_dir();
         std::fs::create_dir_all(dir.path().join("app")).expect("create");
         let runtime = a_runtime_dir();
 
@@ -254,7 +433,7 @@ mod tests {
     /// look for it.
     #[test]
     fn a_short_project_keeps_its_socket_next_to_the_config() {
-        let dir = a_runtime_dir();
+        let dir = a_dir();
         let root = dir.path().canonicalize().expect("canonicalize");
         let runtime = a_runtime_dir();
 
@@ -263,6 +442,8 @@ mod tests {
         });
 
         assert_eq!(paths.socket, root.join(".servicrab/daemon.sock"));
+        assert!(paths.socket_is_in_place());
+        assert_eq!(paths.socket_advice(), "");
     }
 
     #[test]
@@ -292,33 +473,203 @@ mod tests {
     }
 
     /// With no private directory to move to, the long path stays put and `bind`
-    /// reports it.  The shared temp directory is never an answer: a name there
-    /// is predictable to every local user, and `/tmp` being sticky means a
-    /// squatted path can be neither unlinked nor bound.
+    /// reports it, with the rejections to explain why.  A shared directory is
+    /// never an answer: a name there is predictable to every local user, and
+    /// `/tmp` being sticky means a squatted path can be neither unlinked nor
+    /// bound.
     #[test]
-    fn without_a_runtime_dir_the_socket_stays_in_the_project() {
+    fn with_nowhere_private_to_go_the_socket_stays_in_the_project() {
+        let shared = a_dir_with_mode(0o777);
         let (_root, config) = a_project_too_deep_for_a_socket();
 
-        let paths = with_runtime_dir(None, || DaemonPaths::for_config(&config));
+        let paths = with_env(None, Some(shared.path()), || {
+            DaemonPaths::for_config(&config)
+        });
 
         assert!(paths.socket.starts_with(&paths.dir), "{paths:?}");
         assert!(
-            !paths.socket.starts_with(std::env::temp_dir()),
-            "the socket must never land in the shared temp directory"
+            !paths.socket.starts_with(shared.path()),
+            "the socket must never land in a directory other users can reach"
         );
+        // The operator has to be able to act on this, so the message names the
+        // candidate and the reason, not just the length.
+        let advice = paths.socket_advice();
+        assert!(advice.contains("$XDG_RUNTIME_DIR is not set"), "{advice}");
+        assert!(advice.contains("0777"), "{advice}");
+        assert!(advice.contains("no group or other permissions"), "{advice}");
+    }
+
+    /// The point of the predicate: the directory the vulnerable version used is
+    /// exactly the kind the new fallback refuses.
+    #[test]
+    fn the_shared_temp_directory_is_rejected() {
+        let shared = Path::new("/tmp");
+        if !shared.is_dir() {
+            return;
+        }
+        // Only meaningful where /tmp is the usual world-writable, root-owned
+        // directory; a hermetic builder may hand us a private one.
+        let meta = std::fs::metadata(shared.canonicalize().expect("resolve /tmp")).expect("stat");
+        use std::os::unix::fs::MetadataExt;
+        if meta.uid() == nix::unistd::getuid().as_raw() && meta.mode() & 0o077 == 0 {
+            return;
+        }
+
+        let why = is_private_dir(shared).expect_err("/tmp must not be accepted");
+        assert!(
+            why.contains("lets other users in") || why.contains("not by you"),
+            "{why}"
+        );
+    }
+
+    #[test]
+    fn a_private_directory_is_accepted() {
+        let dir = a_dir_with_mode(0o700);
+
+        let resolved = is_private_dir(dir.path()).expect("a 0700 directory we own");
+
+        assert_eq!(resolved, dir.path().canonicalize().expect("canonicalize"));
+    }
+
+    /// A relative value would resolve against whatever directory each command
+    /// started in, so one project would get several sockets.
+    #[test]
+    fn a_relative_candidate_is_rejected() {
+        let why = is_private_dir(Path::new("relative/run")).expect_err("relative");
+
+        assert!(why.contains("absolute"), "{why}");
+    }
+
+    #[test]
+    fn a_candidate_that_is_not_a_directory_is_rejected() {
+        let dir = a_dir_with_mode(0o700);
+        let file = dir.path().join("not-a-dir");
+        std::fs::write(&file, b"").expect("write");
+
+        let why = is_private_dir(&file).expect_err("a file");
+
+        assert!(why.contains("not a directory"), "{why}");
+    }
+
+    #[test]
+    fn a_candidate_that_does_not_exist_is_rejected() {
+        let dir = a_dir_with_mode(0o700);
+
+        let why = is_private_dir(&dir.path().join("absent")).expect_err("absent");
+
+        assert!(why.contains("cannot be resolved"), "{why}");
+    }
+
+    /// Every bit outside the owner's is a way in: group read is enough to
+    /// enumerate the sockets, and connecting is all an attacker needs.
+    #[test]
+    fn any_group_or_other_bit_is_rejected() {
+        for mode in [0o777, 0o750, 0o740, 0o701, 0o704, 0o710] {
+            let dir = a_dir_with_mode(mode);
+
+            let why = is_private_dir(dir.path())
+                .expect_err(&format!("mode {mode:04o} must not be accepted"));
+
+            assert!(why.contains("lets other users in"), "{mode:04o}: {why}");
+        }
+    }
+
+    /// A symlinked candidate is judged by its target, so pointing `$TMPDIR` at
+    /// a world-writable directory does not smuggle one past the check.
+    #[test]
+    fn a_symlink_to_a_shared_directory_is_rejected() {
+        let shared = a_dir_with_mode(0o777);
+        let home = a_dir_with_mode(0o700);
+        let link = home.path().join("link");
+        std::os::unix::fs::symlink(shared.path(), &link).expect("symlink");
+
+        let why = is_private_dir(&link).expect_err("a symlink to a shared directory");
+
+        assert!(why.contains("lets other users in"), "{why}");
+    }
+
+    /// The check has to be able to fail on ownership, not only on mode, or a
+    /// directory somebody else owns and keeps 0700 would be accepted.
+    #[test]
+    fn a_directory_owned_by_someone_else_is_rejected() {
+        // Root's home is the one directory we can rely on not being ours, and
+        // only when we are not root ourselves.
+        if nix::unistd::getuid().is_root() {
+            return;
+        }
+        let candidates = ["/var/root", "/root", "/var/db", "/usr"];
+        let Some(theirs) = candidates.iter().map(Path::new).find(|path| {
+            use std::os::unix::fs::MetadataExt;
+            std::fs::metadata(path)
+                .map(|meta| meta.uid() != nix::unistd::getuid().as_raw())
+                .unwrap_or(false)
+        }) else {
+            return;
+        };
+
+        let why = is_private_dir(theirs).expect_err("a directory we do not own");
+
+        assert!(
+            why.contains("not by you") || why.contains("lets other users in"),
+            "{why}"
+        );
+    }
+
+    /// On a system with no `$XDG_RUNTIME_DIR` but a private per-user temp
+    /// directory — macOS as shipped — a deeply nested project still gets a
+    /// socket.  Without this it had nowhere to go and its daemon would not
+    /// start at all.
+    #[test]
+    fn a_private_temp_directory_carries_the_socket_when_the_runtime_dir_is_unset() {
+        let temp = a_dir_with_mode(0o700);
+        let (_root, config) = a_project_too_deep_for_a_socket();
+
+        let paths = with_env(None, Some(temp.path()), || DaemonPaths::for_config(&config));
+
+        assert!(
+            paths
+                .socket
+                .starts_with(temp.path().canonicalize().expect("canonicalize")),
+            "{} is not in the temp directory",
+            paths.socket.display()
+        );
+        assert!(paths.socket_rejections.is_empty(), "{paths:?}");
+        assert!(!paths.socket_is_in_place());
+        // Only the socket moves.
+        assert!(paths.pid.starts_with(&paths.dir));
+        assert!(paths.log.starts_with(&paths.dir));
+        assert!(paths.stopped.starts_with(&paths.dir));
+    }
+
+    /// `$XDG_RUNTIME_DIR` is tried first, so a system that provides one keeps
+    /// its socket there even though the temp directory would also do.
+    #[test]
+    fn the_runtime_dir_is_preferred_over_the_temp_directory() {
+        let runtime = a_runtime_dir();
+        let temp = a_dir_with_mode(0o700);
+        let (_root, config) = a_project_too_deep_for_a_socket();
+
+        let paths = with_env(Some(runtime.path()), Some(temp.path()), || {
+            DaemonPaths::for_config(&config)
+        });
+
+        assert!(paths.socket.starts_with(runtime.path()), "{paths:?}");
     }
 
     /// A relative `$XDG_RUNTIME_DIR` would resolve against whatever directory
     /// each command started in, so one project would get several sockets.
     #[test]
     fn a_relative_runtime_dir_is_ignored() {
+        let temp = a_dir_with_mode(0o700);
         let (_root, config) = a_project_too_deep_for_a_socket();
 
-        let paths = with_runtime_dir(Some(Path::new("relative/run")), || {
+        let paths = with_env(Some(Path::new("relative/run")), Some(temp.path()), || {
             DaemonPaths::for_config(&config)
         });
 
-        assert!(paths.socket.starts_with(&paths.dir), "{paths:?}");
+        assert!(paths
+            .socket
+            .starts_with(temp.path().canonicalize().expect("canonicalize")));
     }
 
     #[test]
@@ -333,6 +684,29 @@ mod tests {
 
         assert!(first.socket.starts_with(runtime.path()));
         assert_ne!(first.socket, second.socket);
+    }
+
+    /// The constant is a kernel ABI limit, not a preference, so it is worth
+    /// pinning against the thing that enforces it.  Being one byte too generous
+    /// would turn a relocation into a failed `bind`; being one byte too strict
+    /// would relocate a project that did not need it.
+    #[test]
+    fn the_limit_is_exactly_what_bind_accepts() {
+        let dir = a_dir();
+        let root = dir.path().canonicalize().expect("canonicalize");
+        let room = MAX_SOCKET_PATH - root.as_os_str().len() - 1;
+
+        let longest = root.join("s".repeat(room));
+        assert_eq!(longest.as_os_str().len(), MAX_SOCKET_PATH);
+        std::os::unix::net::UnixListener::bind(&longest)
+            .expect("a path of exactly the limit must bind");
+
+        let over = root.join("s".repeat(room + 1));
+        assert_eq!(over.as_os_str().len(), MAX_SOCKET_PATH + 1);
+        assert!(
+            std::os::unix::net::UnixListener::bind(&over).is_err(),
+            "one byte over the limit must not bind"
+        );
     }
 
     #[test]

--- a/crates/servicrab-cli/src/daemon/paths.rs
+++ b/crates/servicrab-cli/src/daemon/paths.rs
@@ -209,12 +209,18 @@ mod tests {
     #[test]
     fn state_lives_next_to_the_config() {
         let dir = TempDir::new().expect("temp dir");
-        let paths = DaemonPaths::for_config(&dir.path().join("servicrab.toml"));
         let root = dir.path().canonicalize().expect("canonicalize");
+        // Pinned: macOS temp paths are long enough that whether the socket
+        // relocates depends on `$XDG_RUNTIME_DIR`, and that is process-global.
+        let runtime = a_runtime_dir();
+        let paths = with_runtime_dir(Some(runtime.path()), || {
+            DaemonPaths::for_config(&root.join("servicrab.toml"))
+        });
 
         assert_eq!(paths.dir, root.join(".servicrab"));
-        assert_eq!(paths.socket, root.join(".servicrab/daemon.sock"));
         assert_eq!(paths.pid, root.join(".servicrab/daemon.pid"));
+        assert_eq!(paths.log, root.join(".servicrab/daemon.log"));
+        assert_eq!(paths.stopped, root.join(".servicrab/stopped"));
     }
 
     /// Two spellings of one project are one project.
@@ -227,23 +233,45 @@ mod tests {
     fn the_same_project_spelled_two_ways_gets_one_socket() {
         let dir = TempDir::new().expect("temp dir");
         std::fs::create_dir_all(dir.path().join("app")).expect("create");
+        let runtime = a_runtime_dir();
 
-        let plain = DaemonPaths::for_config(&dir.path().join("app/servicrab.toml"));
-        let dotted = DaemonPaths::for_config(&dir.path().join("./app/./servicrab.toml"));
-        let detoured = DaemonPaths::for_config(&dir.path().join("app/../app/servicrab.toml"));
+        let (plain, dotted, detoured) = with_runtime_dir(Some(runtime.path()), || {
+            (
+                DaemonPaths::for_config(&dir.path().join("app/servicrab.toml")),
+                DaemonPaths::for_config(&dir.path().join("./app/./servicrab.toml")),
+                DaemonPaths::for_config(&dir.path().join("app/../app/servicrab.toml")),
+            )
+        });
 
         assert_eq!(plain.socket, dotted.socket);
         assert_eq!(plain.socket, detoured.socket);
-        assert!(plain.socket.is_absolute(), "{}", plain.socket.display());
+        assert_eq!(plain.dir, detoured.dir);
+        assert!(plain.dir.is_absolute(), "{}", plain.dir.display());
+    }
+
+    /// A project whose path leaves room for the socket keeps it next to the
+    /// config, which is where the documentation and every third-party client
+    /// look for it.
+    #[test]
+    fn a_short_project_keeps_its_socket_next_to_the_config() {
+        let dir = a_runtime_dir();
+        let root = dir.path().canonicalize().expect("canonicalize");
+        let runtime = a_runtime_dir();
+
+        let paths = with_runtime_dir(Some(runtime.path()), || {
+            DaemonPaths::for_config(&root.join("servicrab.toml"))
+        });
+
+        assert_eq!(paths.socket, root.join(".servicrab/daemon.sock"));
     }
 
     #[test]
     fn a_relative_config_becomes_an_absolute_socket() {
         let paths = DaemonPaths::for_config(Path::new("servicrab.toml"));
-        assert!(paths.socket.is_absolute(), "{}", paths.socket.display());
         // The length limit has to be measured against this, not against the
-        // three characters the operator typed.
-        assert!(paths.socket.ends_with(".servicrab/daemon.sock"));
+        // fourteen characters the operator typed.
+        assert!(paths.dir.is_absolute(), "{}", paths.dir.display());
+        assert!(paths.dir.ends_with(".servicrab"));
     }
 
     #[test]

--- a/crates/servicrab-cli/src/daemon/paths.rs
+++ b/crates/servicrab-cli/src/daemon/paths.rs
@@ -258,8 +258,6 @@ fn candidates() -> Vec<(String, Option<PathBuf>)> {
 ///   a group is enough to enumerate the sockets, and connecting is the only
 ///   capability an attacker needs.
 fn is_private_dir(path: &Path) -> Result<PathBuf, String> {
-    use std::os::unix::fs::MetadataExt;
-
     if !path.is_absolute() {
         return Err("is not an absolute path".to_string());
     }
@@ -270,6 +268,20 @@ fn is_private_dir(path: &Path) -> Result<PathBuf, String> {
     if !meta.is_dir() {
         return Err("is not a directory".to_string());
     }
+    belongs_to_us_alone(&meta)?;
+    Ok(resolved)
+}
+
+/// The ownership and mode half of [`is_private_dir`], which only Unix can
+/// answer.
+///
+/// Split out rather than inlined because `uid` and `mode` come from
+/// `MetadataExt`, which does not exist off Unix — and this file, unlike the rest
+/// of [`super`], is compiled everywhere so that the commands can name their
+/// paths while refusing to run.
+#[cfg(unix)]
+fn belongs_to_us_alone(meta: &std::fs::Metadata) -> Result<(), String> {
+    use std::os::unix::fs::MetadataExt;
 
     let us = nix::unistd::getuid().as_raw();
     if meta.uid() != us {
@@ -285,7 +297,17 @@ fn is_private_dir(path: &Path) -> Result<PathBuf, String> {
              it must have no group or other permissions at all"
         ));
     }
-    Ok(resolved)
+    Ok(())
+}
+
+/// Refuse every candidate on a platform with no Unix sockets to put in one.
+///
+/// Nothing here is reachable: a daemon needs a socket, and the modules that bind
+/// one are `cfg(unix)`.  Answering "no" rather than "yes" keeps that true if it
+/// ever stops being — a directory we cannot inspect is not one we should trust.
+#[cfg(not(unix))]
+fn belongs_to_us_alone(_meta: &std::fs::Metadata) -> Result<(), String> {
+    Err("cannot be shown to be private to you on this platform".to_string())
 }
 
 /// A short, stable, filesystem-safe name for the project at `dir`.
@@ -303,7 +325,14 @@ fn project_slug(dir: &Path) -> String {
     format!("{hash:016x}")
 }
 
-#[cfg(test)]
+/// Unix-only, like the daemon these paths are for.
+///
+/// A few of these cases — path normalisation, the project slug — would pass
+/// anywhere, but the rest set modes and compare uids, and splitting the module
+/// in two to run three of them on a platform that cannot open a socket buys
+/// nothing. The non-Unix build's promise is that it compiles and refuses
+/// clearly, and [`super::super::commands`] is where that is checked.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/servicrab-cli/src/daemon/paths.rs
+++ b/crates/servicrab-cli/src/daemon/paths.rs
@@ -170,13 +170,27 @@ fn normalize(path: &Path) -> PathBuf {
 /// the rejections explain what to fix, which is the difference between
 /// "servicrab is broken" and "your `$TMPDIR` is group-readable".
 fn choose_socket(socket: PathBuf, dir: &Path) -> (PathBuf, Vec<String>) {
+    choose_socket_among(socket, dir, candidates())
+}
+
+/// [`choose_socket`] with the candidates handed in, so a test can describe a
+/// system rather than become one.
+///
+/// The alternative is setting `$TMPDIR`, which is process-global and read by
+/// every temporary-directory helper in the suite, including the ones other
+/// modules' tests are using at the same time.
+fn choose_socket_among(
+    socket: PathBuf,
+    dir: &Path,
+    candidates: Vec<(String, Option<PathBuf>)>,
+) -> (PathBuf, Vec<String>) {
     if socket.as_os_str().len() <= MAX_SOCKET_PATH {
         return (socket, Vec::new());
     }
 
     let name = format!("servicrab-{}.sock", project_slug(dir));
     let mut rejections = Vec::new();
-    for (label, value) in candidates() {
+    for (label, value) in candidates {
         let Some(value) = value else {
             rejections.push(format!("{label} is not set"));
             continue;
@@ -294,37 +308,39 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    /// The socket location reads the environment, which is process-global, so
+    /// The socket location reads `$XDG_RUNTIME_DIR`, which is process-global, so
     /// the tests that set it must not run beside each other.
+    ///
+    /// `$TMPDIR` is deliberately *not* set by any test: every temporary
+    /// directory helper in the suite reads it, including other modules' tests
+    /// running at the same time, so the temp candidate is injected through
+    /// [`choose_socket_among`] instead.
     static ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    /// Set `$XDG_RUNTIME_DIR` and `$TMPDIR` for the duration of `body`.
-    ///
-    /// `$TMPDIR` too, because [`std::env::temp_dir`] reads it: leaving the real
-    /// one in place would make the second candidate whatever the machine
-    /// running the tests happens to have, and these tests are about the
-    /// predicate, not about this machine.
-    fn with_env<T>(runtime: Option<&Path>, temp: Option<&Path>, body: impl FnOnce() -> T) -> T {
+    /// Set `$XDG_RUNTIME_DIR` for the duration of `body`.
+    fn with_runtime_dir<T>(value: Option<&Path>, body: impl FnOnce() -> T) -> T {
         let _guard = ENV.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        let previous = [
-            ("XDG_RUNTIME_DIR", std::env::var_os("XDG_RUNTIME_DIR")),
-            ("TMPDIR", std::env::var_os("TMPDIR")),
-        ];
-        // Safety: the mutex above is what keeps this off other threads.
-        for (name, value) in [("XDG_RUNTIME_DIR", runtime), ("TMPDIR", temp)] {
-            match value {
-                Some(path) => unsafe { std::env::set_var(name, path) },
-                None => unsafe { std::env::remove_var(name) },
-            }
+        let previous = std::env::var_os("XDG_RUNTIME_DIR");
+        match value {
+            // Safety: the mutex above is what keeps this off other threads.
+            Some(path) => unsafe { std::env::set_var("XDG_RUNTIME_DIR", path) },
+            None => unsafe { std::env::remove_var("XDG_RUNTIME_DIR") },
         }
         let out = body();
-        for (name, value) in previous {
-            match value {
-                Some(old) => unsafe { std::env::set_var(name, old) },
-                None => unsafe { std::env::remove_var(name) },
-            }
+        match previous {
+            Some(old) => unsafe { std::env::set_var("XDG_RUNTIME_DIR", old) },
+            None => unsafe { std::env::remove_var("XDG_RUNTIME_DIR") },
         }
         out
+    }
+
+    /// The candidate list a system with no `$XDG_RUNTIME_DIR` and `temp` as its
+    /// temporary directory would offer — macOS, in other words.
+    fn only_a_temp_dir(temp: &Path) -> Vec<(String, Option<PathBuf>)> {
+        vec![
+            ("$XDG_RUNTIME_DIR".to_string(), None),
+            ("the temp directory".to_string(), Some(temp.to_path_buf())),
+        ]
     }
 
     /// A short, already-canonical directory to build test directories under.
@@ -364,13 +380,6 @@ mod tests {
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(mode))
             .expect("set the mode");
         dir
-    }
-
-    /// Set `$XDG_RUNTIME_DIR` for the duration of `body`, with a private temp
-    /// directory behind it so it is never the reason a test passes.
-    fn with_runtime_dir<T>(value: Option<&Path>, body: impl FnOnce() -> T) -> T {
-        let private = a_dir_with_mode(0o700);
-        with_env(value, Some(private.path()), body)
     }
 
     /// A directory nested deeply enough that the socket path inside it cannot
@@ -481,10 +490,18 @@ mod tests {
     fn with_nowhere_private_to_go_the_socket_stays_in_the_project() {
         let shared = a_dir_with_mode(0o777);
         let (_root, config) = a_project_too_deep_for_a_socket();
+        let long = with_runtime_dir(None, || DaemonPaths::for_config(&config));
 
-        let paths = with_env(None, Some(shared.path()), || {
-            DaemonPaths::for_config(&config)
-        });
+        let (socket, socket_rejections) = choose_socket_among(
+            long.dir.join("daemon.sock"),
+            &long.dir,
+            only_a_temp_dir(shared.path()),
+        );
+        let paths = DaemonPaths {
+            socket,
+            socket_rejections,
+            ..long
+        };
 
         assert!(paths.socket.starts_with(&paths.dir), "{paths:?}");
         assert!(
@@ -623,22 +640,24 @@ mod tests {
     fn a_private_temp_directory_carries_the_socket_when_the_runtime_dir_is_unset() {
         let temp = a_dir_with_mode(0o700);
         let (_root, config) = a_project_too_deep_for_a_socket();
+        let long = with_runtime_dir(None, || DaemonPaths::for_config(&config));
 
-        let paths = with_env(None, Some(temp.path()), || DaemonPaths::for_config(&config));
+        let (socket, rejections) = choose_socket_among(
+            long.dir.join("daemon.sock"),
+            &long.dir,
+            only_a_temp_dir(temp.path()),
+        );
 
         assert!(
-            paths
-                .socket
-                .starts_with(temp.path().canonicalize().expect("canonicalize")),
+            socket.starts_with(temp.path().canonicalize().expect("canonicalize")),
             "{} is not in the temp directory",
-            paths.socket.display()
+            socket.display()
         );
-        assert!(paths.socket_rejections.is_empty(), "{paths:?}");
-        assert!(!paths.socket_is_in_place());
+        assert!(rejections.is_empty(), "{rejections:?}");
         // Only the socket moves.
-        assert!(paths.pid.starts_with(&paths.dir));
-        assert!(paths.log.starts_with(&paths.dir));
-        assert!(paths.stopped.starts_with(&paths.dir));
+        assert!(long.pid.starts_with(&long.dir));
+        assert!(long.log.starts_with(&long.dir));
+        assert!(long.stopped.starts_with(&long.dir));
     }
 
     /// `$XDG_RUNTIME_DIR` is tried first, so a system that provides one keeps
@@ -648,28 +667,51 @@ mod tests {
         let runtime = a_runtime_dir();
         let temp = a_dir_with_mode(0o700);
         let (_root, config) = a_project_too_deep_for_a_socket();
+        let long = with_runtime_dir(None, || DaemonPaths::for_config(&config));
 
-        let paths = with_env(Some(runtime.path()), Some(temp.path()), || {
-            DaemonPaths::for_config(&config)
-        });
+        let (socket, _) = choose_socket_among(
+            long.dir.join("daemon.sock"),
+            &long.dir,
+            vec![
+                (
+                    "$XDG_RUNTIME_DIR".to_string(),
+                    Some(runtime.path().to_path_buf()),
+                ),
+                (
+                    "the temp directory".to_string(),
+                    Some(temp.path().to_path_buf()),
+                ),
+            ],
+        );
 
-        assert!(paths.socket.starts_with(runtime.path()), "{paths:?}");
+        assert!(socket.starts_with(runtime.path()), "{}", socket.display());
     }
 
     /// A relative `$XDG_RUNTIME_DIR` would resolve against whatever directory
-    /// each command started in, so one project would get several sockets.
+    /// each command started in, so one project would get several sockets, so it
+    /// is skipped and the next candidate takes it.
     #[test]
     fn a_relative_runtime_dir_is_ignored() {
         let temp = a_dir_with_mode(0o700);
         let (_root, config) = a_project_too_deep_for_a_socket();
+        let long = with_runtime_dir(None, || DaemonPaths::for_config(&config));
 
-        let paths = with_env(Some(Path::new("relative/run")), Some(temp.path()), || {
-            DaemonPaths::for_config(&config)
-        });
+        let (socket, _) = choose_socket_among(
+            long.dir.join("daemon.sock"),
+            &long.dir,
+            vec![
+                (
+                    "$XDG_RUNTIME_DIR".to_string(),
+                    Some(PathBuf::from("relative/run")),
+                ),
+                (
+                    "the temp directory".to_string(),
+                    Some(temp.path().to_path_buf()),
+                ),
+            ],
+        );
 
-        assert!(paths
-            .socket
-            .starts_with(temp.path().canonicalize().expect("canonicalize")));
+        assert!(socket.starts_with(temp.path().canonicalize().expect("canonicalize")));
     }
 
     #[test]

--- a/crates/servicrab-cli/src/daemon/paths.rs
+++ b/crates/servicrab-cli/src/daemon/paths.rs
@@ -3,6 +3,13 @@
 //! Everything lives next to the config file so that two projects never fight
 //! over one daemon, and so that removing the project directory removes its
 //! runtime state with it.
+//!
+//! The socket is the exception, because it has a hard path length limit that a
+//! deeply nested project can exceed.  When that happens it moves to
+//! `$XDG_RUNTIME_DIR`, which the system creates 0700 and per-user.  It never
+//! moves to the shared temp directory: a name there is predictable to every
+//! local user, and `/tmp` being sticky means a squatted path can be neither
+//! unlinked nor bound, so the project could never start a daemon at all.
 
 use std::path::{Path, PathBuf};
 
@@ -32,23 +39,15 @@ pub struct DaemonPaths {
 impl DaemonPaths {
     /// Derive the paths for a project from its config file.
     ///
-    /// A deeply nested project would overflow the socket path limit, so in
-    /// that case the socket (and only the socket) moves to the temp dir under
-    /// a name derived from the config path.
+    /// The socket lives next to the config like everything else.  Only when
+    /// that path would overflow the socket length limit does it move to
+    /// `$XDG_RUNTIME_DIR`, under a name derived from the project directory.
     pub fn for_config(config: &Path) -> Self {
-        let dir = config
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .join(".servicrab");
+        let dir = project_dir(config).join(".servicrab");
         let socket = dir.join("daemon.sock");
-        let socket = if socket.as_os_str().len() > MAX_SOCKET_PATH {
-            std::env::temp_dir().join(format!("servicrab-{}.sock", digest(config)))
-        } else {
-            socket
-        };
 
         Self {
-            socket,
+            socket: relocate_if_too_long(socket, &dir),
             pid: dir.join("daemon.pid"),
             log: dir.join("daemon.log"),
             stopped: dir.join("stopped"),
@@ -63,12 +62,90 @@ impl DaemonPaths {
     }
 }
 
-/// A short, stable, filesystem-safe digest of a path.
-fn digest(path: &Path) -> String {
-    // FNV-1a: tiny, dependency-free, and a collision only costs a confusing
-    // "address already in use" for two projects with the same hash.
+/// The directory holding `config`, absolute wherever we can make it so.
+///
+/// `--config` is taken verbatim, so it may well be relative.  Two spellings of
+/// one project (`a/servicrab.toml` and `./a/servicrab.toml`) have to reach the
+/// same daemon, and the length limit has to be measured against the path the
+/// kernel will actually see.
+fn project_dir(config: &Path) -> PathBuf {
+    let parent = config.parent().unwrap_or_else(|| Path::new("."));
+    // The project directory exists in every real use; `canonicalize` resolves
+    // symlinks too, so the same directory reached two ways is one project.
+    if let Ok(resolved) = parent.canonicalize() {
+        return resolved;
+    }
+    // It does not exist yet — `generate` and the error paths both hit this.
+    // Absolute is still better than relative, and no worse than before.
+    match std::env::current_dir() {
+        Ok(cwd) if parent.is_relative() => normalize(&cwd.join(parent)),
+        _ => parent.to_path_buf(),
+    }
+}
+
+/// Drop `.` and `..` components lexically, for a path we cannot ask the
+/// filesystem about.
+fn normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for part in path.components() {
+        match part {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Move the socket out of the project when its path is too long for `bind`.
+///
+/// `$XDG_RUNTIME_DIR` is created by the system as 0700 and per-user, so a name
+/// in it is no more reachable than one inside the project.  The shared temp
+/// directory is not an option: `$TMPDIR` puts the location under an attacker's
+/// influence, the name would be predictable to every local user, and `/tmp`
+/// being sticky means a pre-created path can be neither unlinked nor bound.
+///
+/// With nowhere private to go we keep the long path.  `bind` then fails with
+/// `ENAMETOOLONG`, which names the real problem, where a fallback into a shared
+/// directory would silently trade a startup failure for a spoofable socket.
+fn relocate_if_too_long(socket: PathBuf, dir: &Path) -> PathBuf {
+    if socket.as_os_str().len() <= MAX_SOCKET_PATH {
+        return socket;
+    }
+    let Some(runtime) = runtime_dir() else {
+        return socket;
+    };
+
+    let moved = runtime.join(format!("servicrab-{}.sock", project_slug(dir)));
+    if moved.as_os_str().len() <= MAX_SOCKET_PATH {
+        moved
+    } else {
+        socket
+    }
+}
+
+/// `$XDG_RUNTIME_DIR`, if it is set to an absolute path.
+///
+/// A relative value would resolve against whatever directory the command
+/// happened to start in, so two invocations for one project could disagree
+/// about where the socket is.
+fn runtime_dir() -> Option<PathBuf> {
+    let value = std::env::var_os("XDG_RUNTIME_DIR")?;
+    let path = PathBuf::from(value);
+    (path.is_absolute() && path.is_dir()).then_some(path)
+}
+
+/// A short, stable, filesystem-safe name for the project at `dir`.
+///
+/// FNV-1a: tiny and dependency-free.  It is not a security boundary — the
+/// directory it names is per-user and 0700, and the peer check is what keeps
+/// strangers out — so all it has to do is separate two projects.  A collision
+/// costs one confusing "already running" for two projects with the same hash.
+fn project_slug(dir: &Path) -> String {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for byte in path.as_os_str().to_string_lossy().as_bytes() {
+    for byte in dir.as_os_str().as_encoded_bytes() {
         hash ^= u64::from(*byte);
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
@@ -78,34 +155,170 @@ fn digest(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
-    #[test]
-    fn state_lives_next_to_the_config() {
-        let paths = DaemonPaths::for_config(Path::new("/srv/app/servicrab.toml"));
-        assert_eq!(paths.dir, PathBuf::from("/srv/app/.servicrab"));
-        assert_eq!(
-            paths.socket,
-            PathBuf::from("/srv/app/.servicrab/daemon.sock")
-        );
-        assert_eq!(paths.pid, PathBuf::from("/srv/app/.servicrab/daemon.pid"));
+    /// The socket location reads `$XDG_RUNTIME_DIR`, which is process-global,
+    /// so the tests that set it must not run beside each other.
+    static ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Set `$XDG_RUNTIME_DIR` for the duration of `body`.
+    fn with_runtime_dir<T>(value: Option<&Path>, body: impl FnOnce() -> T) -> T {
+        let _guard = ENV.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = std::env::var_os("XDG_RUNTIME_DIR");
+        match value {
+            // Safety: the mutex above is what keeps this off other threads.
+            Some(path) => unsafe { std::env::set_var("XDG_RUNTIME_DIR", path) },
+            None => unsafe { std::env::remove_var("XDG_RUNTIME_DIR") },
+        }
+        let out = body();
+        match previous {
+            Some(old) => unsafe { std::env::set_var("XDG_RUNTIME_DIR", old) },
+            None => unsafe { std::env::remove_var("XDG_RUNTIME_DIR") },
+        }
+        out
+    }
+
+    /// A directory nested deeply enough that the socket path inside it cannot
+    /// fit, returned with the config file inside it.
+    fn a_project_too_deep_for_a_socket() -> (TempDir, PathBuf) {
+        let root = TempDir::new().expect("temp dir");
+        let deep = root
+            .path()
+            .join("nested".repeat(12))
+            .join("more".repeat(12));
+        std::fs::create_dir_all(&deep).expect("create the deep project");
+        let config = deep.join("servicrab.toml");
+        (root, config)
+    }
+
+    /// A stand-in for `$XDG_RUNTIME_DIR` that is short enough to hold a socket.
+    ///
+    /// A real one is `/run/user/1000`; macOS's per-user temp directory, which
+    /// is what `TempDir` uses by default, is 60 bytes on its own and would
+    /// leave no room for the socket name.
+    fn a_runtime_dir() -> TempDir {
+        let short = PathBuf::from("/tmp");
+        let root = if short.is_dir() {
+            short
+        } else {
+            std::env::temp_dir()
+        };
+        TempDir::new_in(root).expect("temp dir")
     }
 
     #[test]
-    fn a_very_long_path_moves_the_socket_to_the_temp_dir() {
-        let deep = PathBuf::from("/".to_string() + &"nested/".repeat(30)).join("servicrab.toml");
-        let paths = DaemonPaths::for_config(&deep);
+    fn state_lives_next_to_the_config() {
+        let dir = TempDir::new().expect("temp dir");
+        let paths = DaemonPaths::for_config(&dir.path().join("servicrab.toml"));
+        let root = dir.path().canonicalize().expect("canonicalize");
 
+        assert_eq!(paths.dir, root.join(".servicrab"));
+        assert_eq!(paths.socket, root.join(".servicrab/daemon.sock"));
+        assert_eq!(paths.pid, root.join(".servicrab/daemon.pid"));
+    }
+
+    /// Two spellings of one project are one project.
+    ///
+    /// The length check used to run on the path as typed, so a short relative
+    /// path whose absolute form was too long slipped through and failed `bind`
+    /// with ENAMETOOLONG — and `-c a/servicrab.toml` and `-c ./a/servicrab.toml`
+    /// hashed differently, giving one project two sockets.
+    #[test]
+    fn the_same_project_spelled_two_ways_gets_one_socket() {
+        let dir = TempDir::new().expect("temp dir");
+        std::fs::create_dir_all(dir.path().join("app")).expect("create");
+
+        let plain = DaemonPaths::for_config(&dir.path().join("app/servicrab.toml"));
+        let dotted = DaemonPaths::for_config(&dir.path().join("./app/./servicrab.toml"));
+        let detoured = DaemonPaths::for_config(&dir.path().join("app/../app/servicrab.toml"));
+
+        assert_eq!(plain.socket, dotted.socket);
+        assert_eq!(plain.socket, detoured.socket);
+        assert!(plain.socket.is_absolute(), "{}", plain.socket.display());
+    }
+
+    #[test]
+    fn a_relative_config_becomes_an_absolute_socket() {
+        let paths = DaemonPaths::for_config(Path::new("servicrab.toml"));
+        assert!(paths.socket.is_absolute(), "{}", paths.socket.display());
+        // The length limit has to be measured against this, not against the
+        // three characters the operator typed.
+        assert!(paths.socket.ends_with(".servicrab/daemon.sock"));
+    }
+
+    #[test]
+    fn a_long_path_moves_the_socket_to_the_runtime_dir() {
+        let runtime = a_runtime_dir();
+        let (_root, config) = a_project_too_deep_for_a_socket();
+
+        let paths = with_runtime_dir(Some(runtime.path()), || DaemonPaths::for_config(&config));
+
+        assert!(
+            paths.socket.starts_with(runtime.path()),
+            "{} is not in the runtime dir",
+            paths.socket.display()
+        );
+        // Only the socket moves; the rest of the state stays with the project.
         assert!(paths.dir.ends_with(".servicrab"));
-        assert!(paths.socket.starts_with(std::env::temp_dir()));
+        assert!(paths.pid.starts_with(&paths.dir));
+    }
+
+    /// With no private directory to move to, the long path stays put and `bind`
+    /// reports it.  The shared temp directory is never an answer: a name there
+    /// is predictable to every local user, and `/tmp` being sticky means a
+    /// squatted path can be neither unlinked nor bound.
+    #[test]
+    fn without_a_runtime_dir_the_socket_stays_in_the_project() {
+        let (_root, config) = a_project_too_deep_for_a_socket();
+
+        let paths = with_runtime_dir(None, || DaemonPaths::for_config(&config));
+
+        assert!(paths.socket.starts_with(&paths.dir), "{paths:?}");
+        assert!(
+            !paths.socket.starts_with(std::env::temp_dir()),
+            "the socket must never land in the shared temp directory"
+        );
+    }
+
+    /// A relative `$XDG_RUNTIME_DIR` would resolve against whatever directory
+    /// each command started in, so one project would get several sockets.
+    #[test]
+    fn a_relative_runtime_dir_is_ignored() {
+        let (_root, config) = a_project_too_deep_for_a_socket();
+
+        let paths = with_runtime_dir(Some(Path::new("relative/run")), || {
+            DaemonPaths::for_config(&config)
+        });
+
+        assert!(paths.socket.starts_with(&paths.dir), "{paths:?}");
     }
 
     #[test]
     fn different_projects_get_different_sockets() {
-        let one = PathBuf::from("/".to_string() + &"nested/".repeat(30)).join("a.toml");
-        let two = PathBuf::from("/".to_string() + &"nested/".repeat(30)).join("b.toml");
-        assert_ne!(
-            DaemonPaths::for_config(&one).socket,
-            DaemonPaths::for_config(&two).socket
+        let runtime = a_runtime_dir();
+        let (_root, one) = a_project_too_deep_for_a_socket();
+        let (_other_root, two) = a_project_too_deep_for_a_socket();
+
+        let (first, second) = with_runtime_dir(Some(runtime.path()), || {
+            (DaemonPaths::for_config(&one), DaemonPaths::for_config(&two))
+        });
+
+        assert!(first.socket.starts_with(runtime.path()));
+        assert_ne!(first.socket, second.socket);
+    }
+
+    #[test]
+    fn a_relocated_socket_is_short_enough_to_bind() {
+        let runtime = a_runtime_dir();
+        let (_root, config) = a_project_too_deep_for_a_socket();
+
+        let paths = with_runtime_dir(Some(runtime.path()), || DaemonPaths::for_config(&config));
+
+        assert!(
+            paths.socket.as_os_str().len() <= MAX_SOCKET_PATH,
+            "{} is {} bytes",
+            paths.socket.display(),
+            paths.socket.as_os_str().len()
         );
     }
 }

--- a/crates/servicrab-cli/src/daemon/paths.rs
+++ b/crates/servicrab-cli/src/daemon/paths.rs
@@ -18,6 +18,10 @@ pub struct DaemonPaths {
     /// The Unix socket clients connect to.
     pub socket: PathBuf,
     /// File holding the daemon's process id while it runs.
+    ///
+    /// Nothing reads the number — every command decides liveness by connecting
+    /// to the socket — but the daemon holds an exclusive `flock` on this file
+    /// for its entire life, and that is what keeps two daemons off one project.
     pub pid: PathBuf,
     /// Where a detached daemon's own output is appended.
     pub log: PathBuf,

--- a/crates/servicrab-cli/src/daemon/peer.rs
+++ b/crates/servicrab-cli/src/daemon/peer.rs
@@ -8,6 +8,10 @@
 //!
 //! Asking the kernel who connected costs nothing and does not depend on any
 //! filesystem keeping its promises.
+//!
+//! Root is not granted an exception: it does not need one — it can read the
+//! pidfile, signal the daemon, or become the user — and every accepted uid is
+//! one more principal with full authority over the stack.
 
 use std::os::unix::io::AsFd;
 
@@ -36,13 +40,22 @@ pub fn peer_uid(stream: &impl AsFd) -> Result<u32, String> {
     }
 }
 
-/// Whether the peer is the user this daemon runs as.
+/// What a peer we will not serve is told, naming both uids.
 ///
-/// Root is not granted an exception: it does not need one — it can read the
-/// pidfile, signal the daemon, or become the user — and every accepted uid is
-/// one more principal with full authority over the stack.
-pub fn is_the_same_user(stream: &impl AsFd) -> Result<bool, String> {
-    peer_uid(stream).map(|uid| uid == nix::unistd::getuid().as_raw())
+/// Refusing in silence is what the first version did, and every client reported
+/// it as "the daemon closed the connection without answering" — which is true
+/// and gives an operator no way to guess that a uid mismatch was the cause.
+/// `sudo servicrab status` against a user's daemon is a mistake the generated
+/// systemd unit's `User=` field invites, so it has to explain itself.
+///
+/// Neither number is a secret: a peer knows its own uid, and the daemon's is
+/// readable from the socket's owner.  Nothing else appears here — no path, no
+/// pid, no service name — because nothing else is already known.
+pub fn wrong_user_message(ours: u32, theirs: u32) -> String {
+    format!(
+        "this daemon runs as uid {ours}; you are uid {theirs} — \
+         servicrab only answers the user that started it"
+    )
 }
 
 #[cfg(test)]
@@ -62,8 +75,42 @@ mod tests {
             peer_uid(&server).expect("peer uid"),
             nix::unistd::getuid().as_raw()
         );
-        assert!(is_the_same_user(&server).expect("same user"));
         // Both ends can ask, and both see the same process.
-        assert!(is_the_same_user(&client).expect("same user"));
+        assert_eq!(
+            peer_uid(&client).expect("peer uid"),
+            nix::unistd::getuid().as_raw()
+        );
+    }
+
+    /// A cross-uid connection needs two users, which a test suite does not
+    /// have, so the message is checked on its own; the daemon's use of it and
+    /// the client's pass-through are covered in the integration tests.
+    #[test]
+    fn the_refusal_names_both_uids() {
+        let message = wrong_user_message(501, 0);
+
+        assert!(message.contains("uid 501"), "{message}");
+        assert!(message.contains("uid 0"), "{message}");
+        // Which is which has to be unambiguous, or the operator cannot tell
+        // whose daemon they have reached.
+        assert!(
+            message.starts_with("this daemon runs as uid 501;"),
+            "{message}"
+        );
+        assert!(message.contains("you are uid 0"), "{message}");
+    }
+
+    /// The refusal is sent to somebody we have just decided not to trust, so it
+    /// must say nothing beyond the two uids they could already look up.
+    #[test]
+    fn the_refusal_says_nothing_else() {
+        let message = wrong_user_message(501, 0);
+
+        assert!(!message.contains('/'), "no paths: {message}");
+        assert!(
+            !message.to_ascii_lowercase().contains("pid"),
+            "no pids: {message}"
+        );
+        assert!(!message.contains("servicrab.toml"), "no config: {message}");
     }
 }

--- a/crates/servicrab-cli/src/daemon/peer.rs
+++ b/crates/servicrab-cli/src/daemon/peer.rs
@@ -1,0 +1,69 @@
+//! Who is on the other end of a socket connection.
+//!
+//! The socket's mode is the first line of defence, but it is not the only one
+//! that should exist.  A socket can end up somewhere a stranger can reach — a
+//! directory an operator loosened, a project shared over a network filesystem
+//! that does not honour Unix modes — and an unauthenticated connection is
+//! enough to start, stop and restart every service in the project.
+//!
+//! Asking the kernel who connected costs nothing and does not depend on any
+//! filesystem keeping its promises.
+
+use std::os::unix::io::AsFd;
+
+/// The uid of the process on the other end of `stream`.
+///
+/// Linux answers `SO_PEERCRED`, the BSDs and macOS `LOCAL_PEERCRED`; nix wraps
+/// both, and both report the credentials as they were when the connection was
+/// made, so a peer cannot shed them afterwards.
+pub fn peer_uid(stream: &impl AsFd) -> Result<u32, String> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        use nix::sys::socket::{getsockopt, sockopt::PeerCredentials};
+
+        getsockopt(stream, PeerCredentials)
+            .map(|creds| creds.uid())
+            .map_err(|errno| format!("could not read the peer's credentials: {errno}"))
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        use nix::sys::socket::{getsockopt, sockopt::LocalPeerCred};
+
+        getsockopt(stream, LocalPeerCred)
+            .map(|cred| cred.uid())
+            .map_err(|errno| format!("could not read the peer's credentials: {errno}"))
+    }
+}
+
+/// Whether the peer is the user this daemon runs as.
+///
+/// Root is not granted an exception: it does not need one — it can read the
+/// pidfile, signal the daemon, or become the user — and every accepted uid is
+/// one more principal with full authority over the stack.
+pub fn is_the_same_user(stream: &impl AsFd) -> Result<bool, String> {
+    peer_uid(stream).map(|uid| uid == nix::unistd::getuid().as_raw())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn our_own_connection_is_recognised() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("sock");
+        let listener = std::os::unix::net::UnixListener::bind(&path).expect("bind");
+
+        let client = std::os::unix::net::UnixStream::connect(&path).expect("connect");
+        let (server, _) = listener.accept().expect("accept");
+
+        assert_eq!(
+            peer_uid(&server).expect("peer uid"),
+            nix::unistd::getuid().as_raw()
+        );
+        assert!(is_the_same_user(&server).expect("same user"));
+        // Both ends can ask, and both see the same process.
+        assert!(is_the_same_user(&client).expect("same user"));
+    }
+}

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -176,14 +176,29 @@ pub fn serve(
     }
 
     paths.ensure_dir()?;
-    // A socket file always survives its daemon, so a stale one is only an
-    // error if somebody is still listening on it.
+    // One daemon per project, decided by the kernel rather than by a check
+    // that another start could slip past.  The lock is held for the whole run.
+    let lock = match super::lock::ProjectLock::acquire(&paths.pid) {
+        Ok(lock) => lock,
+        Err(super::lock::LockError::Held) => {
+            return Err(format!(
+                "a daemon is already running for this project (pidfile: {})",
+                paths.pid.display()
+            ))
+        }
+        Err(super::lock::LockError::Failed(problem)) => return Err(problem),
+    };
+    // Holding the lock rules out every daemon that takes it, so anything still
+    // answering on the socket is either a release from before the lock existed
+    // or an impostor.  Refusing is the only safe answer to both.
     if super::client::is_running(&paths.socket) {
         return Err(format!(
             "a daemon is already running for this project (socket: {})",
             paths.socket.display()
         ));
     }
+    // A socket file always survives its daemon, and the lock proves ours is
+    // gone, so a leftover here is stale.
     let _ = std::fs::remove_file(&paths.socket);
 
     let registry = Arc::new(Mutex::new(StatusRegistry::new(plan.iter().map(|name| {
@@ -256,7 +271,8 @@ pub fn serve(
         session.respawn_watchers(cfg, &plan);
         let server = tokio::spawn(accept_loop(listener, Arc::clone(&session)));
 
-        write_pid(&paths.pid)?;
+        // The pidfile is already written and locked; this is the point where a
+        // client can reach us.
         tracing::info!(project = %project, socket = %paths.socket.display(), "daemon ready");
 
         let supervisor = StackSupervisor::new(cfg, plan, stack_options, events_tx)
@@ -277,9 +293,10 @@ pub fn serve(
     });
 
     // Clean up even when the run failed, so the next start is not blocked by
-    // our leftovers.
+    // our leftovers.  Dropping the lock removes the pidfile, and it goes last:
+    // until then no other daemon can get as far as binding the socket.
     let _ = std::fs::remove_file(&paths.socket);
-    let _ = std::fs::remove_file(&paths.pid);
+    drop(lock);
 
     let outcome = result?;
     if !outcome.is_success() {
@@ -638,9 +655,4 @@ async fn command(
             message: "the stack stopped before the command completed".to_string(),
         },
     }
-}
-
-fn write_pid(path: &Path) -> Result<(), String> {
-    std::fs::write(path, format!("{}\n", std::process::id()))
-        .map_err(|e| format!("could not write {}: {e}", path.display()))
 }

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -154,6 +154,10 @@ impl Session {
 /// exists: the umask is process-global, so it must not be visible to any other
 /// thread creating a file.  `set_permissions` afterwards is not the mechanism
 /// but a check, for a platform that might ignore the umask for sockets.
+///
+/// The mode is not the only line of defence — [`super::peer`] asks the kernel
+/// who connected — but it is the one that keeps a stranger from ever reaching
+/// `accept`.
 fn bind_socket(socket: &Path) -> Result<std::os::unix::net::UnixListener, String> {
     use nix::sys::stat::{umask, Mode};
     use std::os::unix::fs::PermissionsExt;
@@ -362,6 +366,22 @@ async fn accept_loop(listener: UnixListener, session: Arc<Session>) {
         let Ok((stream, _)) = listener.accept().await else {
             continue;
         };
+        // The socket's mode is the first line of defence, not the only one that
+        // should exist: a project on a filesystem that ignores Unix modes, or a
+        // directory an operator loosened, would otherwise hand the whole stack
+        // to a stranger.  Asking the kernel does not depend on any of that.
+        match super::peer::is_the_same_user(&stream) {
+            Ok(true) => {}
+            Ok(false) => {
+                let peer = super::peer::peer_uid(&stream).unwrap_or_default();
+                tracing::warn!(uid = peer, "refused a connection from another user");
+                continue;
+            }
+            Err(problem) => {
+                tracing::warn!("{problem}; refusing the connection");
+                continue;
+            }
+        }
         let session = Arc::clone(&session);
         // One task per client keeps a stuck reader from blocking everybody
         // else.

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -288,7 +288,12 @@ pub fn serve(
     // Bound before the runtime exists: the umask that keeps the socket private
     // is process-global, so no other thread may be creating files while it is
     // in effect.
-    let bound = bind_socket(&paths.socket)?;
+    let bound = bind_socket(&paths.socket).map_err(|problem| {
+        // A path too long to bind is the one failure whose cause is not in the
+        // message: it means every private directory we could have moved the
+        // socket to was refused, and only the rejections say which and why.
+        format!("{problem}{}", paths.socket_advice())
+    })?;
 
     let registry = Arc::new(Mutex::new(StatusRegistry::new(plan.iter().map(|name| {
         let has_health = cfg

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -33,8 +33,8 @@ const COLLECTOR_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
 /// The largest request the daemon will assemble, in bytes.
 ///
 /// Every real request is a short JSON object; the longest is a `subscribe` with
-/// a service list, which [`servicrab_protocol::MAX_SUBSCRIBE_SERVICES`] bounds
-/// separately.  64 KiB is far more than any of them needs and small enough that
+/// a service list, which the protocol crate bounds separately at 256 names.
+/// 64 KiB is far more than any of them needs and small enough that
 /// [`MAX_CONNECTIONS`] of them cannot exhaust memory.
 const MAX_FRAME: usize = 64 * 1024;
 
@@ -61,6 +61,14 @@ const MAX_MALFORMED: u32 = 3;
 /// `EMFILE` and `ENFILE` are not transient, and retrying straight away spun
 /// this loop at 100% CPU.
 const ACCEPT_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// How long a refusal may take to write before the connection is dropped.
+///
+/// One short line into an empty socket buffer never blocks, so this only fires
+/// for a peer that connected in order to be refused and then never read.  Short
+/// on purpose: waiting on such a peer would hold a slot in [`MAX_CONNECTIONS`],
+/// which is the limit the refusal path must not become a lever against.
+const REFUSAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Options for the daemon body.
 #[derive(Debug, Clone, Default)]
@@ -288,12 +296,7 @@ pub fn serve(
     // Bound before the runtime exists: the umask that keeps the socket private
     // is process-global, so no other thread may be creating files while it is
     // in effect.
-    let bound = bind_socket(&paths.socket).map_err(|problem| {
-        // A path too long to bind is the one failure whose cause is not in the
-        // message: it means every private directory we could have moved the
-        // socket to was refused, and only the rejections say which and why.
-        format!("{problem}{}", paths.socket_advice())
-    })?;
+    let bound = bind_socket(&paths.socket)?;
 
     let registry = Arc::new(Mutex::new(StatusRegistry::new(plan.iter().map(|name| {
         let has_health = cfg
@@ -431,7 +434,7 @@ async fn accept_loop(listener: UnixListener, session: Arc<Session>) {
     let live = Arc::new(tokio::sync::Semaphore::new(MAX_CONNECTIONS));
 
     loop {
-        let stream = match listener.accept().await {
+        let mut stream = match listener.accept().await {
             Ok((stream, _)) => stream,
             Err(err) => {
                 // Running out of file descriptors is not transient, and
@@ -443,22 +446,6 @@ async fn accept_loop(listener: UnixListener, session: Arc<Session>) {
                 continue;
             }
         };
-        // The socket's mode is the first line of defence, not the only one that
-        // should exist: a project on a filesystem that ignores Unix modes, or a
-        // directory an operator loosened, would otherwise hand the whole stack
-        // to a stranger.  Asking the kernel does not depend on any of that.
-        match super::peer::is_the_same_user(&stream) {
-            Ok(true) => {}
-            Ok(false) => {
-                let peer = super::peer::peer_uid(&stream).unwrap_or_default();
-                tracing::warn!(uid = peer, "refused a connection from another user");
-                continue;
-            }
-            Err(problem) => {
-                tracing::warn!("{problem}; refusing the connection");
-                continue;
-            }
-        }
         // One task per connection with no cap is a way to be talked out of
         // every file descriptor in the process.  Refusing the newest connection
         // keeps the ones already being served, and the client sees a closed
@@ -473,12 +460,68 @@ async fn accept_loop(listener: UnixListener, session: Arc<Session>) {
 
         let session = Arc::clone(&session);
         // One task per client keeps a stuck reader from blocking everybody
-        // else.
+        // else.  The peer check belongs in here rather than in the accept loop:
+        // saying why we are refusing means writing to the socket, and a peer
+        // that never reads must not be able to stall every other client.
         tokio::spawn(async move {
-            handle_client(stream, session).await;
+            if admit(&mut stream).await {
+                handle_client(stream, session).await;
+            }
             drop(permit);
         });
     }
+}
+
+/// Decide whether a connection may be served, and tell it if not.
+///
+/// The socket's mode is the first line of defence, not the only one that should
+/// exist: a project on a filesystem that ignores Unix modes, or a directory an
+/// operator loosened, would otherwise hand the whole stack to a stranger.
+/// Asking the kernel does not depend on any of that.
+///
+/// A refusal used to be a silent close, which every client reported as "the
+/// daemon closed the connection without answering" — true, and no help at all
+/// in guessing that a uid mismatch was the cause.  Since the generated systemd
+/// unit carries a `User=`, `sudo servicrab status` against a user's daemon is a
+/// mistake people will make.
+///
+/// Naming both uids leaks nothing: a peer already knows its own, and the
+/// daemon's is readable from the socket's owner.  Nothing else is said — no
+/// path, no pid, no service name.
+async fn admit(stream: &mut UnixStream) -> bool {
+    let ours = nix::unistd::getuid().as_raw();
+    match super::peer::peer_uid(stream) {
+        Ok(uid) if uid == ours => true,
+        Ok(uid) => {
+            tracing::warn!(uid, "refused a connection from another user");
+            refuse(stream, &super::peer::wrong_user_message(ours, uid)).await;
+            false
+        }
+        Err(problem) => {
+            tracing::warn!("{problem}; refusing the connection");
+            refuse(stream, "this daemon could not confirm who is connecting").await;
+            false
+        }
+    }
+}
+
+/// Send one error line and let the connection drop.
+///
+/// A refused peer has to stay cheaper than an accepted one, or the refusal
+/// becomes the cheapest way to occupy the connection cap: nothing is read, so
+/// there is no frame to bound and no line to mis-parse, and the write is
+/// bounded in time in case the peer never reads it.
+async fn refuse(stream: &mut UnixStream, message: &str) {
+    let Ok(line) = encode(&Response::Error {
+        message: message.to_string(),
+    }) else {
+        return;
+    };
+    let _ = tokio::time::timeout(REFUSAL_TIMEOUT, async {
+        let _ = stream.write_all(line.as_bytes()).await;
+        let _ = stream.flush().await;
+    })
+    .await;
 }
 
 /// Read one request line, bounded in both size and time.

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -239,6 +239,13 @@ pub fn serve(
 ) -> Result<i32, String> {
     let plan = plan_stack(cfg, options.selection()).map_err(|e| e.to_string())?;
 
+    // Before anything of ours exists on disk or on the network.  SIGTERM,
+    // SIGINT and SIGHUP are fatal by default, and the real watcher cannot be
+    // installed until the runtime is built — which is after the socket is
+    // bound.  Claiming them here means a signal in that window is remembered
+    // instead of killing the process and stranding the socket file.
+    super::signals::claim()?;
+
     paths.ensure_dir()?;
     // One daemon per project, decided by the kernel rather than by a check
     // that another start could slip past.  The lock is held for the whole run.
@@ -295,7 +302,8 @@ pub fn serve(
     let _ = std::fs::remove_file(&paths.socket);
     // Bound before the runtime exists: the umask that keeps the socket private
     // is process-global, so no other thread may be creating files while it is
-    // in effect.
+    // in effect.  The signals were claimed above, so the socket cannot outlive
+    // a SIGTERM that lands between here and the real watcher.
     let bound = bind_socket(&paths.socket)?;
 
     let registry = Arc::new(Mutex::new(StatusRegistry::new(plan.iter().map(|name| {
@@ -329,6 +337,19 @@ pub fn serve(
         // over the socket.
         let (stop_tx, mut stop_rx) = shutdown_channel();
         let signals = SignalWatcher::install(&project).map_err(|e| e.to_string())?;
+        // Every signal is now accounted for: anything from before the watcher
+        // existed was recorded by the early handler, anything after it is the
+        // watcher's.  Feeding an early one into the same channel means the
+        // supervisor sees a shutdown request before it starts a single service,
+        // so nothing is spawned only to be stopped again.
+        if let Some(reason) = super::signals::arrived() {
+            tracing::info!(
+                project = %project,
+                %reason,
+                "a shutdown arrived while the daemon was still starting up"
+            );
+            let _ = stop_tx.send(Some(reason));
+        }
         let mut signal_rx = signals.subscribe();
         let signal_stop = stop_tx.clone();
         let signal_task = tokio::spawn(async move {

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -8,13 +8,15 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use servicrab_core::runtime::stack::{Control, ControlTx, StackOptions, StackSupervisor};
+use servicrab_core::runtime::stack::{
+    Control, ControlOutcome, ControlRefusal, ControlTx, StackOptions, StackSupervisor,
+};
 use servicrab_core::runtime::{control_channel, shutdown_channel, wait_for_shutdown};
 use servicrab_core::{
     event_channel, load, plan_stack, Config, EventKind, EventReceiver, EventSender, LogRouter,
     LogSink, ServiceName, ShutdownReason, SignalWatcher, StatusRegistry,
 };
-use servicrab_protocol::{decode, encode, Request, Response};
+use servicrab_protocol::{decode, encode, ErrorCode, Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::task::JoinHandle;
@@ -556,9 +558,7 @@ async fn admit(stream: &mut UnixStream) -> bool {
 /// there is no frame to bound and no line to mis-parse, and the write is
 /// bounded in time in case the peer never reads it.
 async fn refuse(stream: &mut UnixStream, message: &str) {
-    let Ok(line) = encode(&Response::Error {
-        message: message.to_string(),
-    }) else {
+    let Ok(line) = encode(&Response::error(ErrorCode::Failed, message)) else {
         return;
     };
     let _ = tokio::time::timeout(REFUSAL_TIMEOUT, async {
@@ -636,9 +636,10 @@ async fn handle_client(stream: UnixStream, session: Arc<Session>) {
                 );
                 let _ = write(
                     &mut write_half,
-                    &Response::Error {
-                        message: format!("a request may not exceed {MAX_FRAME} bytes"),
-                    },
+                    &Response::error(
+                        ErrorCode::Failed,
+                        format!("a request may not exceed {MAX_FRAME} bytes"),
+                    ),
                 )
                 .await;
                 return;
@@ -692,7 +693,14 @@ async fn handle_client(stream: UnixStream, session: Arc<Session>) {
         if let Request::Subscribe { services, logs } = request {
             let filter = Filter::new(services, logs);
             let receiver = session.stream.subscribe();
-            if write(&mut write_half, &Response::Ok { message: None }).await {
+            // The handshake is where a subscriber learns which contract the
+            // events that follow are written to.
+            let hello = Response::Ok {
+                message: None,
+                changes: None,
+                schema_version: Some(servicrab_protocol::SCHEMA_VERSION),
+            };
+            if write(&mut write_half, &hello).await {
                 stream_events(receiver, filter, write_half).await;
             }
             return;
@@ -717,13 +725,7 @@ async fn strike(
     message: &str,
 ) -> bool {
     *strikes += 1;
-    let alive = write(
-        sink,
-        &Response::Error {
-            message: message.to_string(),
-        },
-    )
-    .await;
+    let alive = write(sink, &Response::error(ErrorCode::Failed, message)).await;
     if !alive {
         return false;
     }
@@ -807,9 +809,7 @@ async fn respond(request: Request, session: &Session) -> Response {
         },
         Request::Status => {
             let Ok(registry) = session.registry.lock() else {
-                return Response::Error {
-                    message: "the status registry is poisoned".to_string(),
-                };
+                return Response::error(ErrorCode::Failed, "the status registry is poisoned");
             };
             Response::Status {
                 services: registry.snapshot().iter().map(to_wire_status).collect(),
@@ -817,9 +817,7 @@ async fn respond(request: Request, session: &Session) -> Response {
         }
         Request::Shutdown => {
             let _ = session.stop.send(Some(ShutdownReason::Terminated));
-            Response::Ok {
-                message: Some("stopping the stack".to_string()),
-            }
+            Response::message("stopping the stack")
         }
         Request::StartService { name } => {
             let response = command(session, &name, |service, ack| Control::Start {
@@ -859,9 +857,10 @@ async fn respond(request: Request, session: &Session) -> Response {
         Request::Reload => reload(session).await,
         // `Request` is `#[non_exhaustive]`, so an older daemon can still be
         // asked something it does not know about.
-        _ => Response::Error {
-            message: "this daemon does not support that request".to_string(),
-        },
+        _ => Response::error(
+            ErrorCode::Unsupported,
+            "this daemon does not support that request",
+        ),
     }
 }
 
@@ -877,14 +876,16 @@ async fn reload(session: &Session) -> Response {
     let (cfg, warnings) = match load(&session.config_path) {
         Ok(loaded) => loaded,
         Err(errors) => {
-            let details: Vec<String> = errors.iter().map(|e| format!("  • {e}")).collect();
+            // One entry per error, rather than one string with newlines and
+            // bullets in it that every caller would have to take apart again.
             return Response::Error {
+                code: ErrorCode::ValidationFailed,
                 message: format!(
-                    "{} has {} error(s); the stack was left untouched:\n{}",
+                    "{} has {} error(s); the stack was left untouched",
                     session.config_path.display(),
                     errors.len(),
-                    details.join("\n")
                 ),
+                errors: errors.iter().map(ToString::to_string).collect(),
             };
         }
     };
@@ -899,9 +900,10 @@ async fn reload(session: &Session) -> Response {
     let plan = match plan_stack(&cfg, selection) {
         Ok(plan) => plan,
         Err(err) => {
-            return Response::Error {
-                message: format!("{err}; the stack was left untouched"),
-            }
+            return Response::error(
+                ErrorCode::ValidationFailed,
+                format!("{err}; the stack was left untouched"),
+            )
         }
     };
 
@@ -918,28 +920,64 @@ async fn reload(session: &Session) -> Response {
     };
     if session.control.send(command).is_err() {
         restore_registry(session, &cfg, &previous);
-        return Response::Error {
-            message: "the supervisor is no longer accepting commands".to_string(),
-        };
+        return Response::error(
+            ErrorCode::Failed,
+            "the supervisor is no longer accepting commands",
+        );
     }
 
     match ack_rx.await {
-        Ok(Ok(message)) => {
+        Ok(Ok(outcome)) => {
             session.respawn_watchers(&cfg, &plan);
             Response::Ok {
-                message: Some(format!("reloaded {}: {message}", session.project)),
+                message: Some(format!("reloaded {}: {outcome}", session.project)),
+                changes: Some(reload_changes(outcome)),
+                schema_version: None,
             }
         }
-        Ok(Err(message)) => {
+        Ok(Err(refusal)) => {
             restore_registry(session, &cfg, &previous);
-            Response::Error { message }
+            Response::error(refusal_code(&refusal), refusal.to_string())
         }
         Err(_) => {
             restore_registry(session, &cfg, &previous);
-            Response::Error {
-                message: "the stack stopped before the reload completed".to_string(),
-            }
+            Response::error(
+                ErrorCode::Failed,
+                "the stack stopped before the reload completed",
+            )
         }
+    }
+}
+
+/// The three counts a reload reports, taken from what the supervisor did.
+///
+/// A `ControlOutcome` that is not a reload cannot reach here — `Control::Reload`
+/// is answered with `Reloaded` and nothing else — and reporting zeroes is a
+/// truthful answer to "what changed" for any outcome that carries no counts.
+fn reload_changes(outcome: ControlOutcome) -> servicrab_protocol::ReloadChanges {
+    match outcome {
+        ControlOutcome::Reloaded {
+            added,
+            changed,
+            removed,
+        } => servicrab_protocol::ReloadChanges {
+            added,
+            changed,
+            removed,
+        },
+        _ => servicrab_protocol::ReloadChanges::default(),
+    }
+}
+
+/// The wire code for a refusal the supervisor sent back.
+fn refusal_code(refusal: &ControlRefusal) -> ErrorCode {
+    match refusal {
+        ControlRefusal::UnknownService(_) => ErrorCode::UnknownService,
+        ControlRefusal::Busy(_) => ErrorCode::Busy,
+        ControlRefusal::AlreadyRunning(_) => ErrorCode::AlreadyRunning,
+        // A refusal a newer core knows about and this code does not is still a
+        // refusal, and saying only that is better than mislabelling it.
+        _ => ErrorCode::Failed,
     }
 }
 
@@ -972,8 +1010,9 @@ async fn command(
 ) -> Response {
     let names = session.known_names();
     let Some(service) = names.iter().find(|known| known.as_str() == name) else {
-        return Response::Error {
-            message: format!(
+        return Response::error(
+            ErrorCode::UnknownService,
+            format!(
                 "unknown service {name:?}; this daemon supervises: {}",
                 names
                     .iter()
@@ -981,7 +1020,7 @@ async fn command(
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-        };
+        );
     };
 
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
@@ -990,19 +1029,19 @@ async fn command(
         .send(build(service.clone(), ack_tx))
         .is_err()
     {
-        return Response::Error {
-            message: "the supervisor is no longer accepting commands".to_string(),
-        };
+        return Response::error(
+            ErrorCode::Failed,
+            "the supervisor is no longer accepting commands",
+        );
     }
 
     match ack_rx.await {
-        Ok(Ok(message)) => Response::Ok {
-            message: Some(format!("{name} {message}")),
-        },
-        Ok(Err(message)) => Response::Error { message },
+        Ok(Ok(outcome)) => Response::message(format!("{name} {outcome}")),
+        Ok(Err(refusal)) => Response::error(refusal_code(&refusal), refusal.to_string()),
         // The ack channel is dropped when the stack shuts down mid-command.
-        Err(_) => Response::Error {
-            message: "the stack stopped before the command completed".to_string(),
-        },
+        Err(_) => Response::error(
+            ErrorCode::Failed,
+            "the stack stopped before the command completed",
+        ),
     }
 }

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -15,7 +15,7 @@ use servicrab_core::{
     ServiceName, ShutdownReason, SignalWatcher, StatusRegistry,
 };
 use servicrab_protocol::{decode, encode, Request, Response};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::task::JoinHandle;
 
@@ -29,6 +29,38 @@ const STREAM_BACKLOG: usize = 4096;
 
 /// How long the daemon waits for the log collector to drain on shutdown.
 const COLLECTOR_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// The largest request the daemon will assemble, in bytes.
+///
+/// Every real request is a short JSON object; the longest is a `subscribe` with
+/// a service list, which [`servicrab_protocol::MAX_SUBSCRIBE_SERVICES`] bounds
+/// separately.  64 KiB is far more than any of them needs and small enough that
+/// [`MAX_CONNECTIONS`] of them cannot exhaust memory.
+const MAX_FRAME: usize = 64 * 1024;
+
+/// How long a connection may say nothing before it is closed.
+///
+/// The CLI sends its request immediately and a subscriber stops reading in a
+/// different loop, so no legitimate client is idle here.  Generous anyway: a
+/// machine under load should not lose a command it already sent.
+const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// How many clients may be connected at once.
+///
+/// Each one costs a file descriptor and a task, and a daemon that has been
+/// talked out of every descriptor in the process cannot supervise anything.  A
+/// handful of CLI invocations plus a few `events` subscribers is the realistic
+/// load, so this leaves two orders of magnitude of headroom.
+const MAX_CONNECTIONS: usize = 64;
+
+/// How many malformed lines one connection may send before it is closed.
+const MAX_MALFORMED: u32 = 3;
+
+/// How long to wait after `accept` fails before trying again.
+///
+/// `EMFILE` and `ENFILE` are not transient, and retrying straight away spun
+/// this loop at 100% CPU.
+const ACCEPT_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// Options for the daemon body.
 #[derive(Debug, Clone, Default)]
@@ -361,10 +393,27 @@ async fn collect(
 }
 
 /// Serve clients until the task is cancelled.
+///
+/// Every limit here exists because the socket is reachable before any request
+/// is understood, so an abusive client must cost the daemon a bounded amount of
+/// memory, file descriptors and CPU.
 async fn accept_loop(listener: UnixListener, session: Arc<Session>) {
+    // Counts live connections; each guard decrements on drop, including on a
+    // panic inside the handler.
+    let live = Arc::new(tokio::sync::Semaphore::new(MAX_CONNECTIONS));
+
     loop {
-        let Ok((stream, _)) = listener.accept().await else {
-            continue;
+        let stream = match listener.accept().await {
+            Ok((stream, _)) => stream,
+            Err(err) => {
+                // Running out of file descriptors is not transient, and
+                // retrying immediately spun this loop at 100% CPU with nothing
+                // logged.  Backing off gives whoever holds them a chance to let
+                // go, and says so.
+                tracing::warn!("could not accept a connection: {err}");
+                tokio::time::sleep(ACCEPT_BACKOFF).await;
+                continue;
+            }
         };
         // The socket's mode is the first line of defence, not the only one that
         // should exist: a project on a filesystem that ignores Unix modes, or a
@@ -382,39 +431,146 @@ async fn accept_loop(listener: UnixListener, session: Arc<Session>) {
                 continue;
             }
         }
+        // One task per connection with no cap is a way to be talked out of
+        // every file descriptor in the process.  Refusing the newest connection
+        // keeps the ones already being served, and the client sees a closed
+        // socket, which its own error handling already covers.
+        let Ok(permit) = Arc::clone(&live).try_acquire_owned() else {
+            tracing::warn!(
+                limit = MAX_CONNECTIONS,
+                "refused a connection: too many clients"
+            );
+            continue;
+        };
+
         let session = Arc::clone(&session);
         // One task per client keeps a stuck reader from blocking everybody
         // else.
         tokio::spawn(async move {
             handle_client(stream, session).await;
+            drop(permit);
         });
     }
 }
 
+/// Read one request line, bounded in both size and time.
+///
+/// `tokio::io::Lines` grows its `String` until it finds a newline, so a stream
+/// that never sends one is a way to drive the daemon out of memory.  Reading
+/// into a capped buffer turns that into a closed connection.
+async fn read_request(
+    reader: &mut BufReader<tokio::net::unix::OwnedReadHalf>,
+    line: &mut Vec<u8>,
+) -> ReadOutcome {
+    line.clear();
+    // `read_until` on a `take`-limited reader stops at the cap instead of
+    // growing the buffer forever.  One extra byte is allowed through so that a
+    // request of exactly `MAX_FRAME` bytes plus its newline still fits.
+    let read = tokio::time::timeout(IDLE_TIMEOUT, async {
+        let mut capped = (&mut *reader).take(MAX_FRAME as u64 + 1);
+        capped.read_until(b'\n', line).await
+    });
+    match read.await {
+        // The client went away — or it filled the cap without a newline, and
+        // the limited reader has nothing more to give.
+        Ok(Ok(0)) if line.is_empty() => ReadOutcome::Closed,
+        Ok(Ok(_)) | Ok(Err(_)) if !line.ends_with(b"\n") => {
+            // No newline means either a half-open connection that closed
+            // mid-request or a stream that never intends to send one.  Both are
+            // the end of this connection; only the second is worth a warning.
+            if line.len() > MAX_FRAME {
+                ReadOutcome::TooLong
+            } else {
+                ReadOutcome::Closed
+            }
+        }
+        Ok(Ok(_)) => ReadOutcome::Line,
+        Ok(Err(err)) => ReadOutcome::Broken(err.to_string()),
+        Err(_) => ReadOutcome::Idle,
+    }
+}
+
+/// What one read attempt produced.
+enum ReadOutcome {
+    /// A whole line is in the buffer.
+    Line,
+    /// The peer closed the connection.
+    Closed,
+    /// [`MAX_FRAME`] bytes arrived with no newline among them.
+    TooLong,
+    /// Nothing arrived for [`IDLE_TIMEOUT`].
+    Idle,
+    /// The read itself failed.
+    Broken(String),
+}
+
 async fn handle_client(stream: UnixStream, session: Arc<Session>) {
     let (read_half, mut write_half) = stream.into_split();
-    let mut lines = BufReader::new(read_half).lines();
+    let mut reader = BufReader::new(read_half);
+    let mut buffer = Vec::with_capacity(1024);
+    let mut strikes = 0_u32;
 
-    while let Ok(Some(line)) = lines.next_line().await {
+    loop {
+        match read_request(&mut reader, &mut buffer).await {
+            ReadOutcome::Line => {}
+            ReadOutcome::Closed => return,
+            ReadOutcome::TooLong => {
+                tracing::warn!(
+                    limit = MAX_FRAME,
+                    "closing a connection that sent an oversized request"
+                );
+                let _ = write(
+                    &mut write_half,
+                    &Response::Error {
+                        message: format!("a request may not exceed {MAX_FRAME} bytes"),
+                    },
+                )
+                .await;
+                return;
+            }
+            ReadOutcome::Idle => {
+                tracing::debug!(
+                    timeout = ?IDLE_TIMEOUT,
+                    "closing an idle connection"
+                );
+                return;
+            }
+            ReadOutcome::Broken(problem) => {
+                tracing::debug!("a client connection broke: {problem}");
+                return;
+            }
+        }
+
+        // A request has to be valid UTF-8 to be JSON; treating it as a
+        // malformed line rather than an error of ours keeps the strike count
+        // honest.
+        let Ok(line) = std::str::from_utf8(&buffer) else {
+            if !strike(
+                &mut strikes,
+                &mut write_half,
+                "a request must be valid UTF-8",
+            )
+            .await
+            {
+                return;
+            }
+            continue;
+        };
         if line.trim().is_empty() {
             continue;
         }
-        let request = match decode::<Request>(&line) {
+        let request = match decode::<Request>(line) {
             Ok(request) => request,
             Err(err) => {
-                if !write(
-                    &mut write_half,
-                    &Response::Error {
-                        message: err.to_string(),
-                    },
-                )
-                .await
-                {
-                    break;
+                // Answering and carrying on let garbage be pumped forever.
+                if !strike(&mut strikes, &mut write_half, &err.to_string()).await {
+                    return;
                 }
                 continue;
             }
         };
+        // A client that talks sense has nothing held against it.
+        strikes = 0;
 
         // Subscribing turns the connection one-way: the client stops asking
         // and only reads until it goes away.
@@ -430,9 +586,40 @@ async fn handle_client(stream: UnixStream, session: Arc<Session>) {
         let response = respond(request, &session).await;
 
         if !write(&mut write_half, &response).await {
-            break;
+            return;
         }
     }
+}
+
+/// Answer a malformed line and count it against the connection.
+///
+/// Returns whether the connection should carry on.  A client that cannot form a
+/// request is either broken or probing; either way, three tries is enough
+/// courtesy, and closing beats letting garbage be pumped in forever.
+async fn strike(
+    strikes: &mut u32,
+    sink: &mut tokio::net::unix::OwnedWriteHalf,
+    message: &str,
+) -> bool {
+    *strikes += 1;
+    let alive = write(
+        sink,
+        &Response::Error {
+            message: message.to_string(),
+        },
+    )
+    .await;
+    if !alive {
+        return false;
+    }
+    if *strikes >= MAX_MALFORMED {
+        tracing::warn!(
+            strikes = *strikes,
+            "closing a connection that keeps sending malformed requests"
+        );
+        return false;
+    }
+    true
 }
 
 /// Write one response, reporting whether the client is still there.
@@ -448,12 +635,15 @@ async fn write(sink: &mut tokio::net::unix::OwnedWriteHalf, response: &Response)
 
 /// Which events a subscriber asked for.
 struct Filter {
-    services: Vec<String>,
+    /// Empty means every service.  A set, because this is consulted once per
+    /// event per subscriber, and a linear scan of a client-supplied list turned
+    /// a busy stack into work proportional to the list length.
+    services: std::collections::BTreeSet<String>,
     logs: bool,
 }
 
 impl Filter {
-    fn new(services: Vec<String>, logs: bool) -> Self {
+    fn new(services: std::collections::BTreeSet<String>, logs: bool) -> Self {
         Self { services, logs }
     }
 
@@ -461,11 +651,7 @@ impl Filter {
         if !self.logs && matches!(event.kind, EventKind::Log { .. }) {
             return false;
         }
-        self.services.is_empty()
-            || self
-                .services
-                .iter()
-                .any(|name| name == event.service.as_str())
+        self.services.is_empty() || self.services.contains(event.service.as_str())
     }
 }
 

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -324,10 +324,20 @@ pub fn serve(
         keep_running: true,
     };
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .map_err(|e| format!("failed to start the async runtime: {e}"))?;
+    {
+        Ok(runtime) => runtime,
+        // The socket is already bound and published, so an early return here
+        // has to tidy up just like the normal exit path does.  Nothing has
+        // accepted a connection yet, and the lock is still ours.
+        Err(problem) => {
+            let _ = std::fs::remove_file(&paths.socket);
+            drop(lock);
+            return Err(format!("failed to start the async runtime: {problem}"));
+        }
+    };
 
     let result = runtime.block_on(async {
         let listener = UnixListener::from_std(bound)

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -119,8 +119,14 @@ impl Session {
     /// Only `restart = "unless-stopped"` acts on this, and only when a stack is
     /// started, so a file we could not write costs nothing right now — it is
     /// logged and the command still succeeds.
-    fn remember(&self, service: &str, is_stopped: bool) {
-        if let Err(problem) = stopped::record(&self.stopped, service, is_stopped) {
+    ///
+    /// The write is a lock plus filesystem calls, so it goes to a blocking
+    /// thread: this is called from a connection task on the same runtime that
+    /// supervises the processes.
+    async fn remember(&self, service: &str, is_stopped: bool) {
+        let outcome =
+            stopped::record_blocking(self.stopped.clone(), service.to_string(), is_stopped).await;
+        if let Err(problem) = outcome {
             tracing::warn!("{problem}");
         }
     }
@@ -224,18 +230,6 @@ pub fn serve(
     options: DaemonOptions,
 ) -> Result<i32, String> {
     let plan = plan_stack(cfg, options.selection()).map_err(|e| e.to_string())?;
-    let held_back = stopped::held_back(cfg, &plan, &stopped::read(&paths.stopped));
-    if !held_back.is_empty() {
-        tracing::info!(
-            services = %held_back
-                .iter()
-                .map(ServiceName::as_str)
-                .collect::<Vec<_>>()
-                .join(", "),
-            file = %paths.stopped.display(),
-            "leaving hand-stopped services (and their dependents) stopped"
-        );
-    }
 
     paths.ensure_dir()?;
     // One daemon per project, decided by the kernel rather than by a check
@@ -250,6 +244,35 @@ pub fn serve(
         }
         Err(super::lock::LockError::Failed(problem)) => return Err(problem),
     };
+
+    // Startup is the one moment when the configuration has just been read and
+    // no request can be in flight, so it is where names of services that no
+    // longer exist get dropped.  Held after the lock, because it writes.
+    match stopped::reconcile(&paths.stopped, cfg) {
+        Ok(dropped) if !dropped.is_empty() => tracing::info!(
+            services = %dropped.iter().cloned().collect::<Vec<_>>().join(", "),
+            file = %paths.stopped.display(),
+            "forgetting hand-stopped services the configuration no longer declares"
+        ),
+        Ok(_) => {}
+        // The memory of a stop is a convenience; failing to tidy it is not a
+        // reason to refuse to start a stack.
+        Err(problem) => tracing::warn!("{problem}"),
+    }
+
+    let held_back = stopped::held_back(cfg, &plan, &stopped::read(&paths.stopped));
+    if !held_back.is_empty() {
+        tracing::info!(
+            services = %held_back
+                .iter()
+                .map(ServiceName::as_str)
+                .collect::<Vec<_>>()
+                .join(", "),
+            file = %paths.stopped.display(),
+            "leaving hand-stopped services (and their dependents) stopped"
+        );
+    }
+
     // Holding the lock rules out every daemon that takes it, so anything still
     // answering on the socket is either a release from before the lock existed
     // or an impostor.  Refusing is the only safe answer to both.
@@ -715,7 +738,7 @@ async fn respond(request: Request, session: &Session) -> Response {
             // Starting a service is how an operator takes back a stop, whether
             // it happened in this daemon or in an earlier one.
             if matches!(response, Response::Ok { .. }) {
-                session.remember(&name, false);
+                session.remember(&name, false).await;
             }
             response
         }
@@ -726,7 +749,7 @@ async fn respond(request: Request, session: &Session) -> Response {
             })
             .await;
             if matches!(response, Response::Ok { .. }) {
-                session.remember(&name, true);
+                session.remember(&name, true).await;
             }
             response
         }
@@ -737,7 +760,7 @@ async fn respond(request: Request, session: &Session) -> Response {
             })
             .await;
             if matches!(response, Response::Ok { .. }) {
-                session.remember(&name, false);
+                session.remember(&name, false).await;
             }
             response
         }

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -12,7 +12,7 @@ use servicrab_core::runtime::stack::{Control, ControlTx, StackOptions, StackSupe
 use servicrab_core::runtime::{control_channel, shutdown_channel, wait_for_shutdown};
 use servicrab_core::{
     event_channel, load, plan_stack, Config, EventKind, EventReceiver, EventSender, LogRouter,
-    ServiceName, ShutdownReason, SignalWatcher, StatusRegistry,
+    LogSink, ServiceName, ShutdownReason, SignalWatcher, StatusRegistry,
 };
 use servicrab_protocol::{decode, encode, Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -290,15 +290,21 @@ pub fn serve(
 
 /// Keep the status registry current, copy output to the log files, and hand
 /// every event to whoever is subscribed.
+///
+/// The file work is handed to a blocking task: the collector shares its worker
+/// threads with the supervisor, so a stalled disk here would stall child
+/// `wait()`s, health probes and the control channel too.
 async fn collect(
     mut events: EventReceiver,
     registry: Arc<Mutex<StatusRegistry>>,
-    mut logs: Option<LogRouter>,
+    logs: Option<LogRouter>,
     stream: tokio::sync::broadcast::Sender<servicrab_core::ServiceEvent>,
 ) {
+    let sink = logs.map(LogSink::spawn);
+
     while let Some(event) = events.recv().await {
-        if let (Some(router), EventKind::Log { line, .. }) = (logs.as_mut(), &event.kind) {
-            if let Some(problem) = router.record(&event.service, line) {
+        if let (Some(sink), EventKind::Log { line, .. }) = (sink.as_ref(), &event.kind) {
+            if let Some(problem) = sink.record(&event.service, line).await {
                 tracing::warn!("{problem}");
             }
         }
@@ -307,6 +313,13 @@ async fn collect(
         }
         // Nobody subscribed is the normal case, and not an error.
         let _ = stream.send(event);
+    }
+
+    // The daemon is stopping; queued lines still have to reach the disk.
+    if let Some(sink) = sink {
+        if let Some(problem) = sink.shutdown().await {
+            tracing::warn!("{problem}");
+        }
     }
 }
 

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -134,23 +134,49 @@ impl Session {
     }
 }
 
-/// Restrict the freshly bound socket to its owner.
+/// Bind the project socket so that it is unreachable by anyone else from the
+/// moment it exists.
 ///
 /// Connecting to a Unix socket needs write permission on the socket file, and
 /// a client that can connect can start, stop and restart every service in the
 /// project.  `bind` applies the process umask, which is 022 on most systems but
 /// 002 on distributions that give each user a private group — there the whole
-/// group would be able to drive the daemon.  Setting the mode explicitly means
-/// the guarantee does not depend on how the operator's shell was configured.
+/// group would be able to drive the daemon.
 ///
-/// A project socket may also land in the shared temp directory when the path
-/// next to the config would exceed the socket length limit, which makes this
-/// matter more, not less.
-fn restrict_socket(socket: &Path) -> Result<(), String> {
+/// Restricting the mode after `bind` is not enough: between the two calls the
+/// socket is live and group-writable, and whoever wins that race gets full
+/// start/stop/shutdown authority.  The invariant this function keeps is
+/// therefore stronger than "ends up 0600": **the socket is never reachable by
+/// anyone but its owner, not even for an instant.**  A umask around `bind`
+/// is what buys that, because the mode is applied when the inode is created.
+///
+/// The bind is deliberately synchronous and happens before the async runtime
+/// exists: the umask is process-global, so it must not be visible to any other
+/// thread creating a file.  `set_permissions` afterwards is not the mechanism
+/// but a check, for a platform that might ignore the umask for sockets.
+fn bind_socket(socket: &Path) -> Result<std::os::unix::net::UnixListener, String> {
+    use nix::sys::stat::{umask, Mode};
     use std::os::unix::fs::PermissionsExt;
 
-    std::fs::set_permissions(socket, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| format!("could not restrict {} to its owner: {e}", socket.display()))
+    // 0o177 masks away every bit but the owner's read and write.
+    let previous = umask(Mode::from_bits_truncate(0o177));
+    let bound = std::os::unix::net::UnixListener::bind(socket);
+    umask(previous);
+
+    let listener = bound.map_err(|e| format!("could not listen on {}: {e}", socket.display()))?;
+
+    let mode = std::fs::metadata(socket)
+        .map(|meta| meta.permissions().mode() & 0o777)
+        .unwrap_or(0);
+    if mode != 0o600 {
+        std::fs::set_permissions(socket, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("could not restrict {} to its owner: {e}", socket.display()))?;
+    }
+
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("could not prepare {}: {e}", socket.display()))?;
+    Ok(listener)
 }
 
 /// Run the daemon in this process until the stack stops or shutdown is
@@ -200,6 +226,10 @@ pub fn serve(
     // A socket file always survives its daemon, and the lock proves ours is
     // gone, so a leftover here is stale.
     let _ = std::fs::remove_file(&paths.socket);
+    // Bound before the runtime exists: the umask that keeps the socket private
+    // is process-global, so no other thread may be creating files while it is
+    // in effect.
+    let bound = bind_socket(&paths.socket)?;
 
     let registry = Arc::new(Mutex::new(StatusRegistry::new(plan.iter().map(|name| {
         let has_health = cfg
@@ -225,9 +255,8 @@ pub fn serve(
         .map_err(|e| format!("failed to start the async runtime: {e}"))?;
 
     let result = runtime.block_on(async {
-        let listener = UnixListener::bind(&paths.socket)
+        let listener = UnixListener::from_std(bound)
             .map_err(|e| format!("could not listen on {}: {e}", paths.socket.display()))?;
-        restrict_socket(&paths.socket)?;
 
         // One channel drives shutdown, whether it was asked for by a signal or
         // over the socket.

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -684,8 +684,15 @@ async fn handle_client(stream: UnixStream, session: Arc<Session>) {
                 continue;
             }
         };
-        // A client that talks sense has nothing held against it.
-        strikes = 0;
+        // A client that talks sense has nothing held against it.  A request
+        // this daemon has no name for is not quite that: it decodes now, which
+        // is what makes the wildcard arm in `respond` reachable from a socket at
+        // all, but it is as good a sign of a broken or probing client as a
+        // malformed line — so it is answered properly and still counted.
+        let unusable = matches!(request, Request::Unknown);
+        if !unusable {
+            strikes = 0;
+        }
 
         // Subscribing turns the connection one-way: the client stops asking
         // and only reads until it goes away.
@@ -703,20 +710,20 @@ async fn handle_client(stream: UnixStream, session: Arc<Session>) {
         if !write(&mut write_half, &response).await {
             return;
         }
+        if unusable && !struck_out(&mut strikes) {
+            return;
+        }
     }
 }
 
 /// Answer a malformed line and count it against the connection.
 ///
-/// Returns whether the connection should carry on.  A client that cannot form a
-/// request is either broken or probing; either way, three tries is enough
-/// courtesy, and closing beats letting garbage be pumped in forever.
+/// Returns whether the connection should carry on.
 async fn strike(
     strikes: &mut u32,
     sink: &mut tokio::net::unix::OwnedWriteHalf,
     message: &str,
 ) -> bool {
-    *strikes += 1;
     let alive = write(
         sink,
         &Response::Error {
@@ -727,10 +734,21 @@ async fn strike(
     if !alive {
         return false;
     }
+    struck_out(strikes)
+}
+
+/// Count one request the daemon could not act on against the connection,
+/// reporting whether it should carry on.
+///
+/// A client that cannot form a request this daemon understands is either broken
+/// or probing; either way, three tries is enough courtesy, and closing beats
+/// letting garbage be pumped in forever.
+fn struck_out(strikes: &mut u32) -> bool {
+    *strikes += 1;
     if *strikes >= MAX_MALFORMED {
         tracing::warn!(
             strikes = *strikes,
-            "closing a connection that keeps sending malformed requests"
+            "closing a connection that keeps sending requests this daemon cannot act on"
         );
         return false;
     }
@@ -801,10 +819,27 @@ async fn stream_events(
 
 async fn respond(request: Request, session: &Session) -> Response {
     match request {
-        Request::Ping => Response::Pong {
-            project: session.project.clone(),
-            pid: std::process::id(),
-        },
+        Request::Ping { version } => {
+            if let Some(theirs) = version {
+                if theirs < servicrab_protocol::PROTOCOL_VERSION {
+                    // Said once per ping and only downwards: a newer client
+                    // talking to us is the case we cannot help with from here,
+                    // and it hears about it from its own side.  An operator
+                    // chasing a command that behaved oddly is already reading
+                    // this log, which is why it goes here and not to the socket.
+                    tracing::info!(
+                        client = theirs,
+                        daemon = servicrab_protocol::PROTOCOL_VERSION,
+                        "a client is speaking an older revision of the protocol"
+                    );
+                }
+            }
+            Response::Pong {
+                project: session.project.clone(),
+                pid: std::process::id(),
+                version: Some(servicrab_protocol::PROTOCOL_VERSION),
+            }
+        }
         Request::Status => {
             let Ok(registry) = session.registry.lock() else {
                 return Response::Error {
@@ -857,8 +892,9 @@ async fn respond(request: Request, session: &Session) -> Response {
             response
         }
         Request::Reload => reload(session).await,
-        // `Request` is `#[non_exhaustive]`, so an older daemon can still be
-        // asked something it does not know about.
+        // Reached by a client newer than this daemon: an unrecognised request
+        // decodes to `Request::Unknown` rather than failing, so this says which
+        // side is behind instead of "malformed message: unknown variant".
         _ => Response::Error {
             message: "this daemon does not support that request".to_string(),
         },

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -304,7 +304,7 @@ async fn collect(
 
     while let Some(event) = events.recv().await {
         if let (Some(sink), EventKind::Log { line, .. }) = (sink.as_ref(), &event.kind) {
-            if let Some(problem) = sink.record(&event.service, line).await {
+            if let Some(problem) = sink.record(&event.service, line) {
                 tracing::warn!("{problem}");
             }
         }

--- a/crates/servicrab-cli/src/daemon/server.rs
+++ b/crates/servicrab-cli/src/daemon/server.rs
@@ -705,7 +705,7 @@ async fn handle_client(stream: UnixStream, session: Arc<Session>) {
             return;
         }
 
-        let response = respond(request, &session).await;
+        let response = respond(request, servicrab_protocol::frame::tag(line), &session).await;
 
         if !write(&mut write_half, &response).await {
             return;
@@ -817,7 +817,37 @@ async fn stream_events(
     }
 }
 
-async fn respond(request: Request, session: &Session) -> Response {
+/// Refuse a request this daemon has no variant for, saying which one and what
+/// it could have asked for instead.
+///
+/// The list is generated from [`Request::SUPPORTED`], which the protocol crate
+/// keeps in step with the enum by a test that fails to compile when a variant is
+/// added without it.  So this is not a hand-maintained list that can rot into a
+/// lie — which is the only reason it is worth printing: a client author reading
+/// a refusal is exactly the person who needs it, and it is what serde's own
+/// `expected one of …` gave them for free before an unknown request stopped
+/// being a decode error.
+///
+/// A line with no usable `type` falls back to the old wording.  It should be
+/// unreachable — decoding got as far as `Request::Unknown`, which means the line
+/// was a JSON object with a `type` — but a message is not the place to insist on
+/// that.
+fn unsupported(named: Option<&str>) -> String {
+    let supported = Request::SUPPORTED.join(", ");
+    match named {
+        Some(tag) => {
+            format!("this daemon does not support the request {tag:?}; it supports: {supported}")
+        }
+        None => format!("this daemon does not support that request; it supports: {supported}"),
+    }
+}
+
+/// Answer one request.
+///
+/// `named` is the `type` the line claimed to be, which is only consulted for a
+/// request this daemon has no variant for: `#[serde(other)]` needs a unit
+/// variant, so [`Request::Unknown`] cannot carry the tag itself.
+async fn respond(request: Request, named: Option<String>, session: &Session) -> Response {
     match request {
         Request::Ping { version } => {
             if let Some(theirs) = version {
@@ -893,10 +923,18 @@ async fn respond(request: Request, session: &Session) -> Response {
         }
         Request::Reload => reload(session).await,
         // Reached by a client newer than this daemon: an unrecognised request
-        // decodes to `Request::Unknown` rather than failing, so this says which
-        // side is behind instead of "malformed message: unknown variant".
+        // decodes to `Request::Unknown` rather than failing, which is what lets
+        // this be answered at all — but the fallback is a unit variant and cannot
+        // carry the tag, so the name comes from the line instead.
+        //
+        // Naming it matters more for the common case than for the forward-
+        // compatible one.  A genuinely newer client knows what it asked for; a
+        // typo or a half-written client does not, and before an unknown request
+        // decoded, serde's `unknown variant "strat", expected one of …` told
+        // whoever sent it both things.  Losing that to gain the forward
+        // compatibility would have been a bad trade in a frozen contract.
         _ => Response::Error {
-            message: "this daemon does not support that request".to_string(),
+            message: unsupported(named.as_deref()),
         },
     }
 }

--- a/crates/servicrab-cli/src/daemon/signals.rs
+++ b/crates/servicrab-cli/src/daemon/signals.rs
@@ -111,6 +111,13 @@ pub fn arrived() -> Option<ShutdownReason> {
 mod tests {
     use super::*;
 
+    /// `EARLY` is process-global, so the tests that write it cannot run
+    /// concurrently: cargo runs them on threads of one process, and without this
+    /// they race — measured at 6 failures in 150 runs before it was added.
+    /// A plain mutex rather than `--test-threads=1`, which would slow every other
+    /// test in the binary down to serial.
+    static EARLY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// The claim has to survive being made twice: `serve` runs once per process,
     /// but the unit tests share one.
     #[test]
@@ -128,6 +135,7 @@ mod tests {
     /// process would be killed by the default disposition.
     #[test]
     fn a_signal_in_the_window_is_recorded_rather_than_fatal() {
+        let _guard = EARLY_LOCK.lock().expect("lock");
         claim().expect("claim");
         EARLY.store(0, Ordering::SeqCst);
         assert_eq!(arrived(), None, "nothing has been signalled yet");
@@ -140,6 +148,7 @@ mod tests {
 
     #[test]
     fn each_claimed_signal_maps_to_its_shutdown_reason() {
+        let _guard = EARLY_LOCK.lock().expect("lock");
         for (signal, expected) in [
             (Signal::SIGINT, ShutdownReason::UserInterrupt),
             (Signal::SIGTERM, ShutdownReason::Terminated),

--- a/crates/servicrab-cli/src/daemon/signals.rs
+++ b/crates/servicrab-cli/src/daemon/signals.rs
@@ -1,0 +1,153 @@
+//! Signal handling for the window before the async runtime exists.
+//!
+//! Two requirements in [`super::server::serve`] point in opposite directions.
+//!
+//! * [`servicrab_core::SignalWatcher`] needs a tokio runtime: it builds its
+//!   `Signal` streams from the runtime's signal driver and spawns a task to read
+//!   them.  It cannot be installed before the runtime is built.
+//! * `bind_socket` must run *before* the runtime is built.  The umask that keeps
+//!   the socket private from the instant it exists is process-global, so no other
+//!   thread may be creating a file while it is in effect.
+//!
+//! So the socket — and with it the whole start/stop/shutdown authority of the
+//! project — becomes reachable while SIGTERM, SIGINT and SIGHUP still have their
+//! default disposition, which is to end the process outright.  A signal in that
+//! window took the daemon down with no graceful shutdown and left the socket file
+//! on disk for the next `start` to trip over.
+//!
+//! The handler cannot be moved earlier, but the *disposition* can.  This module
+//! claims those three signals before anything of ours exists, with a handler that
+//! only records which one arrived.  The process survives, the operator's request
+//! is remembered, and [`arrived`] hands it to the real watcher as soon as the
+//! runtime is up.
+//!
+//! Blocking the signals with `pthread_sigmask` instead looks tidier — the kernel
+//! remembers a pending signal for us and no handler is needed.  It is wrong here:
+//! the mask has to be set before the runtime starts its threads (otherwise a
+//! signal is simply delivered to a worker thread that does not block it), those
+//! threads inherit it, and on this platform a spawned process inherits it too.
+//! Supervised services would come up with SIGTERM blocked and could then only be
+//! stopped with SIGKILL.  Measured, not assumed.
+
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal};
+use servicrab_core::ShutdownReason;
+
+/// The signals whose default disposition ends the process, and which therefore
+/// have to be claimed before the daemon is reachable.
+///
+/// SIGHUP is here for the same reason it is in the real watcher: closing a
+/// terminal must not kill a supervisor and orphan every process group it owns.
+const CLAIMED: [Signal; 3] = [Signal::SIGINT, Signal::SIGTERM, Signal::SIGHUP];
+
+/// The signal number that arrived before the runtime was ready, or zero.
+///
+/// A plain integer rather than a channel or a lock: this is written from a signal
+/// handler, where almost nothing is safe to call.
+static EARLY: AtomicI32 = AtomicI32::new(0);
+
+/// Record the first signal to arrive and return.
+///
+/// Async-signal-safe by construction: one lock-free compare-and-exchange on an
+/// `i32` and no other work at all — no allocation, no locks, no `write(2)`.
+///
+/// The first signal wins.  A second one means "stop waiting", which is a
+/// judgement only the real watcher can act on, and by the time anybody could
+/// send one the watcher is normally already installed.
+extern "C" fn record(signum: i32) {
+    let _ = EARLY.compare_exchange(0, signum, Ordering::SeqCst, Ordering::SeqCst);
+}
+
+/// Take over SIGINT, SIGTERM and SIGHUP so that they stop being fatal.
+///
+/// Call this before anything makes the daemon observable — before the pidfile is
+/// created and long before the socket is bound.  Once the real watcher is
+/// installed it registers its own handler on top; ours stays harmlessly in the
+/// chain, storing into an integer nobody reads any more.
+///
+/// The disposition is process-wide rather than per-thread, and `execve` resets a
+/// caught signal to its default, so nothing here is inherited by a supervised
+/// service.
+pub fn claim() -> Result<(), String> {
+    // `SA_RESTART` so that an interrupted syscall in the startup path — the
+    // `flock`, the `bind` — resumes instead of failing with `EINTR`.
+    let action = SigAction::new(
+        SigHandler::Handler(record),
+        SaFlags::SA_RESTART,
+        SigSet::empty(),
+    );
+    for signal in CLAIMED {
+        // SAFETY: `record` does one atomic store and nothing else, which is
+        // permitted in a signal handler.  `sigaction` is unsafe only because the
+        // handler it installs could do something that is not.
+        unsafe { nix::sys::signal::sigaction(signal, &action) }.map_err(|errno| {
+            format!(
+                "could not take over {} before the daemon becomes reachable: {errno}",
+                signal.as_str()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// The shutdown that was asked for before the runtime existed, if there was one.
+///
+/// Call this once the real watcher is installed, so that no signal can fall
+/// between the two: anything earlier is in [`EARLY`], anything later is the
+/// watcher's.
+pub fn arrived() -> Option<ShutdownReason> {
+    match EARLY.load(Ordering::SeqCst) {
+        0 => None,
+        signum if signum == Signal::SIGINT as i32 => Some(ShutdownReason::UserInterrupt),
+        signum if signum == Signal::SIGHUP as i32 => Some(ShutdownReason::HangUp),
+        // SIGTERM, and any signal we did not claim but somehow ran our handler:
+        // being asked to terminate is the safe reading of an unexpected one.
+        _ => Some(ShutdownReason::Terminated),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The claim has to survive being made twice: `serve` runs once per process,
+    /// but the unit tests share one.
+    #[test]
+    fn claiming_the_signals_reports_success() {
+        claim().expect("claim");
+        claim().expect("claim again");
+    }
+
+    /// The heart of the fix: a signal that arrives in the window is *remembered*
+    /// rather than being fatal or being dropped.  `raise` is thread-directed, so
+    /// this only exercises the calling thread's disposition — which is
+    /// process-wide, and is exactly what the daemon relies on.
+    ///
+    /// If the claim did not work, this test would not fail: the whole test
+    /// process would be killed by the default disposition.
+    #[test]
+    fn a_signal_in_the_window_is_recorded_rather_than_fatal() {
+        claim().expect("claim");
+        EARLY.store(0, Ordering::SeqCst);
+        assert_eq!(arrived(), None, "nothing has been signalled yet");
+
+        nix::sys::signal::raise(Signal::SIGTERM).expect("raise");
+
+        assert_eq!(arrived(), Some(ShutdownReason::Terminated));
+        EARLY.store(0, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn each_claimed_signal_maps_to_its_shutdown_reason() {
+        for (signal, expected) in [
+            (Signal::SIGINT, ShutdownReason::UserInterrupt),
+            (Signal::SIGTERM, ShutdownReason::Terminated),
+            (Signal::SIGHUP, ShutdownReason::HangUp),
+        ] {
+            EARLY.store(signal as i32, Ordering::SeqCst);
+            assert_eq!(arrived(), Some(expected), "{}", signal.as_str());
+        }
+        EARLY.store(0, Ordering::SeqCst);
+    }
+}

--- a/crates/servicrab-cli/src/daemon/stopped.rs
+++ b/crates/servicrab-cli/src/daemon/stopped.rs
@@ -5,14 +5,45 @@
 //! started: a hand-stopped service is never restarted under any policy, but
 //! only this one survives `servicrab down` followed by `servicrab start`.
 //!
-//! The file is a plain list of names, one per line, next to the daemon's socket
-//! and log — small enough to read and edit when a stack ends up in a state
-//! nobody wanted.  The daemon is its only writer.
+//! The file is a version line followed by a plain list of names, one per line,
+//! next to the daemon's socket and log — small enough to read and edit when a
+//! stack ends up in a state nobody wanted.  Deleting a line is a legitimate way
+//! to forget a stop, so the format has to stay hand-editable: the version line
+//! is optional on reading, and a file without one is read as a bare list, which
+//! is exactly what earlier versions wrote.
+//!
+//! One daemon at a time is the only writer, which the pidfile lock now
+//! guarantees.  Within that daemon the writes come from per-connection tasks,
+//! so two concurrent `stop`s can interleave — a read-modify-write would lose
+//! one of them.  A mutex serialises them, and the write goes to a temporary file
+//! that is renamed into place, so a crash mid-write cannot leave a truncated
+//! file that silently means "nothing was ever stopped".
 
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use servicrab_core::{with_dependents, Config, RestartPolicy, ServiceName};
+
+/// The format marker written at the top of the file.
+///
+/// It exists so the format can change later without a daemon having to guess
+/// what it is looking at.  A file without it is version 0 — a bare list — which
+/// is what 0.3 and earlier wrote and what a hand edit that removes the line
+/// leaves behind.
+const VERSION_LINE: &str = "# servicrab stopped v1";
+
+/// Serialises the read-modify-write.
+///
+/// The writes come from per-connection tasks inside one daemon, so a lock in
+/// the process is enough; across processes the pidfile lock already guarantees
+/// a single writer.  A poisoned mutex is recovered from rather than propagated:
+/// losing the memory of a stop is a smaller problem than refusing to record the
+/// next one.
+static WRITING: Mutex<()> = Mutex::new(());
+
+/// Distinguishes the temporary files two writes could otherwise share.
+static NEXT_TEMP: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Read the remembered set.
 ///
@@ -23,34 +54,151 @@ pub fn read(path: &Path) -> BTreeSet<String> {
     let Ok(text) = std::fs::read_to_string(path) else {
         return BTreeSet::new();
     };
+    parse(&text)
+}
+
+/// Split the file into names, ignoring the version line and any other comment.
+fn parse(text: &str) -> BTreeSet<String> {
     text.lines()
         .map(str::trim)
-        .filter(|line| !line.is_empty())
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .map(ToString::to_string)
         .collect()
+}
+
+/// Render a set as the file's contents.
+fn render(names: &BTreeSet<String>) -> String {
+    let mut text = String::from(VERSION_LINE);
+    text.push('\n');
+    for name in names {
+        text.push_str(name);
+        text.push('\n');
+    }
+    text
 }
 
 /// Record whether `service` is currently stopped by hand.
 ///
 /// Read-modify-write on every change rather than a set held in memory: the file
-/// is the state, so a hand edit is picked up and two daemons for one project —
-/// which the socket already prevents — could not silently disagree.
+/// is the state, so a hand edit is picked up.  [`WRITING`] is what makes the
+/// sequence atomic against the other connection tasks in this daemon.
+///
+/// This blocks on a mutex and does synchronous file I/O, so async callers have
+/// to reach it through [`record_blocking`].
 pub fn record(path: &Path, service: &str, stopped: bool) -> Result<(), String> {
+    let _guard = WRITING
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
     let mut names = read(path);
     let changed = if stopped {
         names.insert(service.to_string())
     } else {
         names.remove(service)
     };
+    // Forgetting a name that was never there must not create the file.
     if !changed {
         return Ok(());
     }
 
-    let mut text = names.into_iter().collect::<Vec<_>>().join("\n");
-    if !text.is_empty() {
-        text.push('\n');
+    write_atomically(path, &render(&names))
+}
+
+/// [`record`], moved off the async runtime.
+///
+/// The work is a lock plus three filesystem calls; on a busy or networked
+/// filesystem that is long enough to stall a worker thread that is also
+/// supervising processes.
+pub async fn record_blocking(path: PathBuf, service: String, stopped: bool) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || record(&path, &service, stopped))
+        .await
+        .map_err(|e| format!("could not record the stop: {e}"))?
+}
+
+/// Replace `path`'s contents in a way that cannot be observed half-written.
+///
+/// `std::fs::write` truncates first, so a crash between the truncate and the
+/// write leaves an empty file — which reads back as "nothing was ever stopped",
+/// silently undoing every stop the operator asked for.  A temporary file
+/// renamed into place is either entirely the old contents or entirely the new
+/// ones, because `rename` within a directory is atomic.
+fn write_atomically(path: &Path, contents: &str) -> Result<(), String> {
+    use std::io::Write;
+
+    let directory = path.parent().unwrap_or_else(|| Path::new("."));
+    // Unique per write, not merely per process: [`WRITING`] serialises the
+    // writers inside this daemon, but a temporary name that two of them could
+    // share would make the invariant depend on that lock rather than stand on
+    // its own.
+    let temporary = path.with_file_name(format!(
+        ".{}.{}.{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("stopped"),
+        std::process::id(),
+        NEXT_TEMP.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+
+    // The temporary file has to be in the same directory as its destination:
+    // `rename` is only atomic within one filesystem.
+    let outcome = (|| -> std::io::Result<()> {
+        let mut file = std::fs::File::create(&temporary)?;
+        file.write_all(contents.as_bytes())?;
+        // Without this the rename can land before the contents do, and a
+        // machine that loses power in between finds an empty file under the
+        // real name — the very thing the rename was meant to prevent.
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temporary, path)
+    })();
+
+    if let Err(problem) = outcome {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(format!(
+            "could not write {} (via {}): {problem}",
+            path.display(),
+            directory.display()
+        ));
     }
-    std::fs::write(path, text).map_err(|e| format!("could not write {}: {e}", path.display()))
+    Ok(())
+}
+
+/// Forget every remembered name the configuration no longer declares.
+///
+/// The file only ever grew: every stop was recorded, while [`held_back`] only
+/// ever consults the `unless-stopped` services, so a renamed or deleted service
+/// left its name behind for good.  Reconciling at startup — where the daemon has
+/// just read the configuration and no request can be in flight — keeps the file
+/// as small as the project.
+///
+/// Names are compared against every service in the configuration rather than
+/// against the started plan, because a profile that is not active this time is
+/// not a service that is gone.
+pub fn reconcile(path: &Path, config: &Config) -> Result<BTreeSet<String>, String> {
+    let remembered = read(path);
+    if remembered.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+
+    let known: BTreeSet<&str> = config.services.keys().map(ServiceName::as_str).collect();
+    let (kept, dropped): (BTreeSet<String>, BTreeSet<String>) = remembered
+        .into_iter()
+        .partition(|name| known.contains(name.as_str()));
+
+    if !dropped.is_empty() {
+        let _guard = WRITING
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if kept.is_empty() {
+            // An empty file and no file mean the same thing; removing it is
+            // tidier and matches what an operator would do by hand.
+            std::fs::remove_file(path)
+                .map_err(|e| format!("could not remove {}: {e}", path.display()))?;
+        } else {
+            write_atomically(path, &render(&kept))?;
+        }
+    }
+    Ok(dropped)
 }
 
 /// The planned services that must not be started, given what is remembered.
@@ -140,6 +288,140 @@ restart = "always"
         assert_eq!(read(&path), set(&["db"]));
     }
 
+    /// The exact bytes on disk, because a human may have to read or edit them.
+    ///
+    /// The version line lets the format change later without a daemon having to
+    /// guess what it is looking at; everything below it is still one name per
+    /// line, so deleting a line remains a legitimate way to forget a stop.
+    #[test]
+    fn the_file_is_a_version_line_and_then_names() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("stopped");
+
+        record(&path, "api", true).expect("record");
+        record(&path, "db", true).expect("record");
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            "# servicrab stopped v1\napi\ndb\n"
+        );
+    }
+
+    /// A file written by 0.3 has no version line, and neither does one an
+    /// operator edited it out of.  Both have to keep working.
+    #[test]
+    fn a_file_without_a_version_line_is_still_read() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("stopped");
+        std::fs::write(&path, "api\ndb\n").expect("write");
+
+        assert_eq!(read(&path), set(&["api", "db"]));
+
+        // And the next write brings it up to date without losing anything.
+        record(&path, "cache", true).expect("record");
+        assert_eq!(read(&path), set(&["api", "cache", "db"]));
+        assert!(std::fs::read_to_string(&path)
+            .expect("read")
+            .starts_with(VERSION_LINE));
+    }
+
+    /// Deleting a name by hand is how an operator forgets a stop.
+    #[test]
+    fn a_hand_edited_file_is_honoured() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("stopped");
+        record(&path, "api", true).expect("record");
+        record(&path, "db", true).expect("record");
+
+        let edited = std::fs::read_to_string(&path)
+            .expect("read")
+            .lines()
+            .filter(|line| *line != "api")
+            .map(|line| format!("{line}\n"))
+            .collect::<String>();
+        std::fs::write(&path, edited).expect("write");
+
+        assert_eq!(read(&path), set(&["db"]));
+    }
+
+    /// Two `stop`s at once come from two connection tasks, and a
+    /// read-modify-write would lose one of them.
+    #[test]
+    fn concurrent_records_do_not_lose_each_other() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("stopped");
+
+        let names: Vec<String> = (0..32).map(|n| format!("svc-{n:02}")).collect();
+        std::thread::scope(|scope| {
+            for name in &names {
+                let path = path.clone();
+                scope.spawn(move || record(&path, name, true).expect("record"));
+            }
+        });
+
+        let remembered = read(&path);
+        assert_eq!(
+            remembered.len(),
+            names.len(),
+            "an update was lost: {remembered:?}"
+        );
+        for name in &names {
+            assert!(remembered.contains(name), "{name} was lost");
+        }
+    }
+
+    /// Interleaved stops and starts must leave the file agreeing with the last
+    /// decision about each service, not with whichever writer finished last.
+    #[test]
+    fn concurrent_stops_and_starts_each_land() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("stopped");
+        for n in 0..16 {
+            record(&path, &format!("svc-{n:02}"), true).expect("record");
+        }
+
+        // Forget the even ones and remember sixteen more, all at once.
+        std::thread::scope(|scope| {
+            for n in 0..16 {
+                let path = path.clone();
+                scope.spawn(move || {
+                    if n % 2 == 0 {
+                        record(&path, &format!("svc-{n:02}"), false).expect("record");
+                    }
+                    record(&path, &format!("extra-{n:02}"), true).expect("record");
+                });
+            }
+        });
+
+        let remembered = read(&path);
+        for n in 0..16 {
+            let name = format!("svc-{n:02}");
+            assert_eq!(
+                remembered.contains(&name),
+                n % 2 != 0,
+                "{name} is wrong in {remembered:?}"
+            );
+            assert!(remembered.contains(&format!("extra-{n:02}")));
+        }
+    }
+
+    /// A crash between truncate and write used to leave an empty file, which
+    /// reads back as "nothing was ever stopped".  The temporary file it goes
+    /// through must not be left behind either.
+    #[test]
+    fn a_write_leaves_no_debris() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("stopped");
+        record(&path, "api", true).expect("record");
+
+        let entries: Vec<String> = std::fs::read_dir(dir.path())
+            .expect("read dir")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(entries, vec!["stopped".to_string()], "{entries:?}");
+    }
+
     #[test]
     fn recording_the_same_state_twice_is_a_no_op() {
         let dir = TempDir::new().expect("temp dir");
@@ -161,6 +443,56 @@ restart = "always"
         let path = dir.path().join("stopped");
         std::fs::write(&path, "api\n\n  db  \n\n").expect("write");
         assert_eq!(read(&path), set(&["api", "db"]));
+    }
+
+    /// The file only ever grew: every stop was recorded, while `held_back` only
+    /// consults the `unless-stopped` services, so a renamed or deleted service
+    /// left its name behind for good.
+    #[test]
+    fn reconciliation_forgets_services_the_config_no_longer_declares() {
+        let (dir, config, _plan) = config_with(STACK);
+        let path = dir.path().join("stopped");
+        for name in ["db", "gone", "renamed"] {
+            record(&path, name, true).expect("record");
+        }
+
+        let dropped = reconcile(&path, &config).expect("reconcile");
+
+        assert_eq!(dropped, set(&["gone", "renamed"]));
+        assert_eq!(read(&path), set(&["db"]));
+    }
+
+    /// A service left out of this run's profiles is not a service that is gone.
+    #[test]
+    fn reconciliation_keeps_a_service_that_is_merely_not_planned() {
+        let (dir, config, _plan) = config_with(STACK);
+        let path = dir.path().join("stopped");
+        record(&path, "cache", true).expect("record");
+
+        assert!(reconcile(&path, &config).expect("reconcile").is_empty());
+        assert_eq!(read(&path), set(&["cache"]));
+    }
+
+    #[test]
+    fn reconciliation_removes_a_file_with_nothing_left_in_it() {
+        let (dir, config, _plan) = config_with(STACK);
+        let path = dir.path().join("stopped");
+        record(&path, "gone", true).expect("record");
+
+        assert_eq!(
+            reconcile(&path, &config).expect("reconcile"),
+            set(&["gone"])
+        );
+        assert!(!path.exists(), "an empty file should have been removed");
+    }
+
+    #[test]
+    fn reconciling_an_absent_file_does_nothing() {
+        let (dir, config, _plan) = config_with(STACK);
+        let path = dir.path().join("stopped");
+
+        assert!(reconcile(&path, &config).expect("reconcile").is_empty());
+        assert!(!path.exists());
     }
 
     #[test]

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -67,6 +67,20 @@ fn parse_duration(text: &str) -> Result<std::time::Duration, String> {
     author
 )]
 struct Cli {
+    /// When to colour output: auto (a stream that is a terminal), always, never.
+    #[arg(
+        long,
+        value_name = "WHEN",
+        value_enum,
+        default_value = "auto",
+        global = true
+    )]
+    color: style::ColorChoice,
+
+    /// Never colour output; the same as --color=never.
+    #[arg(long, global = true, conflicts_with = "color")]
+    no_color: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -432,6 +446,14 @@ enum Commands {
 
 fn main() {
     let cli = Cli::parse();
+
+    // Recorded before anything is rendered, so every stream's colour decision
+    // sees the choice that was actually typed.
+    style::set_choice(if cli.no_color {
+        style::ColorChoice::Never
+    } else {
+        cli.color
+    });
 
     // `run` has no other progress output, so its lifecycle transitions are
     // logged by default.  `up` renders the same information from its event

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -24,6 +24,27 @@
 //! - `servicrab completions <SHELL>` — print a shell completion script
 //! - `servicrab man` — print the man page in roff
 
+// These two rustdoc lints are allowed for this crate only, and only because of
+// the clap derive.
+//
+// The doc comments on `Cli`, `Command` and their fields are not documentation in
+// the rustdoc sense: clap turns them verbatim into the `servicrab --help` text.
+// `servicrab run --help` prints "as defined in [services.<name>]" and
+// `servicrab watch --help` prints "declares a [watch] block" — so rustdoc sees
+// `[services.<name>]` as an unclosed `<name>` HTML tag and `[watch]` as a broken
+// intra-doc link, when both are literally the config syntax we want the user to
+// read.
+//
+// The v1.0 stability contract freezes the CLI help output, so the text cannot be
+// reworded to satisfy rustdoc's HTML pedantry. Narrowing the lint here is the
+// only resolution that leaves the user-facing string alone.
+//
+// This is deliberately *not* done for `servicrab-core` or `servicrab-protocol`:
+// there the doc comments really are documentation, intra-doc links really do
+// need to resolve, and both crates keep these lints at deny.
+#![allow(rustdoc::invalid_html_tags)]
+#![allow(rustdoc::broken_intra_doc_links)]
+
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 

--- a/crates/servicrab-cli/src/main.rs
+++ b/crates/servicrab-cli/src/main.rs
@@ -3,7 +3,8 @@
 //! ## Subcommands
 //!
 //! - `servicrab init [--path PATH] [--force]` — create example config
-//! - `servicrab check [--config PATH]` — validate config, print summary
+//! - `servicrab check [--config PATH] [--json]` — validate config, print
+//!   summary
 //! - `servicrab list [--config PATH] [--json]` — list services
 //! - `servicrab run <SERVICE> [--config PATH] [--no-restart]` — run one
 //!   service in the foreground (Linux/macOS)
@@ -50,6 +51,7 @@ use tracing_subscriber::EnvFilter;
 
 mod commands;
 mod daemon;
+mod output;
 mod style;
 mod wire;
 
@@ -92,6 +94,11 @@ enum Commands {
         /// servicrab.toml by walking up from the current directory.
         #[arg(long, short = 'c')]
         config: Option<std::path::PathBuf>,
+
+        /// Print machine-readable JSON instead of the human-readable report.
+        /// Validation errors become a JSON list.
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
 
     /// List all services defined in a servicrab.toml.
@@ -457,20 +464,24 @@ fn main() {
         .init();
 
     // Commands return the process exit code to use; `0` means success.
-    let result = match cli.command {
-        Commands::Init { path, force } => commands::init::run(&path, force).map(|()| 0),
-        Commands::Check { config } => commands::check::run(config.as_deref()).map(|()| 0),
+    let result: Result<i32, output::CliError> = match cli.command {
+        Commands::Init { path, force } => commands::init::run(&path, force)
+            .map(|()| 0)
+            .map_err(Into::into),
+        Commands::Check { config, json } => {
+            commands::check::run(config.as_deref(), json).map(|()| 0)
+        }
         Commands::List { config, json } => commands::list::run(config.as_deref(), json).map(|()| 0),
         Commands::Run {
             service,
             config,
             no_restart,
-        } => commands::run::run(&service, config.as_deref(), no_restart),
+        } => commands::run::run(&service, config.as_deref(), no_restart).map_err(Into::into),
         Commands::Exec {
             service,
             config,
             command,
-        } => commands::exec::run(&service, &command, config.as_deref()),
+        } => commands::exec::run(&service, &command, config.as_deref()).map_err(Into::into),
         Commands::Up {
             services,
             config,
@@ -583,9 +594,14 @@ fn main() {
                 user,
                 profiles,
             },
-        ),
-        Commands::Completions { shell } => commands::completions::run::<Cli>(shell).map(|()| 0),
-        Commands::Man { output } => commands::man::run::<Cli>(output.as_deref()).map(|()| 0),
+        )
+        .map_err(Into::into),
+        Commands::Completions { shell } => commands::completions::run::<Cli>(shell)
+            .map(|()| 0)
+            .map_err(Into::into),
+        Commands::Man { output } => commands::man::run::<Cli>(output.as_deref())
+            .map(|()| 0)
+            .map_err(Into::into),
         Commands::Logs {
             services,
             config,
@@ -601,15 +617,20 @@ fn main() {
                 no_prefix,
             },
         )
-        .map(|()| 0),
+        .map(|()| 0)
+        .map_err(Into::into),
     };
 
     match result {
         Ok(0) => {}
         Ok(code) => std::process::exit(code),
+        // Every error leaves by this one door: stderr, an `error: ` prefix, and
+        // the exit status the error itself carries.  Under `--json` the same
+        // error is a JSON object, still on stderr, so a caller parsing stdout
+        // sees only the document it asked for.
         Err(e) => {
-            eprintln!("error: {e}");
-            std::process::exit(1);
+            e.report();
+            std::process::exit(e.exit_code());
         }
     }
 }

--- a/crates/servicrab-cli/src/output.rs
+++ b/crates/servicrab-cli/src/output.rs
@@ -1,0 +1,281 @@
+//! The machine-readable half of the CLI's output: exit codes, JSON envelopes,
+//! and the one format errors are reported in.
+//!
+//! These shapes are a contract, so they live in one place rather than being
+//! spelled out again in every command.  Three rules hold everywhere:
+//!
+//! - every `--json` document carries a [`SCHEMA_VERSION`], so a script can
+//!   refuse a stream it was not written for instead of guessing;
+//! - every error is one `error: …` line on stderr, with its details as bullets
+//!   below it — never a bare message, never a `✗`, never on stdout;
+//! - under `--json` that error is a JSON object instead, still on stderr, so
+//!   stdout carries nothing but the document a caller asked for.
+
+use serde::Serialize;
+use servicrab_protocol::{ErrorCode, Response, SCHEMA_VERSION};
+
+/// The command failed.
+pub const EXIT_FAILURE: i32 = 1;
+
+/// No daemon is running for this project.
+///
+/// Its own code because "there is nothing to talk to" is the one failure a
+/// script routinely wants to handle rather than report: `down` on an already
+/// stopped stack, `status` in a health check, `stop` in a teardown that may run
+/// twice.  Telling that apart from a real failure used to mean matching on the
+/// message.
+pub const EXIT_NO_DAEMON: i32 = 3;
+
+/// Something that went wrong, together with how to report it.
+///
+/// Built from a `String` wherever a command has nothing more to say, so the
+/// ordinary `Err(format!(…))` and `?` paths keep working and only the errors
+/// that carry a code or an exit status of their own spell one out.
+#[derive(Debug, Clone)]
+pub struct CliError {
+    code: ErrorCode,
+    message: String,
+    errors: Vec<String>,
+    hint: Option<String>,
+    exit: i32,
+    json: bool,
+}
+
+impl CliError {
+    /// An error with a code for a script and a message for a person.
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            errors: Vec::new(),
+            hint: None,
+            exit: EXIT_FAILURE,
+            json: false,
+        }
+    }
+
+    /// The individual problems behind the message.
+    pub fn with_errors(mut self, errors: Vec<String>) -> Self {
+        self.errors = errors;
+        self
+    }
+
+    /// What to do about it, for a person reading the text form.
+    ///
+    /// Left out of the JSON document on purpose: advice is for the operator,
+    /// and a script that wants to act has `code` and `errors`.
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+
+    /// Report as JSON rather than as text, because the command was asked for
+    /// JSON.
+    pub fn in_json(mut self, json: bool) -> Self {
+        self.json = json;
+        self
+    }
+
+    /// Exit with this status instead of [`EXIT_FAILURE`].
+    pub fn with_exit(mut self, exit: i32) -> Self {
+        self.exit = exit;
+        self
+    }
+
+    /// The status the process should exit with.
+    pub fn exit_code(&self) -> i32 {
+        self.exit
+    }
+
+    /// Write the error out, in whichever of the two formats applies.
+    pub fn report(&self) {
+        if self.json {
+            let document = ErrorDocument {
+                schema_version: SCHEMA_VERSION,
+                error: ErrorBody {
+                    code: self.code.as_str(),
+                    message: &self.message,
+                    errors: &self.errors,
+                },
+            };
+            // A JSON error that cannot be rendered still has to reach the
+            // operator, and the text form always can.
+            match serde_json::to_string(&document) {
+                Ok(line) => eprintln!("{line}"),
+                Err(_) => self.report_as_text(),
+            }
+            return;
+        }
+        self.report_as_text();
+    }
+
+    fn report_as_text(&self) {
+        eprintln!("error: {}", self.message);
+        for problem in &self.errors {
+            eprintln!("  • {problem}");
+        }
+        if let Some(hint) = &self.hint {
+            let color = crate::style::color_enabled();
+            eprintln!(
+                "{}",
+                crate::style::paint(color, crate::style::DIM, &format!("  {hint}"))
+            );
+        }
+    }
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl From<String> for CliError {
+    fn from(message: String) -> Self {
+        CliError::new(ErrorCode::Failed, message)
+    }
+}
+
+impl From<&str> for CliError {
+    fn from(message: &str) -> Self {
+        CliError::new(ErrorCode::Failed, message)
+    }
+}
+
+/// The error a command reports when no daemon is listening.
+pub fn no_daemon(project: &str, json: bool) -> CliError {
+    CliError::new(
+        ErrorCode::NotRunning,
+        format!("no daemon is running for {project} — start one with `servicrab start`"),
+    )
+    .with_exit(EXIT_NO_DAEMON)
+    .in_json(json)
+}
+
+/// What every `--json` document looks like from the outside.
+#[derive(Serialize)]
+struct Document<T> {
+    schema_version: u32,
+    #[serde(flatten)]
+    payload: T,
+}
+
+#[derive(Serialize)]
+struct ErrorDocument<'a> {
+    schema_version: u32,
+    error: ErrorBody<'a>,
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    code: &'a str,
+    message: &'a str,
+    #[serde(skip_serializing_if = "<[String]>::is_empty")]
+    errors: &'a [String],
+}
+
+/// Print one `--json` document on stdout, wrapped in the envelope.
+///
+/// Pretty-printed, because these are whole documents a person also reads.  The
+/// event streams are the exception and are newline-delimited; see
+/// [`print_stream_header`].
+pub fn print_document<T: Serialize>(payload: T) -> Result<(), CliError> {
+    let document = Document {
+        schema_version: SCHEMA_VERSION,
+        payload,
+    };
+    let text = serde_json::to_string_pretty(&document)
+        .map_err(|e| CliError::new(ErrorCode::Failed, format!("could not render JSON: {e}")))?;
+    println!("{text}");
+    Ok(())
+}
+
+/// Open an NDJSON event stream with the same handshake line the daemon sends.
+///
+/// `up --json`, `watch --json` and `events --json` all emit the events the
+/// daemon streams, so they all announce the contract the same way: one `ok`
+/// line carrying the schema version, then one event per line.  Repeating the
+/// version on every event line would be noise in a stream that can run for
+/// days.
+pub fn print_stream_header() {
+    let hello = Response::Ok {
+        message: None,
+        changes: None,
+        schema_version: Some(SCHEMA_VERSION),
+    };
+    if let Ok(line) = servicrab_protocol::encode(&hello) {
+        use std::io::Write;
+        let mut out = std::io::stdout().lock();
+        let _ = out.write_all(line.as_bytes());
+        let _ = out.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_plain_message_becomes_an_unclassified_failure() {
+        let error = CliError::from("could not find config".to_string());
+
+        assert_eq!(error.exit_code(), EXIT_FAILURE);
+        assert_eq!(error.to_string(), "could not find config");
+    }
+
+    /// The dedicated code is the whole point: a teardown script has to be able
+    /// to tell "nothing was running" from "the command broke".
+    #[test]
+    fn an_absent_daemon_has_an_exit_code_of_its_own() {
+        let error = no_daemon("demo", false);
+
+        assert_eq!(error.exit_code(), EXIT_NO_DAEMON);
+        assert!(error.to_string().contains("no daemon is running for demo"));
+    }
+
+    #[test]
+    fn a_json_document_carries_the_schema_version() {
+        let document = Document {
+            schema_version: SCHEMA_VERSION,
+            payload: serde_json::json!({ "running": false, "services": [] }),
+        };
+
+        let json = serde_json::to_value(&document).expect("serialize");
+        assert_eq!(json["schema_version"], SCHEMA_VERSION);
+        assert_eq!(json["running"], false);
+    }
+
+    #[test]
+    fn a_json_error_carries_the_schema_version_and_the_code() {
+        let error = CliError::new(ErrorCode::ValidationFailed, "2 error(s)")
+            .with_errors(vec!["first".to_string(), "second".to_string()])
+            .in_json(true);
+        let document = ErrorDocument {
+            schema_version: SCHEMA_VERSION,
+            error: ErrorBody {
+                code: error.code.as_str(),
+                message: &error.message,
+                errors: &error.errors,
+            },
+        };
+
+        let json = serde_json::to_value(&document).expect("serialize");
+        assert_eq!(json["schema_version"], SCHEMA_VERSION);
+        assert_eq!(json["error"]["code"], "validation_failed");
+        assert_eq!(json["error"]["errors"].as_array().expect("a list").len(), 2);
+    }
+
+    /// The stream header is the daemon's own handshake line, so a reader can
+    /// treat a foreground `up --json` exactly like a subscription.
+    #[test]
+    fn the_stream_header_is_the_daemons_handshake_line() {
+        let hello = Response::Ok {
+            message: None,
+            changes: None,
+            schema_version: Some(SCHEMA_VERSION),
+        };
+
+        let line = servicrab_protocol::encode(&hello).expect("encode");
+        assert_eq!(line.trim_end(), r#"{"type":"ok","schema_version":1}"#);
+    }
+}

--- a/crates/servicrab-cli/src/style.rs
+++ b/crates/servicrab-cli/src/style.rs
@@ -4,8 +4,16 @@
 //! needs are easier to audit than another dependency.  Colour is disabled when
 //! the stream is not a terminal, when `NO_COLOR` is set, or when
 //! `TERM=dumb` — the usual conventions.
+//!
+//! The stream matters, and it is the one being written to: most of what
+//! servicrab renders is progress and diagnostics, which go to stderr, while a
+//! supervised service's stdout goes to stdout.  Deciding both from stdout's
+//! terminal-ness got it wrong in both directions — `servicrab up 2> stack.err`
+//! put escapes in the file, `servicrab up | cat` dropped the colour stderr was
+//! still entitled to — so every decision here names the stream it is about.
 
 use std::io::IsTerminal;
+use std::sync::OnceLock;
 
 /// Reset all attributes.
 pub const RESET: &str = "\x1b[0m";
@@ -31,15 +39,118 @@ pub const SERVICE_COLORS: [&str; 6] = [
     "\x1b[31m", // red
 ];
 
-/// Whether coloured output should be produced for stdout.
-pub fn color_enabled() -> bool {
-    if std::env::var_os("NO_COLOR").is_some() {
+/// Whether coloured output should be produced for `stream`.
+pub fn color_enabled_for(stream: Stream) -> bool {
+    decide(choice(), Environment::current(), stream.is_terminal())
+}
+
+/// Which stream a colour decision is being made about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stream {
+    /// Command output, and the stdout of supervised services.
+    Stdout,
+    /// Progress, status lines and diagnostics.
+    Stderr,
+}
+
+impl Stream {
+    fn is_terminal(self) -> bool {
+        match self {
+            Stream::Stdout => std::io::stdout().is_terminal(),
+            Stream::Stderr => std::io::stderr().is_terminal(),
+        }
+    }
+}
+
+/// What `--color` was set to.
+///
+/// `Auto` colours a stream when it is a terminal; `Always` colours both streams
+/// whatever they are; `Never` colours neither.
+///
+/// The variants carry no clap help of their own on purpose: per-value help
+/// switches every `--help` page to clap's long layout, and the v1.0 help output
+/// is a frozen contract.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum ColorChoice {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+/// The `--color` value for this process.
+///
+/// A command-line choice is one value for the whole run, and threading it
+/// through every renderer's constructor would put a parameter on code that has
+/// no other reason to know about it, so it is recorded once in [`set_choice`]
+/// and read from here.
+static CHOICE: OnceLock<ColorChoice> = OnceLock::new();
+
+/// Record what `--color` asked for, before any output is rendered.
+///
+/// Later calls are ignored: the choice is made once, on the command line.
+pub fn set_choice(choice: ColorChoice) {
+    let _ = CHOICE.set(choice);
+}
+
+fn choice() -> ColorChoice {
+    CHOICE.get().copied().unwrap_or_default()
+}
+
+/// The colour-related environment, sampled once per decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct Environment {
+    /// `NO_COLOR` is set, to anything at all.
+    no_color: bool,
+    /// `CLICOLOR_FORCE` is set to something other than `0`.
+    clicolor_force: bool,
+    /// `TERM` says the terminal cannot render escapes.
+    dumb_term: bool,
+}
+
+impl Environment {
+    fn current() -> Self {
+        Self {
+            no_color: std::env::var_os("NO_COLOR").is_some(),
+            clicolor_force: matches!(
+                std::env::var("CLICOLOR_FORCE").as_deref(),
+                Ok(value) if !value.is_empty() && value != "0"
+            ),
+            dumb_term: matches!(std::env::var("TERM").as_deref(), Ok("dumb")),
+        }
+    }
+}
+
+/// Resolve one colour decision from the choice, the environment and whether the
+/// stream is a terminal.
+///
+/// The order is what makes this predictable, and it runs from the most
+/// deliberate signal to the least:
+///
+/// - `--color` was typed on this command line, so it wins over everything.
+/// - `NO_COLOR` is a standing "no" from the operator's environment; nothing
+///   short of the flag overrides it, which also keeps it usable as the one
+///   switch a test or a build script can rely on.
+/// - `CLICOLOR_FORCE` answers only the terminal test — "colour this even though
+///   it is a pipe" — so it beats both remaining signals.
+/// - `TERM=dumb` is a terminal that cannot render escapes.
+/// - Otherwise: colour a terminal, leave a pipe or a file alone.
+fn decide(choice: ColorChoice, env: Environment, is_terminal: bool) -> bool {
+    match choice {
+        ColorChoice::Always => return true,
+        ColorChoice::Never => return false,
+        ColorChoice::Auto => {}
+    }
+    if env.no_color {
         return false;
     }
-    if matches!(std::env::var("TERM").as_deref(), Ok("dumb")) {
+    if env.clicolor_force {
+        return true;
+    }
+    if env.dumb_term {
         return false;
     }
-    std::io::stdout().is_terminal()
+    is_terminal
 }
 
 /// Wrap `text` in `code` when `enabled`, otherwise return it unchanged.
@@ -68,6 +179,67 @@ pub fn utc_hms(now: std::time::SystemTime) -> String {
 mod tests {
     use super::*;
     use std::time::{Duration, UNIX_EPOCH};
+
+    /// A `TERM` that renders escapes, no `NO_COLOR`, no `CLICOLOR_FORCE`.
+    fn plain() -> Environment {
+        Environment::default()
+    }
+
+    #[test]
+    fn a_terminal_is_coloured_and_a_pipe_is_not() {
+        assert!(decide(ColorChoice::Auto, plain(), true));
+        assert!(!decide(ColorChoice::Auto, plain(), false));
+    }
+
+    #[test]
+    fn the_flag_wins_over_the_environment_and_the_terminal() {
+        let hostile = Environment {
+            no_color: true,
+            dumb_term: true,
+            ..plain()
+        };
+        assert!(decide(ColorChoice::Always, hostile, false));
+
+        let inviting = Environment {
+            clicolor_force: true,
+            ..plain()
+        };
+        assert!(!decide(ColorChoice::Never, inviting, true));
+    }
+
+    #[test]
+    fn no_color_beats_clicolor_force() {
+        let env = Environment {
+            no_color: true,
+            clicolor_force: true,
+            ..plain()
+        };
+        assert!(!decide(ColorChoice::Auto, env, true));
+    }
+
+    #[test]
+    fn clicolor_force_colours_a_pipe() {
+        let env = Environment {
+            clicolor_force: true,
+            ..plain()
+        };
+        assert!(decide(ColorChoice::Auto, env, false));
+        // Even a dumb terminal, since forcing is the more specific request.
+        let dumb = Environment {
+            dumb_term: true,
+            ..env
+        };
+        assert!(decide(ColorChoice::Auto, dumb, false));
+    }
+
+    #[test]
+    fn a_dumb_terminal_is_left_alone() {
+        let env = Environment {
+            dumb_term: true,
+            ..plain()
+        };
+        assert!(!decide(ColorChoice::Auto, env, true));
+    }
 
     #[test]
     fn paint_is_a_no_op_when_disabled() {

--- a/crates/servicrab-cli/src/wire.rs
+++ b/crates/servicrab-cli/src/wire.rs
@@ -97,6 +97,8 @@ pub fn to_wire_status(status: &servicrab_core::ServiceStatus) -> servicrab_proto
     servicrab_protocol::ServiceInfo {
         name: status.name.to_string(),
         state: to_wire_state(status.state),
+        pgid: status.pid,
+        // The same number under the name every 0.x client reads.
         pid: status.pid,
         uptime_secs: status.uptime.map(|d| d.as_secs()),
         restarts: status.restarts,

--- a/crates/servicrab-cli/src/wire.rs
+++ b/crates/servicrab-cli/src/wire.rs
@@ -69,6 +69,7 @@ pub fn to_wire_event(kind: &EventKind) -> Event {
             message: message.clone(),
         },
         EventKind::WatchTruncated { limit } => Event::WatchTruncated { limit: *limit },
+        EventKind::LogLinesDropped { count } => Event::LogLinesDropped { count: *count },
         EventKind::Failed { message } => Event::Failed {
             message: message.clone(),
         },

--- a/crates/servicrab-cli/tests/cli.rs
+++ b/crates/servicrab-cli/tests/cli.rs
@@ -246,6 +246,62 @@ fn list_json_output() {
     assert_eq!(first["restart"].as_str().unwrap(), "never");
 }
 
+#[test]
+fn list_handles_a_command_with_multi_byte_characters() {
+    // The preview used to be sliced at byte 29, which falls inside the last
+    // '€' here: `list` died with "not a char boundary" and exit 101.
+    let toml = "version = 1\n[project]\nname = \"demo\"\n[services.api]\ncommand = [\"echo\", \"x€€€€€€€€€\"]\n";
+    let (_dir, path) = temp_dir_with_config(toml);
+
+    cmd()
+        .arg("list")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .success()
+        .stdout(contains("x€€€€€€€€€"));
+
+    let output = cmd()
+        .arg("list")
+        .arg("--config")
+        .arg(&path)
+        .arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8(output).unwrap()).expect("valid JSON");
+    assert_eq!(
+        json[0]["command"],
+        serde_json::json!(["echo", "x€€€€€€€€€"])
+    );
+}
+
+#[test]
+fn list_truncates_a_long_multi_byte_command_without_panicking() {
+    // Long enough that the preview has to cut, with the cut point inside a
+    // multi-byte character.
+    let arg = "€".repeat(40);
+    let toml = format!(
+        "version = 1\n[project]\nname = \"demo\"\n[services.api]\ncommand = [\"echo\", \"{arg}\"]\n"
+    );
+    let (_dir, path) = temp_dir_with_config(&toml);
+
+    // 29 characters of the command line, then the ellipsis.
+    let expected = format!("echo {}…", "€".repeat(24));
+    cmd()
+        .arg("list")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .success()
+        // Cut at a character boundary, so the ellipsis follows whole '€'s.
+        .stdout(contains(expected));
+}
+
 // ── profiles ───────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/servicrab-cli/tests/cli.rs
+++ b/crates/servicrab-cli/tests/cli.rs
@@ -678,6 +678,39 @@ fn the_man_page_has_the_hand_written_sections() {
     );
 }
 
+/// The exit codes are part of the frozen contract, and a code that is not
+/// documented is one nobody can rely on.  This used to cover only `exec` and
+/// `run`, and never mentioned the signal codes `up` and `watch` exit with.
+#[test]
+fn the_man_page_documents_every_exit_code_in_the_contract() {
+    let output = cmd()
+        .arg("man")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    let exit_status = text
+        .split(".SH EXIT STATUS")
+        .nth(1)
+        .expect("an EXIT STATUS section")
+        .split(".SH ")
+        .next()
+        .expect("the section body");
+
+    for code in ["0", "1", "3", "126", "127", "129", "130", "143"] {
+        assert!(
+            exit_status.contains(&format!("\\fB{code}\\fR")),
+            "EXIT STATUS should document {code}: {exit_status}"
+        );
+    }
+    // And the one error format, so the section says where errors go as well as
+    // what the process exits with.
+    assert!(exit_status.contains("error: "), "{exit_status}");
+    assert!(exit_status.contains("schema_version"), "{exit_status}");
+}
+
 // ── env_file ───────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/servicrab-cli/tests/cli.rs
+++ b/crates/servicrab-cli/tests/cli.rs
@@ -609,6 +609,43 @@ fn completions_reject_an_unknown_shell() {
     cmd().arg("completions").arg("tcsh").assert().failure();
 }
 
+/// A reader that is already gone: any write to it fails with `EPIPE`.
+///
+/// `servicrab man | head` only reaches that when the page outgrows the pipe
+/// buffer, which makes it a poor test; a read end closed before the process
+/// starts is the same condition without the race.
+#[cfg(unix)]
+fn closed_pipe() -> std::process::Stdio {
+    let (read, write) = nix::unistd::pipe().expect("a pipe");
+    drop(read);
+    std::process::Stdio::from(write)
+}
+
+#[cfg(unix)]
+#[test]
+fn a_reader_that_has_gone_away_is_not_a_failure() {
+    // `servicrab man | head` and `servicrab completions bash | head` end with
+    // the reader closing the pipe, which is it saying it has seen enough.  The
+    // man page reported that as an error and exited 1; the completion script's
+    // generator writes with `expect` and panicked on it.
+    for args in [vec!["man"], vec!["completions", "bash"]] {
+        let output = std::process::Command::new(assert_cmd::cargo::cargo_bin("servicrab"))
+            .args(&args)
+            .stdout(closed_pipe())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .expect("failed to run servicrab");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "{args:?} exited with {:?}: {stderr}",
+            output.status.code()
+        );
+        assert!(stderr.is_empty(), "{args:?} complained: {stderr}");
+    }
+}
+
 // ── man ────────────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/servicrab-cli/tests/cli.rs
+++ b/crates/servicrab-cli/tests/cli.rs
@@ -235,8 +235,13 @@ fn list_json_output() {
     let text = String::from_utf8(output).unwrap();
     let json: serde_json::Value = serde_json::from_str(&text).expect("valid JSON");
 
-    // Should be an array of service objects.
-    let arr = json.as_array().expect("JSON should be an array");
+    // An envelope with the services inside it, so there is somewhere to put
+    // the schema version.
+    assert_eq!(json["schema_version"], 1, "{json:#}");
+    assert_eq!(json["project"], "test-project", "{json:#}");
+    let arr = json["services"]
+        .as_array()
+        .expect("the services are still an array");
     assert!(!arr.is_empty());
 
     let first = &arr[0];
@@ -275,7 +280,7 @@ fn list_handles_a_command_with_multi_byte_characters() {
     let json: serde_json::Value =
         serde_json::from_str(&String::from_utf8(output).unwrap()).expect("valid JSON");
     assert_eq!(
-        json[0]["command"],
+        json["services"][0]["command"],
         serde_json::json!(["echo", "x€€€€€€€€€"])
     );
 }
@@ -367,10 +372,11 @@ profiles = ["dev", "test"]
 
     let json: serde_json::Value =
         serde_json::from_str(&String::from_utf8(output).unwrap()).expect("valid JSON");
-    assert_eq!(json[0]["name"], "api");
-    assert_eq!(json[0]["profiles"], serde_json::json!([]), "{json:#}");
+    let services = &json["services"];
+    assert_eq!(services[0]["name"], "api");
+    assert_eq!(services[0]["profiles"], serde_json::json!([]), "{json:#}");
     assert_eq!(
-        json[1]["profiles"],
+        services[1]["profiles"],
         serde_json::json!(["dev", "test"]),
         "{json:#}"
     );
@@ -477,7 +483,7 @@ fn values_are_taken_from_the_environment() {
     let json: serde_json::Value =
         serde_json::from_str(&String::from_utf8(output).unwrap()).expect("valid JSON");
     assert_eq!(
-        json[0]["command"],
+        json["services"][0]["command"],
         serde_json::json!(["echo", "--port=3000"]),
         "{json:#}"
     );
@@ -529,7 +535,7 @@ tcp = "127.0.0.1:1"
 
     let json: serde_json::Value =
         serde_json::from_str(&String::from_utf8(output).unwrap()).expect("valid JSON");
-    let api = json
+    let api = json["services"]
         .as_array()
         .unwrap()
         .iter()

--- a/crates/servicrab-cli/tests/cli.rs
+++ b/crates/servicrab-cli/tests/cli.rs
@@ -302,6 +302,34 @@ fn list_truncates_a_long_multi_byte_command_without_panicking() {
         .stdout(contains(expected));
 }
 
+#[test]
+fn list_reports_config_warnings() {
+    // `max_restarts` alongside `restart = "never"` is inert, so loading warns.
+    // `list` used to throw those warnings away, unlike the other commands.
+    let toml = "version = 1\n[project]\nname = \"demo\"\n[services.api]\ncommand = [\"echo\"]\nrestart = \"never\"\nmax_restarts = 3\n";
+    let (_dir, path) = temp_dir_with_config(toml);
+
+    cmd()
+        .arg("list")
+        .arg("--config")
+        .arg(&path)
+        .assert()
+        .success()
+        .stderr(contains("max_restarts"));
+
+    // On stderr, so `--json` output stays parseable on stdout.
+    let assert = cmd()
+        .arg("list")
+        .arg("--config")
+        .arg(&path)
+        .arg("--json")
+        .assert()
+        .success()
+        .stderr(contains("max_restarts"));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    serde_json::from_str::<serde_json::Value>(&stdout).expect("valid JSON");
+}
+
 // ── profiles ───────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/servicrab-cli/tests/color.rs
+++ b/crates/servicrab-cli/tests/color.rs
@@ -1,0 +1,305 @@
+//! Integration tests for the colour decision.
+//!
+//! Colour is a per-stream question — is *this* stream a terminal — and the only
+//! way to hold that to account is to give the process a real terminal on one
+//! stream and a pipe on the other, which is what the pty here is for.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Read;
+use std::os::fd::OwnedFd;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+/// Any escape sequence at all; the tests only care whether there is colour.
+const ESCAPE: &str = "\x1b[";
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+/// A stack of one service that prints one line and exits.
+fn stack(dir: &Path) -> PathBuf {
+    let script = dir.join("hello.sh");
+    fs::write(&script, "#!/bin/sh\necho hello-on-stdout\n").unwrap();
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let path = dir.join("servicrab.toml");
+    fs::write(
+        &path,
+        format!(
+            "version = 1\n[project]\nname = \"demo\"\n[services.api]\ncommand = [\"{}\"]\nrestart = \"never\"\n",
+            script.display()
+        ),
+    )
+    .unwrap();
+    path
+}
+
+/// Which stream gets the terminal.
+#[derive(Clone, Copy)]
+enum Terminal {
+    Stdout,
+    Stderr,
+    Neither,
+}
+
+/// What one run wrote, per stream.
+struct Written {
+    stdout: String,
+    stderr: String,
+}
+
+/// Run `servicrab up` with `terminal` on a pty and the other stream on a pipe.
+///
+/// The pty's output is read back as that stream's text, so a caller can ask the
+/// same question of either stream without caring which one was the terminal.
+fn run(config: &Path, terminal: Terminal, args: &[&str], env: &[(&str, &str)]) -> Written {
+    let mut command = Command::new(binary());
+    command
+        .arg("up")
+        .args(args)
+        .arg("--config")
+        .arg(config)
+        .env_remove("RUST_LOG")
+        .env_remove("NO_COLOR")
+        .env_remove("CLICOLOR_FORCE")
+        .env("TERM", "xterm-256color")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (key, value) in env {
+        command.env(key, value);
+    }
+
+    let pty = match terminal {
+        Terminal::Neither => None,
+        Terminal::Stdout | Terminal::Stderr => Some(nix::pty::openpty(None, None).expect("a pty")),
+    };
+    if let Some(pty) = &pty {
+        let slave = pty.slave.try_clone().expect("clone the pty");
+        match terminal {
+            Terminal::Stdout => command.stdout(Stdio::from(slave)),
+            Terminal::Stderr => command.stderr(Stdio::from(slave)),
+            Terminal::Neither => unreachable!(),
+        };
+        // Without a session of its own the child shares this process's
+        // controlling terminal, and the pty's terminal-ness is the only thing
+        // under test.
+        unsafe {
+            command.pre_exec(|| {
+                nix::unistd::setsid().map_err(std::io::Error::from)?;
+                Ok(())
+            });
+        }
+    }
+
+    let mut child = command.spawn().expect("failed to run servicrab");
+    // The parent's copy of the slave has to go, or the master would never see
+    // the far end close.  Reading it has to happen *while* the child runs:
+    // whatever the slave wrote and nobody read is discarded when the slave is
+    // closed, so draining afterwards would find an empty terminal.
+    let master = pty.map(|pty| {
+        drop(pty.slave);
+        pty.master
+    });
+    let finished = Arc::new(AtomicBool::new(false));
+    let terminal_reader = master.map(|master| {
+        let finished = Arc::clone(&finished);
+        std::thread::spawn(move || read_terminal(master, &finished))
+    });
+
+    // Whichever stream got the pty is `None` here; the other is a pipe, and
+    // both are drained concurrently so neither can fill and stall the child.
+    let out = child.stdout.take();
+    let out_reader = std::thread::spawn(move || drain(out));
+    let err = child.stderr.take();
+    let err_reader = std::thread::spawn(move || drain(err));
+
+    child.wait().expect("servicrab exited");
+    finished.store(true, Ordering::SeqCst);
+    let piped_out = out_reader.join().expect("read stdout");
+    let piped_err = err_reader.join().expect("read stderr");
+    let from_terminal = terminal_reader
+        .map(|reader| reader.join().expect("read the terminal"))
+        .unwrap_or_default();
+
+    match terminal {
+        Terminal::Stdout => Written {
+            stdout: from_terminal,
+            stderr: piped_err,
+        },
+        Terminal::Stderr => Written {
+            stdout: piped_out,
+            stderr: from_terminal,
+        },
+        Terminal::Neither => Written {
+            stdout: piped_out,
+            stderr: piped_err,
+        },
+    }
+}
+
+/// Read one of the child's pipes to the end, if it has one.
+fn drain(stream: Option<impl Read>) -> String {
+    let mut text = String::new();
+    if let Some(mut stream) = stream {
+        let _ = stream.read_to_string(&mut text);
+    }
+    text
+}
+
+/// Drain a pty master until the child is gone and it has stopped producing.
+///
+/// A master has no end of file to wait for: the kernel keeps it open whether or
+/// not any slave is left, so a blocking read would park here forever.  Reading
+/// without blocking, and stopping once the process has exited and the terminal
+/// has gone quiet, is what ends this.
+fn read_terminal(master: OwnedFd, finished: &AtomicBool) -> String {
+    use nix::fcntl::{fcntl, FcntlArg, OFlag};
+
+    fcntl(&master, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)).expect("a non-blocking master");
+
+    let mut collected: Vec<u8> = Vec::new();
+    let mut buffer = [0u8; 4096];
+    loop {
+        match nix::unistd::read(&master, &mut buffer) {
+            Ok(0) => return String::from_utf8_lossy(&collected).into_owned(),
+            Ok(read) => collected.extend_from_slice(&buffer[..read]),
+            Err(nix::errno::Errno::EAGAIN) => {
+                if finished.load(Ordering::SeqCst) {
+                    return String::from_utf8_lossy(&collected).into_owned();
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(_) => return String::from_utf8_lossy(&collected).into_owned(),
+        }
+    }
+}
+
+#[test]
+fn a_terminal_on_stderr_is_coloured_even_when_stdout_is_a_pipe() {
+    let dir = TempDir::new().unwrap();
+    let config = stack(dir.path());
+
+    let written = run(&config, Terminal::Stderr, &[], &[]);
+
+    // The banner and the status lines are stderr's, and stderr is the terminal.
+    assert!(
+        written.stderr.contains(ESCAPE),
+        "stderr had no colour: {:?}",
+        written.stderr
+    );
+    // The service's own output went into a pipe, which gets none.
+    assert!(
+        !written.stdout.contains(ESCAPE),
+        "stdout was coloured into a pipe: {:?}",
+        written.stdout
+    );
+}
+
+#[test]
+fn a_terminal_on_stdout_leaves_a_redirected_stderr_uncoloured() {
+    let dir = TempDir::new().unwrap();
+    let config = stack(dir.path());
+
+    let written = run(&config, Terminal::Stdout, &[], &[]);
+
+    assert!(
+        written.stdout.contains(ESCAPE),
+        "stdout had no colour: {:?}",
+        written.stdout
+    );
+    // `servicrab up 2> stack.err` should not put escapes in the file.
+    assert!(
+        !written.stderr.contains(ESCAPE),
+        "stderr was coloured into a pipe: {:?}",
+        written.stderr
+    );
+}
+
+#[test]
+fn two_pipes_are_left_alone() {
+    let dir = TempDir::new().unwrap();
+    let config = stack(dir.path());
+
+    let written = run(&config, Terminal::Neither, &[], &[]);
+    assert!(!written.stdout.contains(ESCAPE), "{:?}", written.stdout);
+    assert!(!written.stderr.contains(ESCAPE), "{:?}", written.stderr);
+}
+
+#[test]
+fn color_always_colours_both_pipes() {
+    let dir = TempDir::new().unwrap();
+    let config = stack(dir.path());
+
+    let written = run(&config, Terminal::Neither, &["--color=always"], &[]);
+    assert!(written.stdout.contains(ESCAPE), "{:?}", written.stdout);
+    assert!(written.stderr.contains(ESCAPE), "{:?}", written.stderr);
+}
+
+#[test]
+fn color_never_leaves_a_terminal_alone() {
+    let dir = TempDir::new().unwrap();
+    let config = stack(dir.path());
+
+    let written = run(&config, Terminal::Stderr, &["--color=never"], &[]);
+    assert!(!written.stderr.contains(ESCAPE), "{:?}", written.stderr);
+
+    let written = run(&config, Terminal::Stderr, &["--no-color"], &[]);
+    assert!(!written.stderr.contains(ESCAPE), "{:?}", written.stderr);
+}
+
+#[test]
+fn clicolor_force_colours_a_pipe() {
+    let dir = TempDir::new().unwrap();
+    let config = stack(dir.path());
+
+    let written = run(&config, Terminal::Neither, &[], &[("CLICOLOR_FORCE", "1")]);
+    assert!(written.stderr.contains(ESCAPE), "{:?}", written.stderr);
+
+    // Turned off the way the convention says it is turned off.
+    let written = run(&config, Terminal::Neither, &[], &[("CLICOLOR_FORCE", "0")]);
+    assert!(!written.stderr.contains(ESCAPE), "{:?}", written.stderr);
+}
+
+#[test]
+fn no_color_wins_over_clicolor_force_and_the_flag_wins_over_both() {
+    let dir = TempDir::new().unwrap();
+    let config = stack(dir.path());
+
+    let env = [("CLICOLOR_FORCE", "1"), ("NO_COLOR", "1")];
+    let written = run(&config, Terminal::Neither, &[], &env);
+    assert!(!written.stderr.contains(ESCAPE), "{:?}", written.stderr);
+
+    let written = run(&config, Terminal::Neither, &["--color=always"], &env);
+    assert!(written.stderr.contains(ESCAPE), "{:?}", written.stderr);
+}
+
+#[test]
+fn color_and_no_color_cannot_be_asked_for_at_once() {
+    let dir = TempDir::new().unwrap();
+    let config = stack(dir.path());
+
+    let output = Command::new(binary())
+        .arg("up")
+        .arg("--color=always")
+        .arg("--no-color")
+        .arg("--config")
+        .arg(&config)
+        .output()
+        .expect("failed to run servicrab");
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--no-color"),
+        "{:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/servicrab-cli/tests/compat.rs
+++ b/crates/servicrab-cli/tests/compat.rs
@@ -1,0 +1,338 @@
+//! What happens when the two ends of the socket are not the same release.
+//!
+//! After 1.0 the wire format is frozen, which means every line either side
+//! sends has to be readable by a build that predates it.  These tests stand a
+//! *newer* daemon up by hand — a plain Unix-socket server writing lines this
+//! build has no variants for — because there is no other way to get one: the
+//! real daemon can only send what this crate can already name.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+/// Upper bound for any wait here; keeps a hung test from stalling CI.
+const CEILING: Duration = Duration::from_secs(20);
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+/// A project the CLI will load, whose one service exits at once — nothing here
+/// is about supervision.
+fn a_project(dir: &Path) -> PathBuf {
+    let path = dir.join("servicrab.toml");
+    fs::write(
+        &path,
+        "version = 1\n[project]\nname = \"demo\"\n[services.api]\ncommand = [\"true\"]\n",
+    )
+    .unwrap();
+    path
+}
+
+/// Where the CLI will look for this project's daemon.
+fn socket_path(config: &Path) -> PathBuf {
+    config.parent().unwrap().join(".servicrab/daemon.sock")
+}
+
+/// A daemon from the future: it answers by request type, so a test says what a
+/// 1.1 daemon would send without having to know how many connections a command
+/// opens or in what order.
+///
+/// The thread is left running rather than joined.  It ends when the listener is
+/// dropped with the temporary directory, and a test that waited on it would hang
+/// on exactly the failure it is trying to report: a client that gave up early
+/// leaves the next `accept` waiting forever.
+struct StandIn {
+    _dir: TempDir,
+    config: PathBuf,
+}
+
+impl StandIn {
+    /// `pong` names a revision far ahead of ours; `status` and the subscribe
+    /// stream are whatever the test hands in.
+    fn new(status: &'static str, stream: Vec<String>) -> Self {
+        let dir = TempDir::new().unwrap();
+        let config = a_project(dir.path());
+        fs::create_dir_all(config.parent().unwrap().join(".servicrab")).unwrap();
+        let listener = UnixListener::bind(socket_path(&config)).expect("bind the stand-in daemon");
+
+        std::thread::spawn(move || {
+            while let Ok((stream_socket, _)) = listener.accept() {
+                let mut writer = stream_socket.try_clone().expect("clone");
+                let mut request = String::new();
+                let mut reader = BufReader::new(stream_socket);
+                if reader.read_line(&mut request).unwrap_or(0) == 0 {
+                    continue;
+                }
+
+                let mut lines = Vec::new();
+                if request.contains("\"ping\"") {
+                    lines.push(
+                        r#"{"type":"pong","project":"demo","pid":1,"version":99}"#.to_string(),
+                    );
+                } else if request.contains("\"status\"") {
+                    lines.push(status.to_string());
+                } else if request.contains("\"subscribe\"") {
+                    lines.push(r#"{"type":"ok"}"#.to_string());
+                    lines.extend(stream.iter().cloned());
+                } else {
+                    lines.push(r#"{"type":"error","message":"not in this test"}"#.to_string());
+                }
+
+                for line in lines {
+                    if writer.write_all(line.as_bytes()).is_err() {
+                        break;
+                    }
+                    let _ = writer.write_all(b"\n");
+                    let _ = writer.flush();
+                }
+                // Closing is how a daemon shutting down looks, which is what
+                // ends a subscriber cleanly.
+            }
+        });
+
+        Self { _dir: dir, config }
+    }
+
+    fn run(&self, args: &[&str]) -> (i32, String, String) {
+        run_cli(&self.config, args)
+    }
+}
+
+fn run_cli(config: &Path, args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(binary())
+        .args(args)
+        .arg("--config")
+        .arg(config)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// One `log` line, as a 1.1 daemon would still send it.
+fn a_log_line(text: &str) -> String {
+    format!(
+        r#"{{"type":"event","service":"api","event":{{"kind":"log","stream":"stdout","line":"{text}"}}}}"#
+    )
+}
+
+/// The defect this file exists for.
+///
+/// One event kind a 1.0 client has never heard of used to fail to decode, and
+/// the subscribe loop turned that into an error and a non-zero exit — so a
+/// single new event type in 1.1 would have killed `servicrab events` on every
+/// 1.0 client, mid-run, and taken every event behind it with it.  What has to
+/// survive is not the unknown line but the ones after it.
+#[test]
+fn an_unknown_event_kind_does_not_end_the_stream() {
+    let daemon = StandIn::new(
+        "",
+        vec![
+            a_log_line("before"),
+            // The line from the future, in the middle where it does the damage.
+            r#"{"type":"event","service":"api","event":{"kind":"teleported","destination":"mars"}}"#
+                .to_string(),
+            a_log_line("after"),
+        ],
+    );
+
+    let (code, stdout, stderr) = daemon.run(&["events", "--json"]);
+
+    assert_eq!(code, 0, "the stream ended badly: {stdout}{stderr}");
+    assert!(stdout.contains("\"line\":\"before\""), "{stdout}");
+    assert!(
+        stdout.contains("\"line\":\"after\""),
+        "everything after the unknown event was lost:\n{stdout}{stderr}"
+    );
+    // `--json` is a passthrough, so the unknown line survives verbatim for a
+    // consumer that knows what it means even though this build does not.
+    assert!(stdout.contains("\"kind\":\"teleported\""), "{stdout}");
+}
+
+/// The same for a reply type rather than an event kind: a 1.1 daemon may
+/// announce something mid-stream that has nothing to do with any service, and a
+/// client that cannot name it still has to keep reading.
+#[test]
+fn an_unknown_response_type_does_not_end_the_stream() {
+    let daemon = StandIn::new(
+        "",
+        vec![
+            r#"{"type":"reconfigured","by":"someone"}"#.to_string(),
+            a_log_line("after"),
+        ],
+    );
+
+    let (code, stdout, stderr) = daemon.run(&["events", "--json"]);
+
+    assert_eq!(code, 0, "the stream ended badly: {stdout}{stderr}");
+    assert!(stdout.contains("\"line\":\"after\""), "{stdout}{stderr}");
+}
+
+/// A state or health verdict from a newer daemon used to fail the whole status
+/// snapshot, so the reply was reported as malformed rather than as the services
+/// it could perfectly well have named.
+#[test]
+fn an_unknown_state_still_leaves_a_status_readable() {
+    let daemon = StandIn::new(
+        r#"{"type":"status","services":[{"name":"api","state":"hibernating","restarts":0,"health":"degraded"},{"name":"db","state":"running","restarts":0,"health":"healthy"}]}"#,
+        Vec::new(),
+    );
+
+    let (_, stdout, stderr) = daemon.run(&["status"]);
+
+    assert!(
+        stdout.contains("db") && stdout.contains("running"),
+        "the service this build understands was lost:\n{stdout}{stderr}"
+    );
+    assert!(stdout.contains("api"), "{stdout}{stderr}");
+    assert!(
+        !stderr.contains("malformed message"),
+        "a state from the future was reported as a broken message:\n{stderr}"
+    );
+}
+
+/// Write one line to a daemon and read the answer.
+fn ask(socket: &Path, line: &str) -> String {
+    let stream = UnixStream::connect(socket).expect("connect to the daemon");
+    stream
+        .set_read_timeout(Some(CEILING))
+        .expect("read timeout");
+    let mut writer = stream.try_clone().expect("clone");
+    writer.write_all(line.as_bytes()).expect("write");
+    writer.flush().expect("flush");
+
+    let mut reply = String::new();
+    BufReader::new(stream)
+        .read_line(&mut reply)
+        .expect("read the reply");
+    reply
+}
+
+/// Runs a real daemon for the tests where the daemon is the side under test,
+/// and stops it however the test ends.
+struct RealDaemon {
+    _dir: TempDir,
+    config: PathBuf,
+}
+
+impl RealDaemon {
+    fn start() -> Self {
+        let dir = TempDir::new().unwrap();
+        let config = a_project(dir.path());
+        let (code, stdout, stderr) = run_cli(&config, &["start"]);
+        assert_eq!(code, 0, "start failed: {stdout}{stderr}");
+        Self { _dir: dir, config }
+    }
+
+    fn socket(&self) -> PathBuf {
+        socket_path(&self.config)
+    }
+
+    fn log(&self) -> String {
+        fs::read_to_string(self.config.parent().unwrap().join(".servicrab/daemon.log"))
+            .expect("the daemon keeps a log")
+    }
+}
+
+impl Drop for RealDaemon {
+    fn drop(&mut self) {
+        let _ = run_cli(&self.config, &["down"]);
+    }
+}
+
+/// The daemon's own end of the same problem: a request it has no name for used
+/// to come back as `malformed message: unknown variant …`, which reads as "your
+/// client is broken" when the truth is "this daemon is older than your client".
+#[test]
+fn a_request_from_the_future_is_refused_by_name() {
+    let daemon = RealDaemon::start();
+
+    let reply = ask(&daemon.socket(), "{\"type\":\"drain\",\"grace_ms\":500}\n");
+
+    assert!(reply.contains("does not support that request"), "{reply}");
+    // Being unable to act on it is not a reason to stop serving.
+    assert!(
+        ask(&daemon.socket(), "{\"type\":\"ping\"}\n").contains("pong"),
+        "the daemon stopped answering"
+    );
+}
+
+/// A request nobody can act on still costs the connection a strike, or the
+/// leniency that makes the refusal possible would also make a connection free to
+/// talk to forever.
+#[test]
+fn requests_from_the_future_still_run_out_of_patience() {
+    let daemon = RealDaemon::start();
+
+    let stream = UnixStream::connect(daemon.socket()).expect("connect");
+    stream
+        .set_read_timeout(Some(CEILING))
+        .expect("read timeout");
+    let mut writer = stream.try_clone().expect("clone");
+    let mut reader = BufReader::new(stream);
+
+    let mut answers = 0;
+    let mut closed = false;
+    for _ in 0..64 {
+        if writer.write_all(b"{\"type\":\"drain\"}\n").is_err() || writer.flush().is_err() {
+            closed = true;
+            break;
+        }
+        let mut reply = String::new();
+        match reader.read_line(&mut reply) {
+            Ok(0) | Err(_) => {
+                closed = true;
+                break;
+            }
+            Ok(_) => answers += 1,
+        }
+    }
+
+    assert!(closed, "the daemon answered {answers} of them forever");
+    // Per connection, not per daemon.
+    assert!(ask(&daemon.socket(), "{\"type\":\"ping\"}\n").contains("pong"));
+}
+
+/// A `ping` says which revision of the wire format the client speaks, and a
+/// daemon that hears an older one says so.  That log line is the whole point of
+/// the field: it is the only place an operator chasing version skew will look.
+#[test]
+fn the_daemon_reports_a_client_that_is_behind() {
+    let daemon = RealDaemon::start();
+
+    let old = ask(&daemon.socket(), "{\"type\":\"ping\",\"version\":0}\n");
+    // A 0.3 client sends no version at all, and has to stay unremarked rather
+    // than be reported as ancient — otherwise every one of them is noise.
+    let silent = ask(&daemon.socket(), "{\"type\":\"ping\"}\n");
+
+    assert!(old.contains("\"type\":\"pong\""), "{old}");
+    assert!(
+        old.contains("\"version\":1"),
+        "the daemon has to name its own revision back: {old}"
+    );
+    assert!(silent.contains("\"type\":\"pong\""), "{silent}");
+
+    let log = daemon.log();
+    assert!(
+        log.contains("older revision of the protocol"),
+        "the skew went unreported:\n{log}"
+    );
+    assert_eq!(
+        log.matches("older revision of the protocol").count(),
+        1,
+        "a client that said nothing must not be reported as behind:\n{log}"
+    );
+}

--- a/crates/servicrab-cli/tests/compat.rs
+++ b/crates/servicrab-cli/tests/compat.rs
@@ -256,17 +256,75 @@ impl Drop for RealDaemon {
 /// The daemon's own end of the same problem: a request it has no name for used
 /// to come back as `malformed message: unknown variant …`, which reads as "your
 /// client is broken" when the truth is "this daemon is older than your client".
+///
+/// The refusal has to name the request, and that is not a nicety.  Deciding an
+/// unknown request is no longer a decode error is also deciding to throw away
+/// what serde said about it — `unknown variant "strat", expected one of …`,
+/// which told a client author their typo *and* the complete valid set.  A
+/// genuinely newer client knows what it asked for; a typo or a half-written
+/// client is the common case and does not.
 #[test]
 fn a_request_from_the_future_is_refused_by_name() {
     let daemon = RealDaemon::start();
 
     let reply = ask(&daemon.socket(), "{\"type\":\"drain\",\"grace_ms\":500}\n");
 
-    assert!(reply.contains("does not support that request"), "{reply}");
+    assert!(reply.contains("does not support"), "{reply}");
+    assert!(
+        reply.contains("drain"),
+        "the refusal did not say which request it was refusing: {reply}"
+    );
+    // And what to write instead, which is the other half of what serde used to
+    // give a client author for free.
+    for supported in ["ping", "status", "restart_service", "subscribe"] {
+        assert!(reply.contains(supported), "{supported} unlisted: {reply}");
+    }
     // Being unable to act on it is not a reason to stop serving.
     assert!(
         ask(&daemon.socket(), "{\"type\":\"ping\"}\n").contains("pong"),
         "the daemon stopped answering"
+    );
+}
+
+/// A typo is the case this wording is really for, so it is worth pinning
+/// separately from the request-from-the-future one: `strat` is a plausible slip
+/// for `status`, and the reply has to be enough to spot it without reading the
+/// source.
+#[test]
+fn a_misspelled_request_is_quoted_back_with_the_alternatives() {
+    let daemon = RealDaemon::start();
+
+    let reply = ask(&daemon.socket(), "{\"type\":\"strat\"}\n");
+
+    assert!(reply.contains("strat"), "{reply}");
+    assert!(reply.contains("status"), "{reply}");
+    // The reply is JSON, so a quoted tag has to survive being embedded in it.
+    let parsed: serde_json::Value = serde_json::from_str(reply.trim()).expect("a JSON reply");
+    assert_eq!(parsed["type"], "error");
+    assert!(
+        parsed["message"]
+            .as_str()
+            .expect("a message")
+            .contains("strat"),
+        "{reply}"
+    );
+}
+
+/// A refusal is written back down the socket the request arrived on, so the tag
+/// it quotes cannot be unbounded: that would make the refusal a way to have the
+/// daemon echo a payload of the peer's choosing.
+#[test]
+fn an_absurd_request_tag_does_not_come_back_in_full() {
+    let daemon = RealDaemon::start();
+    let huge = "z".repeat(4096);
+
+    let reply = ask(&daemon.socket(), &format!("{{\"type\":\"{huge}\"}}\n"));
+
+    assert!(reply.contains("does not support"), "{reply}");
+    assert!(
+        reply.len() < 500,
+        "the refusal carried the tag back at length ({} bytes)",
+        reply.len()
     );
 }
 

--- a/crates/servicrab-cli/tests/config_reference.rs
+++ b/crates/servicrab-cli/tests/config_reference.rs
@@ -1,0 +1,289 @@
+//! The configuration reference in `README.md` promises specific ranges, and a
+//! range is the kind of claim that rots quietly: someone widens a bound in
+//! `validation.rs`, every test still passes, and the documented number is
+//! wrong until a user hits it.
+//!
+//! So this file reads the table out of `README.md` and, for each documented
+//! bound, feeds the binary a config that sits **just outside** it and one that
+//! sits **on** it. If a bound moves, the pair disagrees with the README and
+//! this test fails naming the field.
+//!
+//! It deliberately checks the documentation against the binary rather than
+//! against the constants: a test that imported `DUR_1H` would agree with the
+//! code by construction and would never catch the README drifting.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+fn readme() -> String {
+    // CARGO_MANIFEST_DIR is crates/servicrab-cli.
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .join("README.md");
+    fs::read_to_string(&root).unwrap_or_else(|e| panic!("cannot read {}: {e}", root.display()))
+}
+
+/// Run `check` on a config and return `(exit code, stderr)`.
+fn check(toml: &str) -> (i32, String) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("servicrab.toml");
+    fs::write(&path, toml).unwrap();
+    let out = Command::new(binary())
+        .arg("check")
+        .arg("--config")
+        .arg(&path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// The README row for `field`, as the text after the last `|` pair.
+///
+/// Rows look like `| `field` | duration | `1s` | **100ms … 1h.** |`.
+fn documented_row(field: &str) -> String {
+    let needle = format!("| `{field}` |");
+    let readme = readme();
+    let row = readme
+        .lines()
+        .find(|line| line.starts_with(&needle))
+        .unwrap_or_else(|| panic!("README has no configuration-reference row for `{field}`"));
+    row.to_string()
+}
+
+/// Assert the README row for `field` mentions `bound`, so the prose and the
+/// behaviour cannot drift apart silently.
+fn assert_documents(field: &str, bound: &str) {
+    let row = documented_row(field);
+    assert!(
+        row.contains(bound),
+        "README row for `{field}` no longer documents the bound {bound}:\n{row}"
+    );
+}
+
+fn service_with(body: &str) -> String {
+    format!("version = 1\n[project]\nname = \"p\"\n[services.api]\ncommand = [\"echo\", \"hi\"]\nrestart = \"always\"\n{body}\n")
+}
+
+fn health_with(body: &str) -> String {
+    format!("version = 1\n[project]\nname = \"p\"\n[services.api]\ncommand = [\"echo\", \"hi\"]\n[services.api.health]\ntcp = \"127.0.0.1:5432\"\n{body}\n")
+}
+
+fn watch_with(body: &str) -> String {
+    let dir = "."; // the config's own directory always exists
+    format!("version = 1\n[project]\nname = \"p\"\n[services.api]\ncommand = [\"echo\", \"hi\"]\n[services.api.watch]\npaths = [\"{dir}\"]\n{body}\n")
+}
+
+fn logs_with(body: &str) -> String {
+    format!("version = 1\n[project]\nname = \"p\"\n[project.logs]\n{body}\n[services.api]\ncommand = [\"echo\", \"hi\"]\n")
+}
+
+/// A value on the documented bound is accepted; one past it is refused, and the
+/// refusal names the field so an operator can find it.
+#[track_caller]
+fn bound_holds(field: &str, accepted: &str, refused: &str) {
+    let (code, _) = check(accepted);
+    assert_eq!(
+        code, 0,
+        "`{field}`: the value the README documents as the edge of the range was rejected"
+    );
+
+    let (code, stderr) = check(refused);
+    assert_eq!(
+        code, 1,
+        "`{field}`: a value outside the documented range was accepted"
+    );
+    assert!(
+        stderr.contains(field),
+        "`{field}`: the error does not name the field:\n{stderr}"
+    );
+}
+
+#[test]
+fn shutdown_timeout_range_is_as_documented() {
+    assert_documents("shutdown_timeout", "100ms … 1h");
+    bound_holds(
+        "shutdown_timeout",
+        &service_with("shutdown_timeout = \"1h\""),
+        &service_with("shutdown_timeout = \"1h1s\""),
+    );
+    bound_holds(
+        "shutdown_timeout",
+        &service_with("shutdown_timeout = \"100ms\""),
+        &service_with("shutdown_timeout = \"99ms\""),
+    );
+}
+
+#[test]
+fn restart_delay_range_is_as_documented() {
+    assert_documents("restart_delay", "100ms … 1h");
+    // `restart_max_delay` must stay >= `restart_delay`, which the reference also
+    // documents, so the ceiling has to be raised to probe this bound at all.
+    bound_holds(
+        "restart_delay",
+        &service_with("restart_delay = \"1h\"\nrestart_max_delay = \"2h\""),
+        &service_with("restart_delay = \"61m\"\nrestart_max_delay = \"2h\""),
+    );
+    bound_holds(
+        "restart_delay",
+        &service_with("restart_delay = \"100ms\""),
+        &service_with("restart_delay = \"50ms\""),
+    );
+}
+
+#[test]
+fn restart_max_delay_range_is_as_documented() {
+    assert_documents("restart_max_delay", "100ms … 24h");
+    bound_holds(
+        "restart_max_delay",
+        &service_with("restart_max_delay = \"24h\""),
+        &service_with("restart_max_delay = \"25h\""),
+    );
+}
+
+#[test]
+fn stable_after_range_is_as_documented() {
+    assert_documents("stable_after", "1s … 24h");
+    bound_holds(
+        "stable_after",
+        &service_with("stable_after = \"1s\""),
+        &service_with("stable_after = \"999ms\""),
+    );
+    bound_holds(
+        "stable_after",
+        &service_with("stable_after = \"24h\""),
+        &service_with("stable_after = \"24h1s\""),
+    );
+}
+
+#[test]
+fn health_interval_and_timeout_ranges_are_as_documented() {
+    assert_documents("interval", "100ms … 1h");
+    bound_holds(
+        "health.interval",
+        &health_with("interval = \"100ms\""),
+        &health_with("interval = \"99ms\""),
+    );
+    bound_holds(
+        "health.timeout",
+        &health_with("timeout = \"1h\""),
+        &health_with("timeout = \"2h\""),
+    );
+}
+
+#[test]
+fn health_start_period_range_is_as_documented() {
+    assert_documents("start_period", "0s … 24h");
+    bound_holds(
+        "health.start_period",
+        &health_with("start_period = \"24h\""),
+        &health_with("start_period = \"48h\""),
+    );
+    // Zero is inside the range, and is the default.
+    let (code, _) = check(&health_with("start_period = \"0s\""));
+    assert_eq!(code, 0, "start_period = 0s should be accepted");
+}
+
+#[test]
+fn health_retries_minimum_is_as_documented() {
+    assert_documents("retries", "≥ 1");
+    let (code, _) = check(&health_with("retries = 1"));
+    assert_eq!(code, 0, "retries = 1 should be accepted");
+
+    let (code, stderr) = check(&health_with("retries = 0"));
+    assert_eq!(code, 1, "retries = 0 should be refused");
+    assert!(stderr.contains("retries"), "{stderr}");
+}
+
+#[test]
+fn watch_debounce_minimum_is_as_documented() {
+    assert_documents("debounce", "50ms … 1h");
+    bound_holds(
+        "watch.debounce",
+        &watch_with("debounce = \"50ms\""),
+        &watch_with("debounce = \"49ms\""),
+    );
+}
+
+#[test]
+fn watch_interval_range_is_as_documented() {
+    bound_holds(
+        "watch.interval",
+        &watch_with("interval = \"100ms\""),
+        &watch_with("interval = \"99ms\""),
+    );
+}
+
+#[test]
+fn log_max_size_range_is_as_documented() {
+    assert_documents("max_size", "1 KiB … 1 TiB");
+    // The smallest and largest accepted thresholds, spelled both ways round.
+    let (code, _) = check(&logs_with("max_size = \"1024\""));
+    assert_eq!(code, 0, "1 KiB should be accepted");
+    let (code, _) = check(&logs_with("max_size = \"1TiB\""));
+    assert_eq!(code, 0, "1 TiB should be accepted");
+
+    let (code, stderr) = check(&logs_with("max_size = \"1023\""));
+    assert_eq!(code, 1, "below 1 KiB should be refused");
+    assert!(stderr.contains("max_size"), "{stderr}");
+
+    let (code, stderr) = check(&logs_with("max_size = \"2TiB\""));
+    assert_eq!(code, 1, "above 1 TiB should be refused");
+    assert!(stderr.contains("max_size"), "{stderr}");
+}
+
+#[test]
+fn log_max_files_range_is_as_documented() {
+    assert_documents("max_files", "0 … 100");
+    let (code, _) = check(&logs_with("max_files = 100"));
+    assert_eq!(code, 0, "100 rotated files should be accepted");
+    let (code, _) = check(&logs_with("max_files = 0"));
+    assert_eq!(code, 0, "0 rotated files should be accepted");
+
+    let (code, stderr) = check(&logs_with("max_files = 101"));
+    assert_eq!(code, 1, "101 rotated files should be refused");
+    assert!(stderr.contains("max_files"), "{stderr}");
+}
+
+/// The name-length limits the reference quotes, checked by overshooting them.
+#[test]
+fn name_length_limits_are_as_documented() {
+    let readme = readme();
+    assert!(
+        readme.contains("64 bytes"),
+        "README no longer documents the 64-byte project-name limit"
+    );
+    assert!(
+        readme.contains("48-byte"),
+        "README no longer documents the 48-byte service-name limit"
+    );
+
+    let long_project = "p".repeat(65);
+    let (code, stderr) = check(&format!(
+        "version = 1\n[project]\nname = \"{long_project}\"\n[services.api]\ncommand = [\"echo\"]\n"
+    ));
+    assert_eq!(code, 1, "a 65-byte project name should be refused");
+    assert!(stderr.contains("64"), "{stderr}");
+
+    let long_service = "s".repeat(49);
+    let (code, stderr) = check(&format!(
+        "version = 1\n[project]\nname = \"p\"\n[services.{long_service}]\ncommand = [\"echo\"]\n"
+    ));
+    assert_eq!(code, 1, "a 49-byte service name should be refused");
+    assert!(stderr.contains("48"), "{stderr}");
+}

--- a/crates/servicrab-cli/tests/contract.rs
+++ b/crates/servicrab-cli/tests/contract.rs
@@ -1,0 +1,502 @@
+//! The machine-readable output contract: exit codes, JSON envelopes, and the
+//! one format every error is reported in.
+//!
+//! These are the shapes v1.0 freezes, so each one gets a test that fails if it
+//! moves — not because the behaviour is subtle, but because it is now a promise.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Upper bound for any wait in this file.
+const CEILING: Duration = Duration::from_secs(20);
+
+fn binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("servicrab")
+}
+
+fn config(dir: &Path, toml: &str) -> PathBuf {
+    let path = dir.join("servicrab.toml");
+    fs::write(&path, toml).unwrap();
+    path
+}
+
+fn script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+/// A long-lived service that exits cleanly on SIGTERM.
+fn resident(dir: &Path, name: &str) -> PathBuf {
+    script(
+        dir,
+        name,
+        "trap 'exit 0' TERM INT\necho up\nwhile true; do sleep 0.2; done",
+    )
+}
+
+fn cli(args: &[&str], config_path: &Path) -> (i32, String, String) {
+    let output = Command::new(binary())
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// A config with one resident service, and nothing else going on.
+fn one_service(dir: &Path) -> PathBuf {
+    let svc = resident(dir, "api.sh");
+    config(
+        dir,
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            svc.display()
+        ),
+    )
+}
+
+/// A config that does not validate, for the error paths.
+fn broken(dir: &Path) -> PathBuf {
+    config(
+        dir,
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = []
+[services.web]
+command = ["true"]
+depends_on = ["nowhere"]
+"#,
+    )
+}
+
+/// Stops the daemon when the test ends, however it ends.
+struct Daemon {
+    config: PathBuf,
+}
+
+impl Daemon {
+    fn start(config: &Path) -> Self {
+        let (code, stdout, stderr) = cli(&["start"], config);
+        assert_eq!(code, 0, "start failed: {stdout}{stderr}");
+        Self {
+            config: config.to_path_buf(),
+        }
+    }
+
+    fn wait_for_status(&self, what: &str, ready: impl Fn(&str) -> bool) -> String {
+        let deadline = Instant::now() + CEILING;
+        loop {
+            let (_, stdout, _) = cli(&["status"], &self.config);
+            if ready(&stdout) {
+                return stdout;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for {what}");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = cli(&["down"], &self.config);
+    }
+}
+
+fn json_of(text: &str) -> serde_json::Value {
+    serde_json::from_str(text).unwrap_or_else(|e| panic!("not JSON: {e}\n{text}"))
+}
+
+// ── Item 3: every --json document carries a schema version ─────────────────
+
+#[test]
+fn every_json_document_carries_a_schema_version() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    for args in [
+        vec!["check", "--json"],
+        vec!["list", "--json"],
+        vec!["status", "--json"],
+    ] {
+        let (_, stdout, stderr) = cli(&args, &cfg);
+        let json = json_of(&stdout);
+        assert_eq!(
+            json["schema_version"], 1,
+            "{args:?} printed {stdout}{stderr}"
+        );
+    }
+}
+
+/// The absent-daemon branch used to be a hand-written compact string that never
+/// went through serde, so it could drift from the running case it is supposed
+/// to mirror.
+#[test]
+fn status_json_reports_an_absent_daemon_in_the_same_shape_as_a_running_one() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let (code, stopped, stderr) = cli(&["status", "--json"], &cfg);
+    assert_eq!(code, 3, "{stopped}{stderr}");
+    let stopped = json_of(&stopped);
+    assert_eq!(stopped["running"], false);
+    assert_eq!(stopped["services"], serde_json::json!([]));
+    assert_eq!(stopped["schema_version"], 1);
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    let (code, running, stderr) = cli(&["status", "--json"], &cfg);
+    assert_eq!(code, 0, "{running}{stderr}");
+    let running = json_of(&running);
+    assert_eq!(running["running"], true);
+    assert_eq!(running["schema_version"], 1);
+
+    // The same keys in both, so a reader does not have to special-case one.
+    let mut stopped_keys: Vec<&String> = stopped.as_object().unwrap().keys().collect();
+    let mut running_keys: Vec<&String> = running.as_object().unwrap().keys().collect();
+    stopped_keys.sort();
+    running_keys.sort();
+    assert_eq!(stopped_keys, running_keys);
+}
+
+/// `check` is the most scripted command, and its whole job is reporting
+/// problems, so those have to arrive as a list rather than as a paragraph.
+#[test]
+fn check_json_reports_validation_errors_as_a_list() {
+    let dir = TempDir::new().unwrap();
+    let cfg = broken(dir.path());
+
+    let (code, stdout, stderr) = cli(&["check", "--json"], &cfg);
+    assert_eq!(code, 1, "{stdout}{stderr}");
+    // Nothing on stdout: a caller parsing it sees only the documents it asked
+    // for, never an error.
+    assert!(stdout.is_empty(), "{stdout}");
+
+    let json = json_of(&stderr);
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["error"]["code"], "validation_failed");
+    let errors = json["error"]["errors"].as_array().expect("a list");
+    assert_eq!(errors.len(), 2, "{json:#}");
+    assert!(
+        errors.iter().all(|e| e.is_string()),
+        "each error is its own string: {json:#}"
+    );
+}
+
+#[test]
+fn check_json_describes_a_config_that_loads() {
+    let dir = TempDir::new().unwrap();
+    let svc = script(dir.path(), "api.sh", "true");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+[services.tools]
+command = ["{}"]
+profiles = ["dev"]
+"#,
+            svc.display(),
+            svc.display()
+        ),
+    );
+
+    let (code, stdout, stderr) = cli(&["check", "--json"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+
+    let json = json_of(&stdout);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["project"], "demo");
+    assert_eq!(json["services"], 2);
+    assert_eq!(json["start_order"], serde_json::json!(["api", "tools"]));
+    assert_eq!(json["profiles"]["dev"], serde_json::json!(["tools"]));
+}
+
+/// Errors never emitted JSON at all, even under `--json`: a script asking for
+/// machine-readable output got a text `error: …` line the moment anything went
+/// wrong.
+#[test]
+fn an_error_under_json_is_json() {
+    let dir = TempDir::new().unwrap();
+    let cfg = broken(dir.path());
+
+    for args in [vec!["list", "--json"], vec!["check", "--json"]] {
+        let (code, stdout, stderr) = cli(&args, &cfg);
+        assert_eq!(code, 1, "{args:?}: {stdout}{stderr}");
+        assert!(stdout.is_empty(), "{args:?} wrote to stdout: {stdout}");
+        let json = json_of(&stderr);
+        assert_eq!(json["schema_version"], 1, "{args:?}");
+        assert_eq!(json["error"]["code"], "validation_failed", "{args:?}");
+    }
+}
+
+/// Without `--json` the same failure is one `error: ` line with the problems as
+/// bullets — never a bare message, and never a `✗` used as an error marker.
+#[test]
+fn an_error_without_json_is_one_prefixed_line_on_stderr() {
+    let dir = TempDir::new().unwrap();
+    let cfg = broken(dir.path());
+
+    let (code, stdout, stderr) = cli(&["check"], &cfg);
+    assert_eq!(code, 1, "{stdout}{stderr}");
+    assert!(stdout.is_empty(), "{stdout}");
+    assert!(stderr.starts_with("error: "), "{stderr}");
+    assert!(!stderr.contains('✗'), "✗ is not an error marker: {stderr}");
+
+    // Reported once: the errors used to be printed here and then summarized
+    // again by main's own `error:` line.
+    assert_eq!(
+        stderr.matches("error(s)").count(),
+        1,
+        "said twice: {stderr}"
+    );
+}
+
+// ── Item 4: exit codes ─────────────────────────────────────────────────────
+
+/// The dedicated code is what makes "nothing is running" scriptable, and it has
+/// to be the same everywhere — it used to be `1` for five commands and `0` for
+/// `down`.
+#[test]
+fn no_daemon_is_exit_three_for_every_command_that_needs_one() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    for args in [
+        vec!["status"],
+        vec!["stop", "api"],
+        vec!["restart", "api"],
+        vec!["start", "api"],
+        vec!["reload"],
+        vec!["events"],
+        vec!["down"],
+    ] {
+        let (code, stdout, stderr) = cli(&args, &cfg);
+        assert_eq!(code, 3, "{args:?} exited {code}: {stdout}{stderr}");
+    }
+}
+
+/// `down` is the one that used to exit `0`.  Idempotence is the point and it is
+/// preserved — the command still does not *fail* — but the code now says
+/// whether there was anything to do.
+#[test]
+fn down_says_there_was_nothing_to_stop_without_calling_it_a_failure() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let (code, stdout, _) = cli(&["down"], &cfg);
+    assert_eq!(code, 3);
+    // Not an error: no `error: ` prefix, and the note is on stdout where it
+    // always was.
+    assert!(stdout.contains("no daemon is running"), "{stdout}");
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+    let (code, stdout, stderr) = cli(&["down"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+
+    // And again, now that it really is gone.
+    let (code, _, _) = cli(&["down"], &cfg);
+    assert_eq!(code, 3);
+}
+
+/// A per-service rejection used to print a bare `✗ …` with no `error: ` prefix,
+/// which is a third format for the same thing.
+#[test]
+fn a_rejected_per_service_command_is_reported_like_every_other_error() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+    let _daemon = Daemon::start(&cfg);
+
+    let (code, stdout, stderr) = cli(&["stop", "nowhere"], &cfg);
+    assert_eq!(code, 1, "{stdout}{stderr}");
+    assert!(stderr.contains("error: "), "{stderr}");
+    assert!(!stderr.contains('✗'), "{stderr}");
+    assert!(stderr.contains("unknown service"), "{stderr}");
+}
+
+// ── Item 1: structured fields beside the prose ─────────────────────────────
+
+/// The reload's three counts were only ever available as a sentence, so a
+/// caller deciding whether anything happened had to parse English.
+#[test]
+fn a_reload_reports_its_counts_as_numbers_over_the_socket() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let cache = resident(dir.path(), "cache.sh");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display()
+        ),
+    );
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    let socket = dir.path().join(".servicrab/daemon.sock");
+
+    // Nothing changed yet.
+    let reply = json_of(&ask(&socket, r#"{"type":"reload"}"#));
+    assert_eq!(reply["type"], "ok", "{reply:#}");
+    assert_eq!(reply["changes"]["added"], 0, "{reply:#}");
+    assert_eq!(reply["changes"]["changed"], 0, "{reply:#}");
+    assert_eq!(reply["changes"]["removed"], 0, "{reply:#}");
+
+    fs::write(
+        &cfg,
+        format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+[services.cache]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display(),
+            cache.display()
+        ),
+    )
+    .unwrap();
+
+    let reply = json_of(&ask(&socket, r#"{"type":"reload"}"#));
+    assert_eq!(reply["changes"]["added"], 1, "{reply:#}");
+    assert_eq!(reply["changes"]["changed"], 0, "{reply:#}");
+    assert_eq!(reply["changes"]["removed"], 0, "{reply:#}");
+    // The prose is still there, for a person.
+    assert!(
+        reply["message"]
+            .as_str()
+            .expect("a message")
+            .contains("1 added"),
+        "{reply:#}"
+    );
+}
+
+/// A refused config used to arrive as one string with `\n`s and `•`s in it,
+/// which every caller had to take apart again.
+#[test]
+fn a_refused_reload_lists_its_errors_and_carries_a_code() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+    let _daemon = Daemon::start(&cfg);
+    let socket = dir.path().join(".servicrab/daemon.sock");
+
+    fs::write(
+        &cfg,
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = []
+[services.web]
+command = ["true"]
+depends_on = ["nowhere"]
+"#,
+    )
+    .unwrap();
+
+    let reply = json_of(&ask(&socket, r#"{"type":"reload"}"#));
+    assert_eq!(reply["type"], "error", "{reply:#}");
+    assert_eq!(reply["code"], "validation_failed", "{reply:#}");
+    assert_eq!(reply["errors"].as_array().expect("a list").len(), 2);
+    assert!(
+        !reply["message"].as_str().expect("a message").contains('\n'),
+        "the message is one line now: {reply:#}"
+    );
+}
+
+#[test]
+fn an_unknown_service_over_the_socket_is_coded_as_such() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+    let _daemon = Daemon::start(&cfg);
+    let socket = dir.path().join(".servicrab/daemon.sock");
+
+    let reply = json_of(&ask(&socket, r#"{"type":"stop_service","name":"nowhere"}"#));
+    assert_eq!(reply["type"], "error");
+    assert_eq!(reply["code"], "unknown_service", "{reply:#}");
+}
+
+// ── Item 2: pid is really a pgid ───────────────────────────────────────────
+
+/// `ServiceInfo.pid` always was a process-group id — its own doc comment said
+/// so, and `Event::Started` calls the same number `pgid`.  Both names now carry
+/// it, so nothing that reads `pid` breaks while new readers get the right one.
+#[test]
+fn status_reports_the_process_group_under_both_pid_and_pgid() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    let (code, stdout, stderr) = cli(&["status", "--json"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+
+    let json = json_of(&stdout);
+    let api = &json["services"][0];
+    let pgid = api["pgid"].as_i64().expect("a pgid: {json:#}");
+    assert!(pgid > 0, "{json:#}");
+    assert_eq!(api["pid"], pgid, "the alias carries the same value");
+}
+
+/// Send one line to the daemon's socket and read one line back.
+fn ask(socket: &Path, request: &str) -> String {
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixStream;
+
+    let mut stream = UnixStream::connect(socket).expect("connect to the daemon");
+    stream
+        .write_all(format!("{request}\n").as_bytes())
+        .expect("write the request");
+    stream.flush().expect("flush");
+
+    let mut reply = String::new();
+    BufReader::new(&stream)
+        .read_line(&mut reply)
+        .expect("read the reply");
+    reply
+}

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -576,6 +576,18 @@ command = ["{}"]
     drop(refusing);
 }
 
+/// Run a per-service command and insist it worked, saying what it printed if
+/// it did not.
+///
+/// `assert_eq!(cli(..).0, 0)` reports only the code, which turns any failure
+/// here into "left == 1, right == 0" and leaves the next reader guessing.  This
+/// suite has a flake history in exactly these spots, so the diagnostics have to
+/// be in the failure itself.
+fn stop_ok(args: &[&str], config_path: &Path) {
+    let (code, stdout, stderr) = cli(args, config_path);
+    assert_eq!(code, 0, "`{}` failed:\n{stdout}{stderr}", args.join(" "));
+}
+
 /// The uid the kernel reports for the other end of `stream`.
 fn peer_uid(stream: &std::os::unix::net::UnixStream) -> u32 {
     use nix::sys::socket::getsockopt;
@@ -1129,7 +1141,7 @@ fn stopping_an_already_stopped_service_is_not_an_error() {
     let daemon = Daemon::start(&cfg);
     daemon.wait_for_status("api to run", |s| s.contains("running"));
 
-    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
+    stop_ok(&["stop", "api"], &cfg);
     let (code, stdout, _) = cli(&["stop", "api"], &cfg);
     assert_eq!(code, 0);
     assert!(stdout.contains("already stopped"), "{stdout}");
@@ -1503,8 +1515,8 @@ fn a_hand_stopped_service_stays_stopped_across_a_daemon_restart() {
         state_of(s, "api") == "running" && state_of(s, "cache") == "running"
     });
 
-    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
-    assert_eq!(cli(&["stop", "cache"], &cfg).0, 0);
+    stop_ok(&["stop", "api"], &cfg);
+    stop_ok(&["stop", "cache"], &cfg);
     drop(daemon);
 
     let daemon = Daemon::start(&cfg);
@@ -1522,7 +1534,7 @@ fn starting_a_remembered_service_takes_the_stop_back() {
 
     let daemon = Daemon::start(&cfg);
     daemon.wait_for_status("api to run", |s| state_of(s, "api") == "running");
-    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
+    stop_ok(&["stop", "api"], &cfg);
     assert_eq!(cli(&["start", "api"], &cfg).0, 0);
     drop(daemon);
 
@@ -1544,7 +1556,7 @@ fn the_remembered_stop_is_a_plain_list_of_names() {
     daemon.wait_for_status("api to run", |s| state_of(s, "api") == "running");
     assert!(!remembered.exists(), "nothing was stopped yet");
 
-    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
+    stop_ok(&["stop", "api"], &cfg);
     assert_eq!(
         fs::read_to_string(&remembered).unwrap(),
         "# servicrab stopped v1\napi\n"
@@ -1638,7 +1650,7 @@ fn a_renamed_service_is_forgotten_at_the_next_start() {
 
     let daemon = Daemon::start(&cfg);
     daemon.wait_for_status("api to run", |s| state_of(s, "api") == "running");
-    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
+    stop_ok(&["stop", "api"], &cfg);
     drop(daemon);
 
     // Rename `api` to `web`, so the remembered name has nothing to refer to.
@@ -1694,7 +1706,7 @@ restart = "always"
     daemon.wait_for_status("the stack to run", |s| {
         state_of(s, "db") == "running" && state_of(s, "api") == "running"
     });
-    assert_eq!(cli(&["stop", "db"], &cfg).0, 0);
+    stop_ok(&["stop", "db"], &cfg);
     drop(daemon);
 
     // `--wait` returns 0 rather than waiting out its timeout on a service the

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -202,9 +202,12 @@ restart = "always"
     assert!(!dir.path().join(".servicrab/daemon.sock").exists());
     assert!(!dir.path().join(".servicrab/daemon.pid").exists());
 
-    let (code, stdout, _) = cli(&["status"], &cfg);
+    let (code, stdout, stderr) = cli(&["status"], &cfg);
     assert_eq!(code, 1);
-    assert!(stdout.contains("no daemon is running"), "{stdout}");
+    assert!(stderr.contains("no daemon is running"), "{stderr}");
+    // Diagnostics, so `servicrab status > snapshot` records no snapshot at all
+    // rather than a sentence about there not being one.
+    assert!(stdout.is_empty(), "{stdout}");
 }
 
 // ── start --wait ───────────────────────────────────────────────────────────
@@ -961,18 +964,21 @@ command = ["{}"]
         ),
     );
 
-    let (code, stdout, _) = cli(&["status"], &cfg);
+    let (code, stdout, stderr) = cli(&["status"], &cfg);
     assert_eq!(code, 1);
-    assert!(stdout.contains("servicrab start"), "{stdout}");
+    assert!(stderr.contains("servicrab start"), "{stderr}");
+    assert!(stdout.is_empty(), "{stdout}");
 
+    // `--json` is output, not diagnostics, so it stays on stdout.
     let (code, stdout, _) = cli(&["status", "--json"], &cfg);
     assert_eq!(code, 1);
     assert!(stdout.contains("\"running\":false"), "{stdout}");
 
     // Stopping something that is not running is not a failure.
-    let (code, stdout, _) = cli(&["down"], &cfg);
+    let (code, stdout, stderr) = cli(&["down"], &cfg);
     assert_eq!(code, 0);
-    assert!(stdout.contains("no daemon is running"), "{stdout}");
+    assert!(stderr.contains("no daemon is running"), "{stderr}");
+    assert!(stdout.is_empty(), "{stdout}");
 }
 
 #[test]

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -542,8 +542,11 @@ fn shell_quote(path: &Path) -> String {
 #[test]
 fn a_deeply_nested_project_puts_its_socket_in_the_runtime_dir() {
     let dir = TempDir::new().unwrap();
-    // Short enough to hold a socket, which is what a real `/run/user/1000` is.
+    // Short enough to hold a socket, and 0700, which is what a real
+    // `/run/user/1000` is — `TempDir` makes 0755 directories, and the daemon
+    // refuses to put a socket in one.
     let runtime = TempDir::new_in("/tmp").unwrap();
+    fs::set_permissions(runtime.path(), fs::Permissions::from_mode(0o700)).unwrap();
 
     let deep = dir.path().join("nested".repeat(12)).join("more".repeat(12));
     fs::create_dir_all(&deep).unwrap();
@@ -603,6 +606,55 @@ restart = "always"
     assert!(
         !deep.join(".servicrab/daemon.sock").exists(),
         "the socket should have moved out of the project"
+    );
+}
+
+/// A `$XDG_RUNTIME_DIR` other users can reach is refused and the daemon does
+/// not start, saying which candidate it turned down and why.
+///
+/// This is the whole point of the predicate: the socket has to be somewhere
+/// nobody else can pre-create a name, and a startup failure that explains
+/// itself is better than a spoofable socket.  The temp directory is pointed at
+/// a loosened directory too, so nothing accidentally saves the day.
+#[test]
+fn a_socket_is_never_put_in_a_directory_other_users_can_reach() {
+    let dir = TempDir::new().unwrap();
+    let shared = TempDir::new_in("/tmp").unwrap();
+    fs::set_permissions(shared.path(), fs::Permissions::from_mode(0o777)).unwrap();
+
+    let deep = dir.path().join("nested".repeat(12)).join("more".repeat(12));
+    fs::create_dir_all(&deep).unwrap();
+    let svc = resident(dir.path(), "api.sh");
+    let cfg = config(
+        &deep,
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            svc.display()
+        ),
+    );
+
+    let shared_path = shared.path().to_str().unwrap();
+    let env = [("XDG_RUNTIME_DIR", shared_path), ("TMPDIR", shared_path)];
+    let (code, stdout, stderr) = cli_with_env(&["start"], &cfg, &env);
+
+    assert_ne!(code, 0, "start should have refused: {stdout}{stderr}");
+    let told = format!("{stdout}{stderr}");
+    // The operator has to be able to fix this, so the message names the
+    // directory and says what is wrong with it.
+    assert!(told.contains(shared_path), "{told}");
+    assert!(told.contains("0777"), "{told}");
+    assert!(told.contains("no group or other permissions"), "{told}");
+    assert_eq!(
+        fs::read_dir(shared.path()).unwrap().count(),
+        0,
+        "nothing may be created in a directory we refused"
     );
 }
 

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -202,9 +202,9 @@ restart = "always"
     assert!(!dir.path().join(".servicrab/daemon.sock").exists());
     assert!(!dir.path().join(".servicrab/daemon.pid").exists());
 
-    let (code, stdout, _) = cli(&["status"], &cfg);
-    assert_eq!(code, 1);
-    assert!(stdout.contains("no daemon is running"), "{stdout}");
+    let (code, _, stderr) = cli(&["status"], &cfg);
+    assert_eq!(code, 3);
+    assert!(stderr.contains("no daemon is running"), "{stderr}");
 }
 
 // ── start --wait ───────────────────────────────────────────────────────────
@@ -961,17 +961,20 @@ command = ["{}"]
         ),
     );
 
-    let (code, stdout, _) = cli(&["status"], &cfg);
-    assert_eq!(code, 1);
-    assert!(stdout.contains("servicrab start"), "{stdout}");
+    // Its own exit code, so a script can tell "nothing is running" from a real
+    // failure without reading the message.
+    let (code, _, stderr) = cli(&["status"], &cfg);
+    assert_eq!(code, 3, "{stderr}");
+    assert!(stderr.contains("servicrab start"), "{stderr}");
 
     let (code, stdout, _) = cli(&["status", "--json"], &cfg);
-    assert_eq!(code, 1);
-    assert!(stdout.contains("\"running\":false"), "{stdout}");
+    assert_eq!(code, 3);
+    assert!(stdout.contains("\"running\": false"), "{stdout}");
 
-    // Stopping something that is not running is not a failure.
+    // Stopping something that is not running is still not a failure — it just
+    // says there was nothing to do.
     let (code, stdout, _) = cli(&["down"], &cfg);
-    assert_eq!(code, 0);
+    assert_eq!(code, 3);
     assert!(stdout.contains("no daemon is running"), "{stdout}");
 }
 
@@ -1166,7 +1169,7 @@ fn per_service_commands_need_a_daemon() {
     let cfg = one_service(dir.path());
 
     let (code, _, stderr) = cli(&["stop", "api"], &cfg);
-    assert_eq!(code, 1);
+    assert_eq!(code, 3);
     assert!(stderr.contains("no daemon is running"), "{stderr}");
 }
 

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -507,6 +507,75 @@ fn the_daemon_reads_the_credentials_of_whoever_connects() {
     assert_eq!(code, 0, "{stdout}");
 }
 
+/// A refused peer is told which uid owns the daemon and which one it is.
+///
+/// A genuine cross-uid connection needs two users, which this suite does not
+/// have, so the daemon's own decision is covered by the unit test on the
+/// message and the one on `peer_uid`; what is exercised here is the rest of the
+/// journey — that a refusal written on the socket reaches the operator instead
+/// of being flattened into "the daemon closed the connection" or, worse, into
+/// "no daemon is running", which would send them looking for one to start.
+#[test]
+fn a_refused_client_is_told_which_uid_owns_the_daemon() {
+    let dir = TempDir::new().unwrap();
+    let svc = resident(dir.path(), "api.sh");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+"#,
+            svc.display()
+        ),
+    );
+
+    // Stand in for a daemon owned by uid 501 that has just refused uid 0.
+    fs::create_dir_all(dir.path().join(".servicrab")).unwrap();
+    let socket = dir.path().join(".servicrab/daemon.sock");
+    let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+    let refusing = std::thread::spawn(move || {
+        use std::io::Write;
+
+        // Every command in the test below opens its own connection.
+        for stream in listener.incoming().take(3) {
+            let Ok(mut stream) = stream else { break };
+            let _ = stream.write_all(
+                b"{\"type\":\"error\",\"message\":\"this daemon runs as uid 501; \
+                  you are uid 0 - servicrab only answers the user that started it\"}\n",
+            );
+            let _ = stream.flush();
+        }
+    });
+
+    for command in [vec!["status"], vec!["stop", "api"], vec!["reload"]] {
+        let (code, stdout, stderr) = cli(&command, &cfg);
+        let told = format!("{stdout}{stderr}");
+
+        assert_ne!(
+            code,
+            0,
+            "`{}` should have failed: {told}",
+            command.join(" ")
+        );
+        assert!(
+            told.contains("uid 501") && told.contains("uid 0"),
+            "`{}` hid the refusal: {told}",
+            command.join(" ")
+        );
+        assert!(
+            !told.contains("no daemon is running"),
+            "`{}` reported an absent daemon: {told}",
+            command.join(" ")
+        );
+    }
+
+    drop(refusing);
+}
+
 /// The uid the kernel reports for the other end of `stream`.
 fn peer_uid(stream: &std::os::unix::net::UnixStream) -> u32 {
     use nix::sys::socket::getsockopt;

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -1412,7 +1412,9 @@ fn starting_a_remembered_service_takes_the_stop_back() {
 #[test]
 fn the_remembered_stop_is_a_plain_list_of_names() {
     // The file is state a human may have to look at — or edit — when a stack
-    // ends up in a shape nobody wanted.
+    // ends up in a shape nobody wanted.  The version line above the names lets
+    // the format change later; everything below it is still one name per line,
+    // so deleting a line remains a legitimate way to forget a stop.
     let dir = TempDir::new().unwrap();
     let cfg = two_policies(dir.path());
     let remembered = dir.path().join(".servicrab/stopped");
@@ -1422,10 +1424,119 @@ fn the_remembered_stop_is_a_plain_list_of_names() {
     assert!(!remembered.exists(), "nothing was stopped yet");
 
     assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
-    assert_eq!(fs::read_to_string(&remembered).unwrap(), "api\n");
+    assert_eq!(
+        fs::read_to_string(&remembered).unwrap(),
+        "# servicrab stopped v1\napi\n"
+    );
 
     assert_eq!(cli(&["restart", "api"], &cfg).0, 0);
-    assert_eq!(fs::read_to_string(&remembered).unwrap(), "");
+    assert_eq!(
+        fs::read_to_string(&remembered).unwrap(),
+        "# servicrab stopped v1\n"
+    );
+}
+
+/// Two `stop`s at once must both be remembered.
+///
+/// Each arrives on its own connection and is handled by its own task, and the
+/// record was a read-modify-write with no lock and no temp+rename: one update
+/// simply vanished, and a crash mid-write left an empty file that reads back as
+/// "nothing was ever stopped".  The verdict is what a fresh daemon does with the
+/// file, not what the two commands printed.
+#[test]
+fn two_services_stopped_at_once_are_both_remembered() {
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let cache = resident(dir.path(), "cache.sh");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "unless-stopped"
+[services.cache]
+command = ["{}"]
+restart = "unless-stopped"
+"#,
+            api.display(),
+            cache.display()
+        ),
+    );
+    let remembered = dir.path().join(".servicrab/stopped");
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        state_of(s, "api") == "running" && state_of(s, "cache") == "running"
+    });
+
+    // Two separate processes, so the two requests really do overlap.
+    let mut stops = vec![
+        spawn_cli(&["stop", "api"], &cfg),
+        spawn_cli(&["stop", "cache"], &cfg),
+    ];
+    for stop in &mut stops {
+        assert_eq!(wait_bounded(stop), 0);
+    }
+
+    let contents = fs::read_to_string(&remembered).unwrap();
+    let names: Vec<&str> = contents
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["api", "cache"],
+        "an update was lost: {contents:?}"
+    );
+
+    // And a fresh daemon acts on both, which is what the file is for.
+    drop(daemon);
+    let daemon = Daemon::start(&cfg);
+    let status = daemon.wait_for_status("the stack to settle", |s| {
+        state_of(s, "api") == "stopped" && state_of(s, "cache") == "stopped"
+    });
+    assert_eq!(state_of(&status, "api"), "stopped", "{status}");
+    assert_eq!(state_of(&status, "cache"), "stopped", "{status}");
+}
+
+/// A name the configuration no longer declares must not stay remembered
+/// forever.
+///
+/// Every stop was recorded while only `unless-stopped` services were ever
+/// consulted, so a renamed or deleted service left its name behind for good and
+/// the file only grew.
+#[test]
+fn a_renamed_service_is_forgotten_at_the_next_start() {
+    let dir = TempDir::new().unwrap();
+    let cfg = two_policies(dir.path());
+    let remembered = dir.path().join(".servicrab/stopped");
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| state_of(s, "api") == "running");
+    assert_eq!(cli(&["stop", "api"], &cfg).0, 0);
+    drop(daemon);
+
+    // Rename `api` to `web`, so the remembered name has nothing to refer to.
+    // Only the section header, or the replacement would mangle the script path
+    // too and the config would stop describing a runnable service.
+    let renamed = fs::read_to_string(&cfg)
+        .unwrap()
+        .replace("[services.api]", "[services.web]");
+    fs::write(&cfg, renamed).unwrap();
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("web to run", |s| state_of(s, "web") == "running");
+
+    let contents = fs::read_to_string(&remembered).unwrap_or_default();
+    assert!(
+        !contents.contains("api"),
+        "the old name is still remembered: {contents:?}"
+    );
+    drop(daemon);
 }
 
 #[test]

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -1732,6 +1732,91 @@ fn pid_of(daemon: &Daemon) -> i64 {
     parsed["services"][0]["pid"].as_i64().unwrap_or(0)
 }
 
+/// A SIGTERM that arrives while the daemon is still starting up has to be
+/// honoured rather than being fatal.
+///
+/// **What this proves.** The daemon publishes its socket (`bind_socket`) before
+/// the async runtime exists, because the umask that keeps the socket private is
+/// process-global; the real signal watcher cannot be installed until after the
+/// runtime is built.  Everything in between used to run with the *default*
+/// disposition for SIGTERM, so a signal there killed the process outright — no
+/// graceful shutdown, and the socket file left on disk for the next `start` to
+/// misread.
+///
+/// The test does not try to hit that window at one exact instant, which is what
+/// makes [`a_foreground_daemon_stops_on_sigterm`] only see it about once in
+/// sixty runs.  It waits for the pidfile — the daemon's *first* artefact, created
+/// before the socket is bound — and then keeps signalling until the process is
+/// gone, so signals are delivered continuously across the whole of startup,
+/// including the window.  Reverted against the fix it fails every time.
+///
+/// **What it does not prove.** There is still an irreducible window before the
+/// daemon claims the signals at all: process start, argument parsing, reading the
+/// configuration.  A signal there is still fatal — deliberately, because nothing
+/// of ours exists on disk yet and `start` reports its child's exit status.  The
+/// test also says nothing about SIGKILL, which no handler can catch; the pidfile
+/// `flock` is what covers that.
+#[test]
+fn a_daemon_signalled_during_startup_shuts_down_cleanly() {
+    let dir = TempDir::new().unwrap();
+    let svc = resident(dir.path(), "api.sh");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            svc.display()
+        ),
+    );
+
+    let mut child = Command::new(binary())
+        .arg("daemon")
+        .arg("--config")
+        .arg(&cfg)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn the daemon");
+    let pid = Pid::from_raw(child.id() as i32);
+
+    // The pidfile is created by `ProjectLock::acquire`, which runs before the
+    // socket is bound, so this is the earliest moment the daemon is observable
+    // from outside.
+    let pidfile = dir.path().join(".servicrab/daemon.pid");
+    let deadline = Instant::now() + CEILING;
+    while !pidfile.exists() {
+        assert!(Instant::now() < deadline, "the pidfile never appeared");
+    }
+
+    // Signalling once could still land after the watcher is installed and prove
+    // nothing.  Signalling until the process is gone covers every instant of
+    // startup, so the unprotected window cannot be missed.  A repeat is not a
+    // second *request*: the daemon already treats extra signals as "stop
+    // waiting", which a graceful shutdown of a trapping service does not need.
+    let deadline = Instant::now() + CEILING;
+    while child.try_wait().unwrap().is_none() {
+        assert!(Instant::now() < deadline, "the daemon never exited");
+        let _ = kill(pid, Signal::SIGTERM);
+    }
+
+    assert_eq!(
+        child.wait().unwrap().code(),
+        Some(0),
+        "a signal during startup must not kill the daemon outright"
+    );
+    let socket = dir.path().join(".servicrab/daemon.sock");
+    assert!(!socket.exists(), "the socket outlived the daemon");
+    assert!(!pidfile.exists(), "the pidfile outlived the daemon");
+}
+
 #[test]
 fn a_foreground_daemon_stops_on_sigterm() {
     let dir = TempDir::new().unwrap();

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -1198,6 +1198,119 @@ fn an_unknown_service_is_rejected_by_the_daemon() {
 
 // ── socket hardening ───────────────────────────────────────────────────────
 
+/// Whether reading an abusive connection to its end shows that the daemon
+/// closed it.
+///
+/// A graceful `FIN` is not the only shape a deliberate close arrives in. The
+/// daemon stops reading at its frame cap, so by the time it closes there are
+/// still megabytes of this test's 4 MiB sitting unread in the socket's receive
+/// queue — and a kernel asked to throw unread data away tells the peer so with a
+/// reset rather than an orderly end-of-stream. Linux does exactly that here;
+/// macOS reports a plain EOF for the same close. Both mean closed, which is the
+/// only thing this asserts.
+///
+/// A daemon that really had left the connection open looks nothing like either:
+/// nothing would arrive at all, and the read would sit until the socket's own
+/// timeout expired and surfaced as `WouldBlock` or `TimedOut`. That is the
+/// outcome the test exists to catch, so it has to keep failing.
+fn ended_because_the_daemon_closed(outcome: &std::io::Result<usize>) -> bool {
+    match outcome {
+        Ok(_) => true,
+        Err(err) => err.kind() == std::io::ErrorKind::ConnectionReset,
+    }
+}
+
+/// The distinction the assertion rests on, made executable rather than left to a
+/// comment: a reset is a close, and the read timeout a still-open connection
+/// produces is not.
+#[test]
+fn a_reset_ends_a_connection_but_a_read_timeout_means_it_is_still_open() {
+    use std::io::ErrorKind;
+
+    assert!(ended_because_the_daemon_closed(&Ok(0)));
+    assert!(ended_because_the_daemon_closed(&Err(
+        ErrorKind::ConnectionReset.into()
+    )));
+
+    for still_open in [ErrorKind::WouldBlock, ErrorKind::TimedOut] {
+        assert!(
+            !ended_because_the_daemon_closed(&Err(still_open.into())),
+            "{still_open:?} is the daemon never closing, not a close"
+        );
+    }
+}
+
+/// What a connection the daemon *failed* to close actually looks like to the
+/// reader, so that accepting a reset above cannot quietly accept this too.
+///
+/// The listener here is the test's own, standing in for a daemon that gave up on
+/// the frame and then simply never closed. Nothing but the socket's read timeout
+/// ends the read, and the error kind that surfaces is the platform's choice —
+/// which is the whole reason to check it against the classifier rather than
+/// assume it.
+#[test]
+fn a_daemon_that_never_closes_is_not_mistaken_for_one_that_did() {
+    use std::io::{Read, Write};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    // Short on purpose: this timeout is the thing being provoked, so it is the
+    // test's own runtime rather than a bound on somebody else's work.
+    const PATIENCE: Duration = Duration::from_millis(500);
+
+    let dir = TempDir::new().unwrap();
+    let socket = dir.path().join("stalled.sock");
+    let listener = std::os::unix::net::UnixListener::bind(&socket).expect("bind");
+
+    let done = Arc::new(AtomicBool::new(false));
+    let server = std::thread::spawn({
+        let done = Arc::clone(&done);
+        move || {
+            let (mut conn, _) = listener.accept().expect("accept");
+            // Read a frame's worth and then stop, as the daemon's capped reader
+            // does — but hold the connection instead of dropping it.
+            let mut buffer = vec![0u8; 8 * 1024];
+            let mut read = 0;
+            while read <= 64 * 1024 {
+                match conn.read(&mut buffer) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => read += n,
+                }
+            }
+            while !done.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            drop(conn);
+        }
+    });
+
+    let mut stream = std::os::unix::net::UnixStream::connect(&socket).expect("connect");
+    stream.set_write_timeout(Some(PATIENCE)).expect("write");
+    stream.set_read_timeout(Some(PATIENCE)).expect("read");
+
+    let chunk = vec![b'x'; 64 * 1024];
+    let mut written = 0usize;
+    while written < 4 * 1024 * 1024 {
+        match stream.write_all(&chunk) {
+            Ok(()) => written += chunk.len(),
+            Err(_) => break,
+        }
+    }
+    let _ = stream.flush();
+
+    let mut sink = Vec::new();
+    let outcome = stream.read_to_end(&mut sink);
+
+    done.store(true, Ordering::Relaxed);
+    drop(stream);
+    server.join().expect("server thread");
+
+    assert!(
+        !ended_because_the_daemon_closed(&outcome),
+        "a connection nobody closed was read as closed: {outcome:?}"
+    );
+}
+
 /// A newline-free stream must not be able to grow the daemon's memory without
 /// bound.
 ///
@@ -1242,7 +1355,7 @@ fn an_oversized_request_closes_the_connection_and_leaves_the_daemon_alive() {
     let mut sink = Vec::new();
     let closed = stream.read_to_end(&mut sink);
     assert!(
-        closed.is_ok(),
+        ended_because_the_daemon_closed(&closed),
         "the daemon left the abusive connection open: {closed:?}"
     );
     drop(stream);

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -408,6 +408,80 @@ restart = "always"
     assert_eq!(mode, 0o600, "socket mode is {mode:o}, expected 600");
 }
 
+/// The mode must hold from the instant the socket exists, not only once the
+/// daemon is up.
+///
+/// Binding and then chmod-ing leaves a window where the socket is live and
+/// group-writable, and whoever connects in it gets full start/stop/shutdown
+/// authority.  Sampling the mode after `start` returns cannot see that window,
+/// so this test watches for the socket to appear and reads the mode on its very
+/// first sighting — under a umask of 000, which is what makes the window as
+/// wide as it can possibly be.
+#[test]
+fn the_socket_is_never_group_writable_even_for_an_instant() {
+    let dir = TempDir::new().unwrap();
+    let svc = resident(dir.path(), "api.sh");
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            svc.display()
+        ),
+    );
+    let socket = dir.path().join(".servicrab/daemon.sock");
+
+    // `sh -c 'umask 000; …'` rather than touching this process's umask: that is
+    // global, and the other tests in this binary run in parallel.
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "umask 000; exec {} daemon --config {}",
+            shell_quote(&binary()),
+            shell_quote(&cfg)
+        ))
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn the daemon");
+
+    // Spin without a sleep: the window this is looking for is microseconds
+    // wide, so any pause would step right over it.
+    let deadline = Instant::now() + CEILING;
+    let mode = loop {
+        if let Ok(meta) = fs::metadata(&socket) {
+            break meta.permissions().mode() & 0o777;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the socket never appeared within {CEILING:?}"
+        );
+    };
+
+    let _ = kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM);
+    wait_bounded(&mut child);
+
+    assert_eq!(
+        mode, 0o600,
+        "the socket was {mode:o} when it first existed: anyone in the group \
+         could have driven the daemon"
+    );
+}
+
+/// Quote a path for `sh -c`.  The test paths are temp dirs, so this only has to
+/// survive spaces, but it must not silently mangle anything either.
+fn shell_quote(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', r"'\''"))
+}
+
 #[test]
 fn starting_twice_is_refused() {
     let dir = TempDir::new().unwrap();

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -434,6 +434,113 @@ restart = "always"
     assert!(stderr.contains("already running"), "{stderr}");
 }
 
+/// Two starts that overlap must not both end up supervising the stack.
+///
+/// Checking the socket and then binding it is a race: interleaved, the second
+/// process unlinks the first one's live socket and binds its own, and both
+/// daemons then run the whole stack — duplicate processes, duplicate port
+/// binds.  The pidfile lock is what decides, so the verdict here is the number
+/// of service processes the project actually has, not what either `start` said.
+#[test]
+fn two_concurrent_starts_leave_exactly_one_daemon() {
+    let dir = TempDir::new().unwrap();
+    // A distinctive argument makes this service countable with `pgrep -f`
+    // without matching anything else on the machine.
+    let marker = format!("servicrab-race-{}", std::process::id());
+    let svc = script(
+        dir.path(),
+        "api.sh",
+        "trap 'exit 0' TERM INT\nwhile true; do sleep 0.2; done",
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}", "{marker}"]
+restart = "always"
+"#,
+            svc.display()
+        ),
+    );
+
+    let daemon = Daemon::guard(&cfg);
+    let mut starts: Vec<Child> = (0..2).map(|_| spawn_cli(&["start"], &cfg)).collect();
+    let codes: Vec<i32> = starts.iter_mut().map(wait_bounded).collect();
+
+    assert_eq!(
+        codes.iter().filter(|code| **code == 0).count(),
+        1,
+        "exactly one start should have succeeded, got {codes:?}"
+    );
+
+    // The survivor is a working daemon, not just a process holding a lock.
+    let status = daemon.wait_for_status("api to run", |s| s.contains("running"));
+    assert!(status.contains("api"), "{status}");
+
+    // And there is one copy of the service, not two.  Both daemons would have
+    // started their own, and the second one would have unlinked the first's
+    // socket, so `status` alone cannot tell the two cases apart.
+    let processes = wait_for_processes(&marker, 1);
+    assert_eq!(
+        processes, 1,
+        "{processes} copies of the service are running; two daemons supervised it"
+    );
+
+    // The loser did not take the winner's runtime files with it when it exited.
+    assert!(
+        dir.path().join(".servicrab/daemon.sock").exists(),
+        "the socket was removed under the running daemon"
+    );
+    assert!(
+        dir.path().join(".servicrab/daemon.pid").exists(),
+        "the pidfile was removed under the running daemon"
+    );
+
+    assert_eq!(cli(&["down"], &cfg).0, 0);
+    assert_eq!(
+        wait_for_processes(&marker, 0),
+        0,
+        "a service outlived the daemon"
+    );
+}
+
+/// How many processes match `marker`, once that count has settled on `expected`
+/// or the ceiling runs out.
+///
+/// Polling rather than sleeping: a second daemon needs a moment to spawn its
+/// own copy, and asserting too early would pass for the wrong reason.
+fn wait_for_processes(marker: &str, expected: usize) -> usize {
+    let deadline = Instant::now() + CEILING;
+    let mut seen = count_processes(marker);
+    while seen != expected && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        seen = count_processes(marker);
+    }
+    // One more look after a settling pause, so a *second* copy that arrives
+    // late still fails the test rather than sneaking in after it passed.
+    if seen == expected {
+        std::thread::sleep(Duration::from_millis(500));
+        seen = count_processes(marker);
+    }
+    seen
+}
+
+fn count_processes(marker: &str) -> usize {
+    let output = Command::new("pgrep")
+        .arg("-f")
+        .arg(marker)
+        .output()
+        .expect("pgrep is available on Linux and macOS");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
+}
+
 #[test]
 fn status_without_a_daemon_is_not_an_error_message_soup() {
     let dir = TempDir::new().unwrap();

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -1051,7 +1051,209 @@ fn an_unknown_service_is_rejected_by_the_daemon() {
     assert!(stderr.contains("api"), "{stderr}");
 }
 
-// ── profiles ───────────────────────────────────────────────────────────────
+// ── socket hardening ───────────────────────────────────────────────────────
+
+/// A newline-free stream must not be able to grow the daemon's memory without
+/// bound.
+///
+/// `Lines` assembles a `String` until it finds a newline, so a client that never
+/// sends one is a way to drive the daemon into the OOM killer.  The verdict here
+/// is the daemon's state afterwards: it has to close the abusive connection and
+/// still answer a legitimate client.
+#[test]
+fn an_oversized_request_closes_the_connection_and_leaves_the_daemon_alive() {
+    use std::io::{Read, Write};
+
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+    let socket = dir.path().join(".servicrab/daemon.sock");
+
+    let mut stream = std::os::unix::net::UnixStream::connect(&socket).expect("connect");
+    stream
+        .set_write_timeout(Some(CEILING))
+        .expect("write timeout");
+    stream
+        .set_read_timeout(Some(CEILING))
+        .expect("read timeout");
+
+    // 4 MiB with no newline anywhere: far past any frame limit worth having,
+    // and nothing a real request could resemble.
+    let chunk = vec![b'x'; 64 * 1024];
+    let mut written = 0usize;
+    while written < 4 * 1024 * 1024 {
+        match stream.write_all(&chunk) {
+            Ok(()) => written += chunk.len(),
+            // The daemon closing on us is the intended outcome, and it can
+            // happen before we finish writing.
+            Err(_) => break,
+        }
+    }
+    let _ = stream.flush();
+
+    // The connection must end on the daemon's initiative, within a bound.
+    let mut sink = Vec::new();
+    let closed = stream.read_to_end(&mut sink);
+    assert!(
+        closed.is_ok(),
+        "the daemon left the abusive connection open: {closed:?}"
+    );
+    drop(stream);
+
+    // And the daemon is still there, supervising, and answering.
+    let status = daemon.wait_for_status("api to still be running", |s| s.contains("running"));
+    assert!(status.contains("api"), "{status}");
+    assert_eq!(
+        cli(&["restart", "api"], &cfg).0,
+        0,
+        "the daemon stopped working"
+    );
+}
+
+/// Garbage cannot be pumped in forever.
+///
+/// Answering a malformed line and carrying on means an unbounded amount of work
+/// per connection.  After a few strikes the daemon closes, and — the part that
+/// matters — it is still serving everybody else.
+#[test]
+fn repeated_malformed_requests_close_the_connection_only() {
+    use std::io::{BufRead, BufReader, Write};
+
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+    let socket = dir.path().join(".servicrab/daemon.sock");
+
+    let stream = std::os::unix::net::UnixStream::connect(&socket).expect("connect");
+    stream
+        .set_read_timeout(Some(CEILING))
+        .expect("read timeout");
+    stream
+        .set_write_timeout(Some(CEILING))
+        .expect("write timeout");
+    let mut writer = stream.try_clone().expect("clone");
+    let mut reader = BufReader::new(stream);
+
+    // Keep sending nonsense until the daemon stops listening.  The bound is the
+    // number of attempts, so a daemon that never closes fails rather than hangs.
+    let mut answers = 0;
+    let mut closed = false;
+    for _ in 0..64 {
+        if writer.write_all(b"{\"type\":\"fly\"}\n").is_err() || writer.flush().is_err() {
+            closed = true;
+            break;
+        }
+        let mut reply = String::new();
+        match reader.read_line(&mut reply) {
+            Ok(0) => {
+                closed = true;
+                break;
+            }
+            Ok(_) => {
+                assert!(reply.contains("\"error\""), "unexpected reply: {reply}");
+                answers += 1;
+            }
+            Err(_) => {
+                closed = true;
+                break;
+            }
+        }
+    }
+
+    assert!(
+        closed,
+        "the daemon answered {answers} malformed lines without ever giving up"
+    );
+    assert!(
+        answers < 64,
+        "the daemon never struck the connection out ({answers} answers)"
+    );
+
+    // The strike-out is per connection, not per daemon.
+    let status = daemon.wait_for_status("api to still be running", |s| s.contains("running"));
+    assert!(status.contains("api"), "{status}");
+    assert_eq!(
+        cli(&["restart", "api"], &cfg).0,
+        0,
+        "the daemon stopped working"
+    );
+}
+
+/// The connection cap must be a cap on *live* connections, not a budget that
+/// runs down over the daemon's lifetime.
+///
+/// A permit that outlived its connection would leave the daemon reachable but
+/// useless after 64 clients, which is a handful of CLI invocations.  Each round
+/// here completes a whole request/response exchange, so the daemon has demonstrably
+/// finished with one connection before the next is opened.
+#[test]
+fn the_connection_cap_is_released_when_a_client_leaves() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+    let socket = dir.path().join(".servicrab/daemon.sock");
+
+    // Well past the cap of 64, so a permit leaking once per client would stop
+    // this dead partway through.
+    let deadline = Instant::now() + CEILING;
+    for round in 0..200 {
+        assert!(
+            Instant::now() < deadline,
+            "the daemon stopped keeping up; reached round {round}"
+        );
+        let reply = ping(&socket)
+            .unwrap_or_else(|err| panic!("connection {round} did not get an answer: {err}"));
+        assert!(reply.contains("\"pong\""), "round {round}: {reply}");
+    }
+
+    assert_eq!(cli(&["status"], &cfg).0, 0, "the daemon stopped answering");
+}
+
+/// One ping over a fresh connection, with a bounded wait for the answer.
+fn ping(socket: &Path) -> std::io::Result<String> {
+    use std::io::{BufRead, BufReader, Write};
+
+    let stream = std::os::unix::net::UnixStream::connect(socket)?;
+    stream.set_read_timeout(Some(CEILING))?;
+    stream.set_write_timeout(Some(CEILING))?;
+
+    let mut writer = stream.try_clone()?;
+    writer.write_all(b"{\"type\":\"ping\"}\n")?;
+    writer.flush()?;
+
+    let mut reply = String::new();
+    BufReader::new(stream).read_line(&mut reply)?;
+    Ok(reply)
+}
+
+/// A dead-quiet connection is closed rather than held forever.
+///
+/// There was no read timeout at all, so a client that connected and said nothing
+/// kept a task and a descriptor for as long as the daemon lived.
+#[test]
+fn a_silent_connection_does_not_block_a_real_one() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+    let socket = dir.path().join(".servicrab/daemon.sock");
+
+    // Held open on purpose and never written to.
+    let _silent: Vec<std::os::unix::net::UnixStream> = (0..8)
+        .map(|_| std::os::unix::net::UnixStream::connect(&socket).expect("connect"))
+        .collect();
+
+    // Whatever the daemon does about them, it must keep serving.
+    assert_eq!(cli(&["status"], &cfg).0, 0);
+    assert_eq!(cli(&["restart", "api"], &cfg).0, 0);
+}
 
 #[test]
 fn a_daemon_keeps_its_profiles_across_a_reload() {

--- a/crates/servicrab-cli/tests/daemon.rs
+++ b/crates/servicrab-cli/tests/daemon.rs
@@ -476,10 +476,205 @@ restart = "always"
     );
 }
 
+/// The daemon asks the kernel who connected and serves only its own user.
+///
+/// The socket's mode is the first line of defence, but not the only one that
+/// should exist: a project on a filesystem that ignores Unix modes, or a
+/// directory an operator loosened, would otherwise hand full start/stop/
+/// shutdown authority to a stranger.  A test cannot become another user without
+/// root, so this pins the mechanism instead — the credentials the daemon reads
+/// are the ones the connecting process really has, and they arrive before any
+/// request is parsed.
+#[test]
+fn the_daemon_reads_the_credentials_of_whoever_connects() {
+    let dir = TempDir::new().unwrap();
+    let cfg = one_service(dir.path());
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("api to run", |s| s.contains("running"));
+
+    let socket = dir.path().join(".servicrab/daemon.sock");
+    let stream = std::os::unix::net::UnixStream::connect(&socket).expect("connect");
+
+    // Both directions of the check agree on this process, so a daemon comparing
+    // the peer uid against its own accepts us and would refuse anyone else.
+    let ours = nix::unistd::getuid().as_raw();
+    assert_eq!(peer_uid(&stream), ours);
+
+    // And the connection is a working one, so the check is not simply refusing
+    // everybody.
+    let (code, stdout, _) = cli(&["status"], &cfg);
+    assert_eq!(code, 0, "{stdout}");
+}
+
+/// The uid the kernel reports for the other end of `stream`.
+fn peer_uid(stream: &std::os::unix::net::UnixStream) -> u32 {
+    use nix::sys::socket::getsockopt;
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        getsockopt(stream, nix::sys::socket::sockopt::PeerCredentials)
+            .expect("peer credentials")
+            .uid()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        getsockopt(stream, nix::sys::socket::sockopt::LocalPeerCred)
+            .expect("peer credentials")
+            .uid()
+    }
+}
+
 /// Quote a path for `sh -c`.  The test paths are temp dirs, so this only has to
 /// survive spaces, but it must not silently mangle anything either.
 fn shell_quote(path: &Path) -> String {
     format!("'{}'", path.display().to_string().replace('\'', r"'\''"))
+}
+
+/// A project whose own directory is too deep to hold a socket must still get a
+/// daemon, and the socket must land in `$XDG_RUNTIME_DIR` rather than in the
+/// shared temp directory.
+///
+/// A name in `/tmp` is predictable to every local user: a stranger can squat it
+/// (and `/tmp` being sticky means the project can then never start a daemon at
+/// all), or bind their own listener and answer every `status`, `stop`, `down`
+/// and `reload` the operator sends.
+#[test]
+fn a_deeply_nested_project_puts_its_socket_in_the_runtime_dir() {
+    let dir = TempDir::new().unwrap();
+    // Short enough to hold a socket, which is what a real `/run/user/1000` is.
+    let runtime = TempDir::new_in("/tmp").unwrap();
+
+    let deep = dir.path().join("nested".repeat(12)).join("more".repeat(12));
+    fs::create_dir_all(&deep).unwrap();
+    let svc = resident(dir.path(), "api.sh");
+    let cfg = config(
+        &deep,
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            svc.display()
+        ),
+    );
+
+    let env = [("XDG_RUNTIME_DIR", runtime.path().to_str().unwrap())];
+    let _daemon = DaemonIn::start(&cfg, &env);
+
+    let deadline = Instant::now() + CEILING;
+    let socket = loop {
+        let found: Vec<PathBuf> = fs::read_dir(runtime.path())
+            .unwrap()
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("servicrab-") && name.ends_with(".sock"))
+            })
+            .collect();
+        if let Some(socket) = found.into_iter().next() {
+            break socket;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no socket appeared in {}",
+            runtime.path().display()
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    };
+
+    // Relocated to the private per-user directory, and nowhere else.
+    assert!(socket.starts_with(runtime.path()), "{}", socket.display());
+    assert_eq!(
+        fs::metadata(&socket).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+    // And it is a working daemon, not just a file.
+    let status = wait_for_status_in("api to run", &cfg, &env, |s| s.contains("running"));
+    assert!(status.contains("api"), "{status}");
+
+    // The rest of the state stays with the project.
+    assert!(deep.join(".servicrab/daemon.pid").exists());
+    assert!(
+        !deep.join(".servicrab/daemon.sock").exists(),
+        "the socket should have moved out of the project"
+    );
+}
+
+/// `cli`, plus environment variables the socket location depends on.
+fn cli_with_env(args: &[&str], config_path: &Path, env: &[(&str, &str)]) -> (i32, String, String) {
+    let mut command = Command::new(binary());
+    command
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1");
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let output = command.output().expect("failed to run servicrab");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn wait_for_status_in(
+    what: &str,
+    config_path: &Path,
+    env: &[(&str, &str)],
+    predicate: impl Fn(&str) -> bool,
+) -> String {
+    let deadline = Instant::now() + CEILING;
+    loop {
+        let (_, status, _) = cli_with_env(&["status"], config_path, env);
+        if predicate(&status) {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for {what}; last status:\n{status}");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// The [`Daemon`] guard for a project whose socket location depends on the
+/// environment, so `down` has to be given the same one.
+struct DaemonIn {
+    config: PathBuf,
+    env: Vec<(String, String)>,
+}
+
+impl DaemonIn {
+    fn start(config: &Path, env: &[(&str, &str)]) -> Self {
+        let (code, stdout, stderr) = cli_with_env(&["start"], config, env);
+        assert_eq!(code, 0, "start failed: {stdout}{stderr}");
+        Self {
+            config: config.to_path_buf(),
+            env: env
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+        }
+    }
+}
+
+impl Drop for DaemonIn {
+    fn drop(&mut self) {
+        let env: Vec<(&str, &str)> = self
+            .env
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        let _ = cli_with_env(&["down"], &self.config, &env);
+    }
 }
 
 #[test]

--- a/crates/servicrab-cli/tests/health.rs
+++ b/crates/servicrab-cli/tests/health.rs
@@ -366,6 +366,63 @@ on_unhealthy = "ignore"
 }
 
 #[test]
+fn a_dead_probe_still_reports_its_first_failure_but_not_every_tick() {
+    // `HealthProbeFailed` used to go out on every failing tick, so a probe that
+    // is dead for good under `on_unhealthy = "ignore"` was a perpetual event
+    // source.  The first failure still has to be reported — that is the one an
+    // operator acts on.
+    let dir = TempDir::new().unwrap();
+    let done = dir.path().join("done.txt");
+
+    script(
+        dir.path(),
+        "svc.sh",
+        &format!("sleep 2\necho done > {}", done.display()),
+    );
+    script(dir.path(), "probe.sh", "exit 1");
+
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.svc]
+command = ["{svc}"]
+restart = "never"
+
+[services.svc.health]
+command = ["{probe}"]
+interval = "100ms"
+retries = 1
+on_unhealthy = "ignore"
+"#,
+            svc = dir.path().join("svc.sh").display(),
+            probe = dir.path().join("probe.sh").display(),
+        ),
+    );
+
+    let (code, _stdout, stderr) = up(&cfg, &[]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    wait_for_file(&done);
+
+    let reports = stderr
+        .lines()
+        .filter(|l| l.contains("health probe failed"))
+        .count();
+    assert!(reports >= 1, "the first failure was not reported: {stderr}");
+    // Roughly twenty ticks fit into the two seconds the service runs, so an
+    // unthrottled monitor would report about twenty times.
+    assert!(
+        reports <= 3,
+        "a dead probe reported {reports} times; the throttle is not working:\n{stderr}"
+    );
+}
+
+#[test]
 fn a_tcp_probe_reports_a_listening_service_as_healthy() {
     let dir = TempDir::new().unwrap();
     // Pick a port by binding and releasing it immediately.

--- a/crates/servicrab-cli/tests/help.rs
+++ b/crates/servicrab-cli/tests/help.rs
@@ -1,0 +1,510 @@
+//! The `--help` output as a contract.
+//!
+//! The `clap` doc comments in `main.rs` *are* `servicrab --help`, which makes
+//! them the one piece of documentation a v1.0 promise applies to directly: an
+//! operator's muscle memory and a script's `--help | grep` both read it.  Two
+//! things can break that without breaking a compile, and neither had a test:
+//!
+//! - a reword.  A lint or a tidy-up that improves a sentence changes the page.
+//! - a layout switch.  Attaching per-value help to an enum-valued flag makes
+//!   `clap` render *every* page in its long form — one flag per paragraph, help
+//!   on its own line, blank lines between — for the whole binary.  It has been
+//!   hit once already, by `--color`, and the symptom is not local to the flag
+//!   that caused it.
+//!
+//! What is pinned is the flag set and the wording, with runs of whitespace
+//! collapsed.  Alignment is deliberately *not* pinned: `clap` aligns the
+//! description column to the longest flag on the page, so adding a flag shifts
+//! every other line on it — and adding a flag is exactly what 1.x is allowed to
+//! do.  A byte-exact snapshot would forbid what semver permits, be rewritten
+//! whenever it complained, and pin nothing by the second time.
+//!
+//! Adding a flag therefore means adding a row here.  Rewording an existing one
+//! means changing a row that says it is frozen, which is the point.
+
+use std::process::Command;
+
+/// One page's option list: the flag as `clap` spells it, and its description
+/// with runs of whitespace collapsed to one space.
+type Page = (&'static str, &'static [(&'static str, &'static str)]);
+
+/// What `--color`'s description says on every page it appears on.
+///
+/// Spelled once because it is global, so it is on all of them, and twenty
+/// copies of one sentence is twenty chances for them to disagree.
+const COLOR: &str = "When to colour output: auto (a stream that is a terminal), always, never \
+                     [default: auto] [possible values: auto, always, never]";
+
+/// What `--no-color`'s description says, likewise.
+const NO_COLOR: &str = "Never colour output; the same as --color=never";
+
+/// What `--config`'s description says, likewise.
+const CONFIG: &str = "Path to the configuration file. If omitted, discovers servicrab.toml by \
+                      walking up from the current directory";
+
+/// A page rendered in `clap`'s long layout puts each description on its own
+/// line, so there is no description beside the flag to record.
+///
+/// `generate` is the only page that is legitimately in the long layout — its
+/// value enums carry per-value help of their own — and it is here so that a
+/// change *to* the long layout elsewhere shows up as a page that started
+/// claiming this.
+const LONG: &str = "<the long layout>";
+
+/// Every page, and the options it offers.
+///
+/// The empty name is the top-level page.  `help` is left out: it is `clap`'s
+/// own, and `servicrab help --help` is an error rather than a page.
+const PAGES: &[Page] = &[
+    (
+        "",
+        &[
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+            ("-V, --version", "Print version"),
+        ],
+    ),
+    (
+        "init",
+        &[
+            ("--color <WHEN>", COLOR),
+            (
+                "--path <PATH>",
+                "Where to write the config file [default: servicrab.toml]",
+            ),
+            ("--force", "Overwrite the file if it already exists"),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "check",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            (
+                "--json",
+                "Print machine-readable JSON instead of the human-readable report. Validation \
+                 errors become a JSON list",
+            ),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "list",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            (
+                "--json",
+                "Output in JSON format instead of the human-readable table",
+            ),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "run",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            (
+                "--no-restart",
+                "Never restart the service, whatever the configured policy says",
+            ),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "exec",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "up",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            (
+                "--profile <NAME>",
+                "Also start the services in this profile. Repeatable. Cannot be combined with \
+                 naming services",
+            ),
+            (
+                "--no-restart",
+                "Never restart services, whatever their configured policy says",
+            ),
+            (
+                "--no-prefix",
+                "Do not prefix output lines with the service name",
+            ),
+            ("--timestamps", "Prefix output lines with a UTC timestamp"),
+            (
+                "--abort-on-failure",
+                "Stop the whole stack as soon as one service fails",
+            ),
+            (
+                "--json",
+                "Print one JSON event per line on stdout instead of rendering for a terminal",
+            ),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "watch",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            (
+                "--profile <NAME>",
+                "Also start the services in this profile. Repeatable. Cannot be combined with \
+                 naming services",
+            ),
+            (
+                "--no-restart",
+                "Never restart services, whatever their configured policy says",
+            ),
+            (
+                "--no-prefix",
+                "Do not prefix output lines with the service name",
+            ),
+            ("--timestamps", "Prefix output lines with a UTC timestamp"),
+            (
+                "--abort-on-failure",
+                "Stop the whole stack as soon as one service fails",
+            ),
+            (
+                "--json",
+                "Print one JSON event per line on stdout instead of rendering for a terminal",
+            ),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "logs",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            (
+                "-f, --follow",
+                "Keep printing new lines as they are written",
+            ),
+            ("--no-color", NO_COLOR),
+            (
+                "-n, --lines <LINES>",
+                "Number of trailing lines to show per service [default: 50]",
+            ),
+            (
+                "--no-prefix",
+                "Do not prefix output lines with the service name",
+            ),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "start",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            (
+                "--profile <NAME>",
+                "Also supervise the services in this profile. Repeatable. The daemon keeps the \
+                 set, so `reload` plans the same stack. Cannot be combined with naming services",
+            ),
+            (
+                "--no-restart",
+                "Never restart services, whatever their configured policy says",
+            ),
+            (
+                "--wait",
+                "Return only once every started service is ready — running, and health-checked \
+                 if it declares a health check. Exits non-zero if a service fails or the timeout \
+                 runs out",
+            ),
+            (
+                "--timeout <TIMEOUT>",
+                "How long --wait waits before giving up, e.g. `90s` or `2m`",
+            ),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "stop",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "restart",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "reload",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "events",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            (
+                "--json",
+                "Print one JSON object per line instead of rendering for a terminal",
+            ),
+            ("--no-color", NO_COLOR),
+            ("--no-prefix", "Do not prefix lines with the service name"),
+            ("-t, --timestamps", "Prefix lines with a UTC timestamp"),
+            (
+                "--no-logs",
+                "Leave captured stdout/stderr out of the stream",
+            ),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "status",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--json", "Print machine-readable JSON instead of a table"),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "down",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "generate",
+        &[
+            ("-c, --config <CONFIG>", LONG),
+            ("--color <WHEN>", LONG),
+            ("--no-color", LONG),
+            ("--scope <SCOPE>", LONG),
+            ("-o, --output <OUTPUT>", LONG),
+            ("--user <USER>", LONG),
+            ("--profile <NAME>", LONG),
+            ("-h, --help", LONG),
+        ],
+    ),
+    (
+        "completions",
+        &[
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "man",
+        &[
+            ("--color <WHEN>", COLOR),
+            (
+                "-o, --output <OUTPUT>",
+                "Write one page per command into this directory instead, creating it if needed",
+            ),
+            ("--no-color", NO_COLOR),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+    (
+        "daemon",
+        &[
+            ("-c, --config <CONFIG>", CONFIG),
+            ("--color <WHEN>", COLOR),
+            ("--no-color", NO_COLOR),
+            (
+                "--profile <NAME>",
+                "Also supervise the services in this profile. Repeatable",
+            ),
+            (
+                "--no-restart",
+                "Never restart services, whatever their configured policy says",
+            ),
+            ("-h, --help", "Print help"),
+        ],
+    ),
+];
+
+fn help(page: &str) -> String {
+    let binary = assert_cmd::cargo::cargo_bin("servicrab");
+    let mut command = Command::new(binary);
+    if !page.is_empty() {
+        command.arg(page);
+    }
+    // `TERM` and the rest are irrelevant to `--help`, but `COLUMNS` is not:
+    // `clap` wraps to the terminal width, and a narrow one would fold the long
+    // descriptions differently.  Set wide, and collapsed whitespace absorbs the
+    // rest.
+    let output = command
+        .arg("--help")
+        .env("COLUMNS", "400")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run servicrab");
+    assert!(
+        output.status.success(),
+        "`servicrab {page} --help` exited {:?}",
+        output.status.code()
+    );
+    String::from_utf8(output.stdout).expect("--help is UTF-8")
+}
+
+/// The flag and description read off one page, whitespace collapsed.
+fn options(text: &str) -> Vec<(String, String)> {
+    let mut found = Vec::new();
+    let mut inside = false;
+    for line in text.lines() {
+        if line.starts_with("Options:") {
+            inside = true;
+            continue;
+        }
+        if !inside {
+            continue;
+        }
+        // A page's option list runs to the first line that is neither indented
+        // nor blank; `clap`'s long layout has blank lines inside it.
+        if !line.starts_with(' ') && !line.trim().is_empty() {
+            break;
+        }
+        let Some((flag, rest)) = split_flag(line) else {
+            continue;
+        };
+        found.push((flag, collapse(&rest)));
+    }
+    found
+}
+
+/// Split an option line into the flag and whatever follows it, if it starts
+/// with a flag at all: a description's own continuation lines do not, and
+/// neither do the `- value: …` bullets the long layout lists a value enum with.
+fn split_flag(line: &str) -> Option<(String, String)> {
+    let trimmed = line.trim_start();
+    let rest_of_flag = trimmed.strip_prefix("--").or_else(|| {
+        trimmed
+            .strip_prefix('-')
+            .filter(|rest| !rest.starts_with('-'))
+    })?;
+    // `- system: a system-wide unit` is a bullet, not a flag; a flag's name
+    // begins immediately after its dashes.
+    if !rest_of_flag.starts_with(|c: char| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    // The flag is everything up to the run of spaces that opens the description
+    // column, or the whole of it in the long layout, where there is none.
+    let (flag, rest) = match trimmed.find("  ") {
+        Some(gap) => (&trimmed[..gap], &trimmed[gap..]),
+        None => (trimmed, ""),
+    };
+    let rest = if rest.trim().is_empty() {
+        LONG.to_string()
+    } else {
+        rest.to_string()
+    };
+    Some((flag.trim().to_string(), rest))
+}
+
+fn collapse(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Rewording an existing flag's help, or dropping one, is a breaking change to
+/// a v1.0 contract, and nothing else would notice.
+#[test]
+fn every_help_page_offers_the_flags_it_promised_with_the_wording_it_promised() {
+    for (page, expected) in PAGES {
+        let actual = options(&help(page));
+        let name = if page.is_empty() { "servicrab" } else { page };
+
+        let actual_flags: Vec<&str> = actual.iter().map(|(flag, _)| flag.as_str()).collect();
+        let expected_flags: Vec<&str> = expected.iter().map(|(flag, _)| *flag).collect();
+        assert_eq!(
+            actual_flags, expected_flags,
+            "the flags of `{name} --help` changed"
+        );
+
+        for ((flag, actual_help), (_, promised)) in actual.iter().zip(expected.iter()) {
+            assert_eq!(
+                actual_help,
+                &collapse(promised),
+                "the help for `{flag}` on `{name} --help` was reworded"
+            );
+        }
+    }
+}
+
+/// The trap this file exists for: per-value help on an enum-valued flag puts
+/// `clap` into its long layout for the *whole binary*, not just that flag's
+/// page, so the damage shows up nowhere near the change that caused it.
+/// `generate` is the one page that is meant to be in the long layout.
+#[test]
+fn only_the_page_with_per_value_help_is_in_claps_long_layout() {
+    for (page, expected) in PAGES {
+        let long = expected.iter().any(|(_, help)| *help == LONG);
+        let actual = options(&help(page));
+        let name = if page.is_empty() { "servicrab" } else { page };
+
+        assert!(
+            !actual.is_empty(),
+            "`{name} --help` listed no options at all"
+        );
+        assert_eq!(
+            actual.iter().all(|(_, help)| help == LONG),
+            long,
+            "`{name} --help` switched layout — per-value help on a flag does this to every page"
+        );
+    }
+}
+
+/// Every page is reachable and reported, so a subcommand added without a row
+/// here fails rather than going unchecked.
+#[test]
+fn every_subcommand_the_binary_offers_has_a_pinned_help_page() {
+    let top = help("");
+    let listed: Vec<&str> = top
+        .lines()
+        .skip_while(|line| !line.starts_with("Commands:"))
+        .skip(1)
+        .take_while(|line| line.starts_with(' '))
+        .filter_map(|line| line.split_whitespace().next())
+        // `help` is clap's own, and `servicrab help --help` is an error.
+        .filter(|name| *name != "help")
+        .collect();
+
+    let pinned: Vec<&str> = PAGES
+        .iter()
+        .map(|(page, _)| *page)
+        .filter(|page| !page.is_empty())
+        .collect();
+
+    assert_eq!(listed, pinned, "the set of subcommands changed");
+}

--- a/crates/servicrab-cli/tests/logs.rs
+++ b/crates/servicrab-cli/tests/logs.rs
@@ -407,6 +407,35 @@ command = ["{}"]
 }
 
 #[test]
+fn logs_reports_config_warnings() {
+    let dir = TempDir::new().unwrap();
+    let hello = script(dir.path(), "hello.sh", "echo hi");
+    // `max_restarts` alongside `restart = "never"` is inert, so loading warns.
+    // `logs` used to throw those warnings away, unlike the other commands.
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+[services.api]
+command = ["{}"]
+restart = "never"
+max_restarts = 3
+"#,
+            hello.display()
+        ),
+    );
+
+    // The command itself still fails (nothing has been captured), which is
+    // exactly the case where a warning is easiest to lose.
+    let (_, _, stderr) = cli(&["logs"], &cfg);
+    assert!(stderr.contains("max_restarts"), "{stderr}");
+}
+
+#[test]
 fn logs_reports_when_nothing_has_been_captured_yet() {
     let dir = TempDir::new().unwrap();
     let hello = script(dir.path(), "hello.sh", "echo hi");

--- a/crates/servicrab-cli/tests/logs.rs
+++ b/crates/servicrab-cli/tests/logs.rs
@@ -412,12 +412,30 @@ restart = "never"
     });
 
     let mut seen: Vec<String> = Vec::new();
-    let deadline = Instant::now() + CEILING;
-    let mut lines = reader.lines();
     let last = format!("line {LINES}");
-    while Instant::now() < deadline {
-        let Some(Ok(line)) = lines.next() else { break };
-        let line = line.trim().to_string();
+    // Draining stdout on its own thread keeps two things true at once: the
+    // follower never stalls on a full pipe (it has to keep polling a growing
+    // file, or the duplicate this test hunts for could not arise), and the wait
+    // below can be bounded by something other than a stopwatch.
+    let (lines_tx, lines_rx) = std::sync::mpsc::channel();
+    let drain = std::thread::spawn(move || {
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            if lines_tx.send(line.trim().to_string()).is_err() {
+                break;
+            }
+        }
+    });
+
+    // The condition is silence, not elapsed time. `CEILING` used to have to
+    // cover the paced flood *and* the follow of it, and the flood alone is
+    // `LINES * PACE` of sleeping — a floor rather than a duration, since every
+    // sleep overruns and on a loaded runner it overruns by enough that the
+    // deadline expired while the writer was still mid-file. That failed a
+    // follower that was working perfectly, blaming whichever line the clock cut
+    // it off at. A follow that has genuinely stopped is instead recognisable by
+    // what it does: it goes quiet and stays quiet, however slow the machine.
+    while let Ok(line) = lines_rx.recv_timeout(CEILING) {
         let done = line == last;
         seen.push(line);
         if done {
@@ -428,6 +446,8 @@ restart = "never"
     appender.join().unwrap();
     let _ = follower.kill();
     let _ = follower.wait();
+    drop(lines_rx);
+    let _ = drain.join();
 
     let mut once: BTreeSet<&String> = BTreeSet::new();
     let mut twice: Vec<&String> = Vec::new();

--- a/crates/servicrab-cli/tests/logs.rs
+++ b/crates/servicrab-cli/tests/logs.rs
@@ -431,6 +431,63 @@ command = ["{}"]
 }
 
 #[test]
+fn every_line_reaches_the_file_across_a_graceful_stop() {
+    // The writer batches its flushes, so the interesting case is the tail: the
+    // lines that were still buffered when the stack was asked to stop.  They
+    // have to be on disk by the time the process exits, in order, with nothing
+    // missing in between.
+    const LINES: usize = 2_000;
+
+    let dir = TempDir::new().unwrap();
+    let done = dir.path().join("printed");
+    let chatty = script(
+        dir.path(),
+        "chatty.sh",
+        &format!(
+            "i=1\nwhile [ $i -le {LINES} ]; do echo \"line $i\"; i=$((i+1)); done\necho printed > {}\nsleep 30",
+            done.display()
+        ),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+max_size = "1MB"
+max_files = 1
+[services.api]
+command = ["{}"]
+restart = "never"
+"#,
+            chatty.display()
+        ),
+    );
+
+    let mut stack = spawn(&["up"], &cfg);
+    // The script is done printing, so every line is either in the pipe, in the
+    // queue or already written — a stop from here must lose none of them.
+    wait_for_file(&done);
+    interrupt(&stack);
+    wait_bounded(&mut stack);
+
+    let written = fs::read_to_string(dir.path().join("logs/api.log")).unwrap();
+    let seen: Vec<&str> = written.lines().collect();
+    let expected: Vec<String> = (1..=LINES).map(|i| format!("line {i}")).collect();
+    assert_eq!(
+        seen.len(),
+        LINES,
+        "lost {} line(s) of output; last written was {:?}",
+        LINES - seen.len().min(LINES),
+        seen.last()
+    );
+    assert_eq!(seen, expected, "output was reordered");
+}
+
+#[test]
 fn run_also_writes_a_log_file_while_still_printing_output() {
     let dir = TempDir::new().unwrap();
     let hello = script(dir.path(), "hello.sh", "echo hello-from-run");

--- a/crates/servicrab-cli/tests/logs.rs
+++ b/crates/servicrab-cli/tests/logs.rs
@@ -436,7 +436,10 @@ fn every_line_reaches_the_file_across_a_graceful_stop() {
     // lines that were still buffered when the stack was asked to stop.  They
     // have to be on disk by the time the process exits, in order, with nothing
     // missing in between.
-    const LINES: usize = 2_000;
+    // Fewer than the event channel's log-line allowance, so nothing is dropped
+    // and the batched flush is what the test is about; far more than one flush
+    // batch, so the tail really is still buffered when the stop arrives.
+    const LINES: usize = 900;
 
     let dir = TempDir::new().unwrap();
     let done = dir.path().join("printed");
@@ -444,7 +447,7 @@ fn every_line_reaches_the_file_across_a_graceful_stop() {
         dir.path(),
         "chatty.sh",
         &format!(
-            "i=1\nwhile [ $i -le {LINES} ]; do echo \"line $i\"; i=$((i+1)); done\necho printed > {}\nsleep 30",
+            "awk 'BEGIN{{for (i = 1; i <= {LINES}; i++) print \"line \" i}}'\necho printed > {}\nsleep 30",
             done.display()
         ),
     );
@@ -468,11 +471,22 @@ restart = "never"
     );
 
     let mut stack = spawn(&["up"], &cfg);
+    // Keep reading the terminal output, so the renderer never stalls on a full
+    // pipe: what is being tested here is the batched flush, not the drop policy
+    // that a stalled consumer would trigger.
+    let terminal = stack.stdout.take().expect("stdout");
+    let drain = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut sink = Vec::new();
+        let _ = std::io::BufReader::new(terminal).read_to_end(&mut sink);
+    });
+
     // The script is done printing, so every line is either in the pipe, in the
     // queue or already written — a stop from here must lose none of them.
     wait_for_file(&done);
     interrupt(&stack);
     wait_bounded(&mut stack);
+    drain.join().expect("drain thread");
 
     let written = fs::read_to_string(dir.path().join("logs/api.log")).unwrap();
     let seen: Vec<&str> = written.lines().collect();

--- a/crates/servicrab-cli/tests/logs.rs
+++ b/crates/servicrab-cli/tests/logs.rs
@@ -2,6 +2,7 @@
 
 #![cfg(unix)]
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::os::unix::fs::PermissionsExt;
@@ -359,6 +360,184 @@ restart = "never"
 }
 
 #[test]
+fn a_sustained_append_is_never_followed_into_a_duplicate_line() {
+    // The bug this pins: `follow` sampled the file length, read to whatever the
+    // current end was — which by then could be past that length — and then set
+    // the offset back to the stale sample.  Everything appended in between came
+    // out again on the next pass.  A writer that never pauses is what makes that
+    // window land on every pass, so the assertion is simply that no line is ever
+    // printed twice.
+    const LINES: usize = 6_000;
+    /// Paced so the writer is still appending during every follow pass: at 200µs
+    /// a line, the flood outlasts several of the 200ms polls, which is exactly
+    /// when a read can run past a length sampled before it started.
+    const PACE: Duration = Duration::from_micros(200);
+
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("logs")).unwrap();
+    let log = dir.path().join("logs/api.log");
+    // A tail to start from, so the follower has an offset that is not zero.
+    fs::write(&log, "line 0\n").unwrap();
+
+    let cfg = config(
+        dir.path(),
+        r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+[services.api]
+command = ["true"]
+restart = "never"
+"#,
+    );
+
+    let mut follower = spawn(&["logs", "-f", "-n", "1"], &cfg);
+    let reader = BufReader::new(follower.stdout.take().unwrap());
+
+    // Nothing supervises this file: the writer here is the test, so the flood is
+    // under its control rather than a service's.
+    let appender = std::thread::spawn({
+        let log = log.clone();
+        move || {
+            use std::io::Write;
+            let mut file = fs::OpenOptions::new().append(true).open(&log).unwrap();
+            for i in 1..=LINES {
+                writeln!(file, "line {i}").unwrap();
+                file.flush().unwrap();
+                std::thread::sleep(PACE);
+            }
+        }
+    });
+
+    let mut seen: Vec<String> = Vec::new();
+    let deadline = Instant::now() + CEILING;
+    let mut lines = reader.lines();
+    let last = format!("line {LINES}");
+    while Instant::now() < deadline {
+        let Some(Ok(line)) = lines.next() else { break };
+        let line = line.trim().to_string();
+        let done = line == last;
+        seen.push(line);
+        if done {
+            break;
+        }
+    }
+
+    appender.join().unwrap();
+    let _ = follower.kill();
+    let _ = follower.wait();
+
+    let mut once: BTreeSet<&String> = BTreeSet::new();
+    let mut twice: Vec<&String> = Vec::new();
+    for line in &seen {
+        if !once.insert(line) {
+            twice.push(line);
+        }
+    }
+    assert!(
+        twice.is_empty(),
+        "{} line(s) came out more than once, e.g. {:?}",
+        twice.len(),
+        &twice[..twice.len().min(5)]
+    );
+    assert!(
+        seen.iter().any(|l| l == &format!("line {LINES}")),
+        "the follow stopped early: last was {:?}",
+        seen.last()
+    );
+}
+
+#[test]
+fn a_line_still_being_written_is_printed_once_and_whole() {
+    // A log file ends mid-line whenever a service is in the middle of writing
+    // one.  Treating that fragment as a finished line printed it immediately and
+    // then again, in full, once its newline arrived.
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("logs")).unwrap();
+    let log = dir.path().join("logs/api.log");
+    fs::write(&log, "complete\n").unwrap();
+
+    let cfg = config(
+        dir.path(),
+        r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+[services.api]
+command = ["true"]
+restart = "never"
+"#,
+    );
+
+    let mut follower = spawn(&["logs", "-f", "-n", "1"], &cfg);
+    let mut reader = BufReader::new(follower.stdout.take().unwrap());
+
+    let mut first = String::new();
+    reader.read_line(&mut first).unwrap();
+    assert_eq!(first.trim(), "complete");
+
+    {
+        use std::io::Write;
+        let mut file = fs::OpenOptions::new().append(true).open(&log).unwrap();
+        write!(file, "half a").unwrap();
+        file.flush().unwrap();
+        // Long enough that a follow pass has certainly seen the fragment.
+        std::thread::sleep(Duration::from_millis(500));
+        writeln!(file, " line").unwrap();
+        file.flush().unwrap();
+    }
+
+    let mut second = String::new();
+    reader.read_line(&mut second).unwrap();
+    let _ = follower.kill();
+    let _ = follower.wait();
+
+    assert_eq!(
+        second.trim(),
+        "half a line",
+        "the fragment was printed before it was finished"
+    );
+}
+
+#[test]
+fn a_log_line_that_is_not_utf8_does_not_stop_the_command() {
+    // A service is free to print a stray byte — a binary blob, output in another
+    // encoding, a multi-byte character caught mid-write.  That used to fail the
+    // whole command, and silently cut a follow short at the offending line.
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("logs")).unwrap();
+    fs::write(
+        dir.path().join("logs/api.log"),
+        b"before\n\xff\xfe not text\nafter\n",
+    )
+    .unwrap();
+
+    let cfg = config(
+        dir.path(),
+        r#"
+version = 1
+[project]
+name = "demo"
+[project.logs]
+dir = "logs"
+[services.api]
+command = ["true"]
+restart = "never"
+"#,
+    );
+
+    let (code, stdout, stderr) = cli(&["logs"], &cfg);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stdout.contains("before"), "{stdout}");
+    assert!(stdout.contains("after"), "{stdout}");
+    assert!(stdout.contains('\u{fffd}'), "{stdout}");
+}
+
+#[test]
 fn logs_explains_that_file_logging_is_off() {
     let dir = TempDir::new().unwrap();
     let hello = script(dir.path(), "hello.sh", "echo hi");
@@ -454,9 +633,12 @@ command = ["{}"]
         ),
     );
 
-    let (code, _, stderr) = cli(&["logs"], &cfg);
-    assert_eq!(code, 1);
+    // An empty log directory is what a stack that has not run yet looks like,
+    // so this says so and succeeds; `servicrab logs && …` is not a failure path.
+    let (code, stdout, stderr) = cli(&["logs"], &cfg);
+    assert_eq!(code, 0, "{stderr}");
     assert!(stderr.contains("no log output yet"), "{stderr}");
+    assert!(stdout.is_empty(), "{stdout}");
 }
 
 #[test]

--- a/crates/servicrab-cli/tests/reload.rs
+++ b/crates/servicrab-cli/tests/reload.rs
@@ -362,6 +362,141 @@ command = ["{}"]
     assert!(stderr.contains("no daemon is running"), "{stderr}");
 }
 
+/// A service that ignores SIGTERM, so its shutdown always runs to the
+/// configured timeout and can be observed while it is still in progress.
+fn stubborn(dir: &Path, name: &str, pids: &Path) -> PathBuf {
+    script(
+        dir,
+        name,
+        &format!(
+            "echo $$ >> {}\ntrap '' TERM\nwhile true; do sleep 0.2; done",
+            pids.display()
+        ),
+    )
+}
+
+fn is_alive(pid: i32) -> bool {
+    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
+}
+
+/// Every pid the stubborn fixture has recorded so far.
+fn recorded_pids(path: &Path) -> Vec<i32> {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| line.trim().parse().ok())
+        .collect()
+}
+
+/// Poll until `predicate` holds for the recorded pids, or the ceiling elapses.
+fn wait_for_pids(path: &Path, what: &str, predicate: impl Fn(&[i32]) -> bool) -> Vec<i32> {
+    let deadline = Instant::now() + CEILING;
+    loop {
+        let pids = recorded_pids(path);
+        if predicate(&pids) {
+            return pids;
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for {what}; recorded pids: {pids:?}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn a_reload_that_re_adds_a_still_stopping_service_leaves_one_process() {
+    // The dropped slot is still winding down when the second reload brings the
+    // service back.  Replacing that slot would discard the `stop` channel and
+    // the task handle of the process that is on its way out, so the freshly
+    // started one would never be signalled and would outlive the daemon.
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let pids = dir.path().join("slow.pids");
+    let slow = stubborn(dir.path(), "slow.sh", &pids);
+
+    let with_slow = format!(
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+[services.slow]
+command = ["{}"]
+restart = "always"
+shutdown_timeout = "4s"
+"#,
+        api.display(),
+        slow.display()
+    );
+    let without_slow = format!(
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+        api.display()
+    );
+
+    let cfg = write_config(dir.path(), &with_slow);
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        s.matches("running").count() == 2
+    });
+    let first = wait_for_pids(&pids, "the first process to record itself", |p| {
+        p.len() == 1
+    })[0];
+
+    // Drop the service.  It ignores SIGTERM, so it is still alive — and its
+    // slot still retired — while the next reload is applied.
+    fs::write(&cfg, &without_slow).unwrap();
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("1 removed"), "{stdout}");
+    assert!(
+        is_alive(first),
+        "the fixture should still be winding down at this point"
+    );
+
+    // …and put it straight back.
+    fs::write(&cfg, &with_slow).unwrap();
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("1 added"), "{stdout}");
+
+    // The replacement runs only once its predecessor is gone: exactly one
+    // process for this service is alive at any time.
+    let all = wait_for_pids(&pids, "the replacement to start", |p| p.len() == 2);
+    let alive: Vec<i32> = all.iter().copied().filter(|pid| is_alive(*pid)).collect();
+    assert_eq!(
+        alive.len(),
+        1,
+        "expected exactly one live process, recorded {all:?}, alive {alive:?}"
+    );
+    daemon.wait_for_status("the replacement to be reported running", |s| {
+        s.matches("running").count() == 2
+    });
+
+    // And the supervisor can still reach it: nothing survives `down`.
+    let (code, stdout, stderr) = cli(&["down"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    let deadline = Instant::now() + CEILING;
+    loop {
+        let survivors: Vec<i32> = all.iter().copied().filter(|pid| is_alive(*pid)).collect();
+        if survivors.is_empty() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            panic!("processes {survivors:?} outlived the daemon");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 #[test]
 fn a_reload_that_adds_a_dependency_does_not_block_the_dependent() {
     // A service with no dependents has no readiness subscriber, so its status

--- a/crates/servicrab-cli/tests/reload.rs
+++ b/crates/servicrab-cli/tests/reload.rs
@@ -363,6 +363,74 @@ command = ["{}"]
 }
 
 #[test]
+fn a_reload_that_adds_a_dependency_does_not_block_the_dependent() {
+    // A service with no dependents has no readiness subscriber, so its status
+    // is only recorded if the supervisor writes it unconditionally.  A reload
+    // that gives it a dependent makes that dependent read the recorded value
+    // first: a stale `pending` there blocks the dependent forever.
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let db = resident(dir.path(), "db.sh");
+    let independent = format!(
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+[services.db]
+command = ["{}"]
+restart = "always"
+"#,
+        api.display(),
+        db.display()
+    );
+    let cfg = write_config(dir.path(), &independent);
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        s.matches("running").count() == 2
+    });
+    let api_pid = daemon.pid_of("api");
+
+    // `db` has been up for a while by now, so the only record of its readiness
+    // is the one the supervisor kept while nobody was watching.
+    fs::write(
+        &cfg,
+        format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+depends_on = ["db"]
+[services.db]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display(),
+            db.display()
+        ),
+    )
+    .unwrap();
+
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("1 changed"), "{stdout}");
+
+    // The dependent has to come back up: `db` is running, so its dependency is
+    // satisfied the moment it is consulted.
+    let fresh = daemon.wait_for_pid_change("api", api_pid);
+    assert_ne!(fresh, api_pid);
+    daemon.wait_for_status("both services to run again", |s| {
+        s.matches("running").count() == 2
+    });
+}
+
+#[test]
 fn a_reloaded_service_can_be_controlled_by_name() {
     let dir = TempDir::new().unwrap();
     let api = resident(dir.path(), "api.sh");

--- a/crates/servicrab-cli/tests/reload.rs
+++ b/crates/servicrab-cli/tests/reload.rs
@@ -498,6 +498,93 @@ restart = "always"
 }
 
 #[test]
+fn a_retired_service_does_not_leave_its_process_group_behind() {
+    // A service dropped by a reload is still winding down when the daemon is
+    // told to stop, and it is no longer in the config, so `stop_all` treats it
+    // specially.  Whichever way it ends — signalled, escalated or detached —
+    // its whole process group has to go, not just the direct child.
+    let dir = TempDir::new().unwrap();
+    let api = resident(dir.path(), "api.sh");
+    let grandchild_pid = dir.path().join("grandchild.pid");
+    let deaf = script(
+        dir.path(),
+        "deaf.sh",
+        &format!(
+            "trap '' TERM\n\
+             (trap '' TERM; echo $$ > {}; while true; do sleep 0.2; done) &\n\
+             while true; do sleep 0.2; done",
+            grandchild_pid.display()
+        ),
+    );
+
+    let with_deaf = format!(
+        r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+[services.deaf]
+command = ["{}"]
+restart = "always"
+shutdown_timeout = "50s"
+"#,
+        api.display(),
+        deaf.display()
+    );
+    let cfg = write_config(dir.path(), &with_deaf);
+
+    let daemon = Daemon::start(&cfg);
+    daemon.wait_for_status("both services to run", |s| {
+        s.matches("running").count() == 2
+    });
+    let deadline = Instant::now() + CEILING;
+    while !grandchild_pid.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let grandchild: i32 = fs::read_to_string(&grandchild_pid)
+        .expect("the fixture should have recorded its grandchild")
+        .trim()
+        .parse()
+        .unwrap();
+    assert!(is_alive(grandchild), "fixture grandchild should be running");
+
+    // Retire the service.  It ignores SIGTERM, so it is still in its 50s
+    // shutdown when the daemon is told to stop.
+    fs::write(
+        &cfg,
+        format!(
+            r#"
+version = 1
+[project]
+name = "demo"
+[services.api]
+command = ["{}"]
+restart = "always"
+"#,
+            api.display()
+        ),
+    )
+    .unwrap();
+    let (code, stdout, stderr) = daemon.reload();
+    assert_eq!(code, 0, "{stdout}{stderr}");
+    assert!(stdout.contains("1 removed"), "{stdout}");
+
+    let (code, stdout, stderr) = cli(&["down"], &cfg);
+    assert_eq!(code, 0, "{stdout}{stderr}");
+
+    let deadline = Instant::now() + CEILING;
+    while is_alive(grandchild) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        !is_alive(grandchild),
+        "grandchild {grandchild} outlived the supervisor"
+    );
+}
+
+#[test]
 fn a_reload_that_adds_a_dependency_does_not_block_the_dependent() {
     // A service with no dependents has no readiness subscriber, so its status
     // is only recorded if the supervisor writes it unconditionally.  A reload

--- a/crates/servicrab-cli/tests/run.rs
+++ b/crates/servicrab-cli/tests/run.rs
@@ -560,6 +560,56 @@ fn no_orphans_remain_after_a_normal_run() {
 }
 
 #[test]
+fn a_hangup_does_not_leave_the_process_group_behind() {
+    // SIGHUP is what a closing terminal delivers.  Without an explicit handler
+    // its default disposition kills the supervisor outright, and every service
+    // it was supervising keeps running.
+    let dir = TempDir::new().unwrap();
+    let pidfile = dir.path().join("grandchild.pid");
+    let sh = script(
+        dir.path(),
+        "parent.sh",
+        &format!("sleep 30 &\necho $! > {}\nwait", pidfile.display()),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            "version = 1\n\
+             [project]\nname = \"hangup\"\n\
+             [services.tree]\ncommand = [\"{}\"]\n\
+             restart = \"always\"\nshutdown_timeout = \"1s\"\n",
+            sh.display()
+        ),
+    );
+
+    let mut child = spawn_service_with(&cfg, "tree", Stdio::null(), Stdio::piped());
+    wait_for_file(&pidfile);
+    let grandchild: i32 = fs::read_to_string(&pidfile)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert!(is_alive(grandchild), "fixture grandchild should be running");
+
+    kill(Pid::from_raw(child.id() as i32), Signal::SIGHUP).unwrap();
+    let code = wait_bounded(&mut child);
+    let stderr = drain_stderr(&mut child);
+
+    // 129 == 128 + SIGHUP; `restart = "always"` must not resurrect the service
+    // after the terminal went away either.
+    assert_eq!(code, 129, "supervisor said: {stderr}");
+
+    let deadline = Instant::now() + CEILING;
+    while is_alive(grandchild) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        !is_alive(grandchild),
+        "grandchild {grandchild} outlived the hung-up supervisor"
+    );
+}
+
+#[test]
 fn missing_executable_reports_a_spawn_failure() {
     let dir = TempDir::new().unwrap();
     let cfg = config(

--- a/crates/servicrab-cli/tests/run.rs
+++ b/crates/servicrab-cli/tests/run.rs
@@ -124,6 +124,21 @@ fn run_count(counter: &Path) -> usize {
         .unwrap_or(0)
 }
 
+/// Wait until the counting fixture has run at least `count` times.
+fn wait_for_runs(counter: &Path, count: usize) {
+    let deadline = Instant::now() + CEILING;
+    while Instant::now() < deadline {
+        if run_count(counter) >= count {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!(
+        "timed out waiting for {count} runs; saw {}",
+        run_count(counter)
+    );
+}
+
 fn is_alive(pid: i32) -> bool {
     kill(Pid::from_raw(pid), None).is_ok()
 }
@@ -395,6 +410,38 @@ fn no_restart_flag_overrides_the_configured_policy() {
     let (code, _, _) = run_service(&cfg, "svc", &["--no-restart"]);
     assert_eq!(code, 1);
     assert_eq!(run_count(&counter), 1, "--no-restart must win");
+}
+
+#[test]
+fn zero_max_restarts_means_unlimited_restarts() {
+    let dir = TempDir::new().unwrap();
+    let counter = dir.path().join("count.txt");
+    let cfg = counting_config(
+        dir.path(),
+        &counter,
+        "exit 1",
+        "restart = \"on-failure\"\nrestart_delay = \"100ms\"\nrestart_max_delay = \"100ms\"\nmax_restarts = 0\n",
+    );
+
+    let mut child = spawn_service_with(&cfg, "svc", Stdio::null(), Stdio::piped());
+
+    // More runs than the default budget of 10 would ever allow, so the count
+    // rules out both a finite limit and the old "give up on the first failure"
+    // reading of `max_restarts = 0`.
+    wait_for_runs(&counter, 12);
+    assert!(
+        is_alive(child.id() as i32),
+        "the supervisor must not have given up"
+    );
+
+    kill(Pid::from_raw(child.id() as i32), Signal::SIGINT).unwrap();
+    let code = wait_bounded(&mut child);
+    let stderr = drain_stderr(&mut child);
+    assert_eq!(code, 130, "supervisor said: {stderr}");
+    assert!(
+        !stderr.contains("giving up"),
+        "the restart limit must never be reached: {stderr}"
+    );
 }
 
 // ── shutdown ───────────────────────────────────────────────────────────────

--- a/crates/servicrab-cli/tests/up.rs
+++ b/crates/servicrab-cli/tests/up.rs
@@ -1105,10 +1105,17 @@ command = ["{}"]
     let (code, stdout, stderr) = up(&cfg, &["--json"]);
     assert_eq!(code, 0, "{stdout}{stderr}");
 
-    let events: Vec<serde_json::Value> = stdout
+    let lines: Vec<serde_json::Value> = stdout
         .lines()
         .map(|line| serde_json::from_str(line).unwrap_or_else(|e| panic!("{line:?}: {e}")))
         .collect();
+
+    // The stream opens with the same handshake line the daemon answers a
+    // `subscribe` with, so a reader can treat all three streams identically.
+    let (header, events) = lines.split_first().expect("a handshake line");
+    assert_eq!(header["type"], "ok", "{stdout}");
+    assert_eq!(header["schema_version"], 1, "{stdout}");
+
     assert!(!events.is_empty(), "no events on stdout");
     assert!(events.iter().all(|e| e["type"] == "event"));
     assert!(events.iter().all(|e| e["service"] == "hello"));

--- a/crates/servicrab-cli/tests/up.rs
+++ b/crates/servicrab-cli/tests/up.rs
@@ -528,6 +528,93 @@ restart = "never"
 
 // ── ordering, dependencies, shutdown ───────────────────────────────────────
 
+/// Ctrl+C has to work even when the operator's own output has backed up.
+///
+/// The renderer writes to stdout and stderr synchronously, and those writes
+/// block while the far end is not keeping up — which is the right thing to do
+/// to a slow terminal.  But a consumer that has stopped reading altogether (a
+/// parent that captured both pipes and reads them only after the child exits is
+/// the classic way to arrange this) leaves the renderer parked in a write that
+/// never returns.  The supervisor used to wait for that renderer before exiting,
+/// so `up` never exited at all: not in ten seconds, not in two minutes.
+///
+/// The verdict is the observable one an operator cares about: the service is
+/// gone and the process is gone, with the Ctrl+C exit code.
+#[test]
+fn a_ctrl_c_is_honoured_while_the_output_nobody_reads_is_backed_up() {
+    // Comfortably more than a pipe buffer holds once the renderer has prefixed
+    // it, so the renderer is certain to be parked in a write by the time the
+    // signal arrives.
+    const LINES: usize = 1_500;
+    const WIDTH: usize = 200;
+
+    let dir = TempDir::new().unwrap();
+    let printed = dir.path().join("printed");
+    let pidfile = dir.path().join("service.pid");
+    script(
+        dir.path(),
+        "noisy.sh",
+        &format!(
+            "echo $$ > {}\n\
+             awk 'BEGIN{{for (i = 1; i <= {LINES}; i++) printf \"warn %d {}\\n\", i}}' 1>&2\n\
+             echo done > {}\n\
+             sleep 30",
+            pidfile.display(),
+            "-".repeat(WIDTH),
+            printed.display()
+        ),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{0}"]
+restart = "never"
+"#,
+            dir.path().join("noisy.sh").display()
+        ),
+    );
+
+    // Both pipes are captured and neither is ever read, so every write the
+    // renderer makes past the first pipeful blocks for good.
+    let mut child = Command::new(binary())
+        .arg("up")
+        .arg("--config")
+        .arg(&cfg)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn servicrab up");
+
+    wait_for_file(&pidfile);
+    let service = read_pid(&pidfile);
+    // Every line has been handed over, so the renderer has as much to write as
+    // it is ever going to get.
+    wait_for_file(&printed);
+
+    kill(Pid::from_raw(child.id() as i32), Signal::SIGINT).unwrap();
+    let code = wait_bounded(&mut child);
+
+    assert_eq!(
+        code, 130,
+        "a Ctrl+C that is honoured exits 130, whatever the output is doing"
+    );
+    // Nothing may be left behind, which is the promise the process groups exist
+    // for; the pid is the service's shell, which leads its own group.
+    assert!(
+        !is_alive(service),
+        "the service ({service}) outlived the supervisor"
+    );
+}
+
 /// The verdict comes from the supervisor's own event stream, not from what the
 /// two service scripts manage to write to a shared file.
 ///

--- a/crates/servicrab-cli/tests/up.rs
+++ b/crates/servicrab-cli/tests/up.rs
@@ -426,6 +426,106 @@ command = ["{0}"]
     );
 }
 
+/// A service that prints faster than the supervisor can render must not grow
+/// the supervisor's heap without limit.  The bound comes with a drop policy, and
+/// the policy has to be *visible*: the operator sees a `LogLinesDropped` event
+/// rather than silently missing output.
+#[test]
+fn a_flooding_service_has_its_output_dropped_and_says_so() {
+    // Far more than the channel's log-line allowance, and more than fits in the
+    // pipe the renderer writes to while it is blocked below.
+    const LINES: usize = 20_000;
+
+    let dir = TempDir::new().unwrap();
+    let printed = dir.path().join("printed");
+    script(
+        dir.path(),
+        "flood.sh",
+        &format!(
+            "awk 'BEGIN{{for (i = 1; i <= {LINES}; i++) print \"line \" i}}'\necho done > {}\nsleep 30",
+            printed.display()
+        ),
+    );
+    let cfg = config(
+        dir.path(),
+        &format!(
+            r#"
+version = 1
+
+[project]
+name = "demo"
+
+[services.api]
+command = ["{0}"]
+restart = "never"
+"#,
+            dir.path().join("flood.sh").display()
+        ),
+    );
+
+    // Both streams are piped and neither is read yet, so the renderer blocks on
+    // its first full stdout write and the queue behind it has to absorb the
+    // flood — or refuse to.
+    let mut child = Command::new(binary())
+        .arg("up")
+        .arg("--config")
+        .arg(&cfg)
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn servicrab up");
+
+    // The script is done printing, so every line has been read off the pipe and
+    // either queued or dropped.
+    wait_for_file(&printed);
+
+    // Now let the renderer catch up, which is when it gets to the report.
+    let mut stdout = child.stdout.take().expect("stdout");
+    let drain = std::thread::spawn(move || {
+        let mut sink = String::new();
+        use std::io::Read;
+        let _ = stdout.read_to_string(&mut sink);
+        sink.lines().filter(|l| l.contains("line ")).count()
+    });
+
+    let mut stderr = std::io::BufReader::new(child.stderr.take().expect("stderr"));
+    let mut reported = None;
+    let deadline = Instant::now() + CEILING;
+    let mut seen = String::new();
+    while Instant::now() < deadline {
+        let mut line = String::new();
+        use std::io::BufRead;
+        if stderr.read_line(&mut line).unwrap_or(0) == 0 {
+            break;
+        }
+        seen.push_str(&line);
+        if line.contains("dropped") {
+            reported = Some(line);
+            break;
+        }
+    }
+
+    kill(Pid::from_raw(child.id() as i32), Signal::SIGINT).unwrap();
+    wait_bounded(&mut child);
+    let rendered = drain.join().expect("drain thread");
+
+    let reported = reported.unwrap_or_else(|| {
+        panic!("the drop was never reported; stderr so far:\n{seen}\nrendered {rendered} line(s)")
+    });
+    assert!(
+        reported.contains("output line(s)"),
+        "unexpected report: {reported}"
+    );
+    // The verdict is the observable one: output really was dropped, so the
+    // supervisor never had to hold all of it.
+    assert!(
+        rendered < LINES,
+        "nothing was dropped, so the channel was not bounded ({rendered} of {LINES} rendered)"
+    );
+}
+
 // ── ordering, dependencies, shutdown ───────────────────────────────────────
 
 /// The verdict comes from the supervisor's own event stream, not from what the

--- a/crates/servicrab-cli/tests/watch.rs
+++ b/crates/servicrab-cli/tests/watch.rs
@@ -10,6 +10,8 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use nix::sys::signal::{kill, Signal};
@@ -239,6 +241,49 @@ fn up_also_restarts_on_a_watched_change() {
 }
 
 // ── entry checks ───────────────────────────────────────────────────────────
+
+#[test]
+fn a_tree_that_never_settles_still_gets_its_restart() {
+    // A file changing faster than the debounce window keeps the tree from ever
+    // being quiet.  Without a cap on the settle loop the watcher re-scans
+    // forever and the restart it exists to request is never made.
+    let dir = TempDir::new().unwrap();
+    let cfg = project(
+        dir.path(),
+        "paths = [\"src\"]\ninterval = \"200ms\"\ndebounce = \"100ms\"",
+    );
+    let starts_log = dir.path().join("starts.log");
+
+    let child = spawn("watch", &cfg);
+    wait_for_starts(&starts_log, 1);
+
+    // A writer that keeps a file in the watched tree changing throughout.
+    let noisy = dir.path().join("src/noisy.txt");
+    let stop = Arc::new(AtomicBool::new(false));
+    let writer = {
+        let stop = Arc::clone(&stop);
+        std::thread::spawn(move || {
+            let mut n = 0u64;
+            while !stop.load(Ordering::Relaxed) {
+                n += 1;
+                // Growing content, so the change is visible even to a
+                // second-granularity mtime.
+                let _ = fs::write(&noisy, "x".repeat(n as usize % 4096 + 1));
+                std::thread::sleep(Duration::from_millis(40));
+            }
+        })
+    };
+
+    // The verdict comes from the service actually starting again, within the
+    // file's own bounded wait.
+    let result = std::panic::catch_unwind(|| wait_for_starts(&starts_log, 2));
+    stop.store(true, Ordering::Relaxed);
+    writer.join().unwrap();
+    let stderr = interrupt(child);
+    result.unwrap_or_else(|_| {
+        panic!("the watcher never requested a restart; supervisor said: {stderr}")
+    });
+}
 
 #[test]
 fn watch_refuses_to_start_when_nothing_is_watched() {

--- a/crates/servicrab-core/Cargo.toml
+++ b/crates/servicrab-core/Cargo.toml
@@ -25,3 +25,6 @@ nix = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+# `test-util` gives the tests a paused clock, so a test that has to observe a
+# timeout costs no wall time.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/servicrab-core/Cargo.toml
+++ b/crates/servicrab-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servicrab-core"
-description = "Configuration models, validation, and service lifecycle types for servicrab"
+description = "Configuration models, validation, and the process runtime behind servicrab"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/servicrab-core/src/config.rs
+++ b/crates/servicrab-core/src/config.rs
@@ -376,7 +376,8 @@ pub struct Service {
     pub restart_delay: Duration,
     /// Maximum delay between restart attempts (exponential-backoff ceiling).
     pub restart_max_delay: Duration,
-    /// Maximum number of restart attempts before giving up.
+    /// Maximum number of restart attempts before giving up; `0` means
+    /// unlimited.
     pub max_restarts: u32,
     /// How long the process must run before it is considered stable.
     pub stable_after: Duration,

--- a/crates/servicrab-core/src/error.rs
+++ b/crates/servicrab-core/src/error.rs
@@ -234,6 +234,11 @@ pub enum ConfigError {
         reason: String,
     },
 
+    /// `[health] retries` is zero, which would mean "unhealthy without ever
+    /// probing".
+    #[error("service {service:?}: [health] retries must be at least 1, got 0")]
+    InvalidHealthRetries { service: String },
+
     /// A malformed byte size in `[project.logs]`.
     #[error("project.logs: invalid size {value:?} for field `{field}`: {reason}")]
     InvalidSize {

--- a/crates/servicrab-core/src/error.rs
+++ b/crates/servicrab-core/src/error.rs
@@ -316,6 +316,14 @@ pub enum ConfigWarning {
         service: String,
         field: &'static str,
     },
+
+    /// A service asked for file logging but the project never declared where
+    /// log files go, so nothing is written.
+    LogsWithoutProjectLogs { service: String },
+
+    /// `on_unhealthy = "restart"` was combined with `restart = "never"`, so an
+    /// unhealthy service is stopped and never comes back.
+    UnhealthyRestartWithoutPolicy { service: String },
 }
 
 impl std::fmt::Display for ConfigWarning {
@@ -334,6 +342,18 @@ impl std::fmt::Display for ConfigWarning {
                 write!(
                     f,
                     "service {service:?}: field `{field}` has no effect when restart = \"never\""
+                )
+            }
+            ConfigWarning::LogsWithoutProjectLogs { service } => {
+                write!(
+                    f,
+                    "service {service:?}: [logs] enabled has no effect without a [project.logs] table, so no output is written to a file"
+                )
+            }
+            ConfigWarning::UnhealthyRestartWithoutPolicy { service } => {
+                write!(
+                    f,
+                    "service {service:?}: [health] on_unhealthy = \"restart\" only stops the service when restart = \"never\"; use on-failure, always or unless-stopped to bring it back"
                 )
             }
         }

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -42,7 +42,7 @@ pub use load::{discover_config, load, resolve_config_path};
 pub use runtime::filewatch::{spawn_watchers, watched_services};
 pub use runtime::{
     control_channel, event_channel, plan_stack, with_dependents, Control, ControlTx, EventKind,
-    EventReceiver, EventSender, EventSink, ForegroundRunner, Health, LogRouter, LogWriter,
+    EventReceiver, EventSender, EventSink, ForegroundRunner, Health, LogRouter, LogSink, LogWriter,
     OutputMode, RunOptions, RunOutcome, Selection, ServiceEvent, ServiceRunner, ServiceStatus,
     SignalWatcher, StackOptions, StackOutcome, StackSupervisor, StatusRegistry, Stream,
 };

--- a/crates/servicrab-core/src/lib.rs
+++ b/crates/servicrab-core/src/lib.rs
@@ -1,11 +1,27 @@
-//! `servicrab-core` — configuration types, loading, validation, and
-//! dependency-graph utilities.
+//! `servicrab-core` — configuration types, loading, validation, dependency-graph
+//! utilities, and the process runtime.
 //!
 //! # Architecture
 //!
-//! This crate is intentionally dependency-light so that it can be shared by
-//! the CLI, its daemon, and any other client without pulling in the full async
-//! runtime.  All I/O is delegated to callers.
+//! This crate does the work; the CLI renders it. It never formats output for a
+//! terminal: it returns typed values and publishes structured events, and
+//! whoever calls it decides how those look.
+//!
+//! It is not I/O-free, and it is not sync. [`mod@load`] reads files,
+//! [`validation`] walks `PATH` to check that a command exists, the TCP health
+//! probe in [`runtime::health`] opens connections, and [`runtime`] is built on
+//! `tokio`, which is a full dependency. What the crate avoids is a *second*
+//! runtime and the CLI's own dependencies — no `clap`, no styling, no terminal
+//! detection — so a different front end can link it without inheriting ours.
+//!
+//! The process runtime is Linux and macOS only. On other platforms the runtime
+//! entry points return [`RuntimeError::UnsupportedPlatform`] rather than failing
+//! to compile, so the whole workspace still builds and its tests still run
+//! there.
+//!
+//! There is no semver guarantee on this Rust API. The stable surface of the
+//! project is the `servicrab` CLI, its socket protocol and its JSON output; this
+//! crate is an implementation detail of those and may change in any release.
 //!
 //! ## Usage
 //!

--- a/crates/servicrab-core/src/lifecycle.rs
+++ b/crates/servicrab-core/src/lifecycle.rs
@@ -269,6 +269,7 @@ pub struct RestartTracker {
     policy: RestartPolicy,
     restart_delay: Duration,
     restart_max_delay: Duration,
+    /// Restarts allowed between stable runs; `0` means unlimited.
     max_restarts: u32,
     stable_after: Duration,
     attempts: u32,
@@ -276,6 +277,8 @@ pub struct RestartTracker {
 
 impl RestartTracker {
     /// Build a tracker from validated service settings.
+    ///
+    /// `max_restarts = 0` means unlimited restarts.
     pub fn new(
         policy: RestartPolicy,
         restart_delay: Duration,
@@ -360,18 +363,30 @@ impl RestartTracker {
             return RestartDecision::Stop;
         }
 
-        if self.attempts >= self.max_restarts {
+        if !self.budget_left() {
             return RestartDecision::Fail {
                 reason: ShutdownReason::RestartLimit,
             };
         }
 
         let delay = self.backoff_for_attempt(self.attempts);
-        self.attempts += 1;
+        // Saturating because an unlimited budget has no bound to stop the
+        // counter: the number is only reported, and a service that has crashed
+        // four billion times has bigger problems than an off-by-one.
+        self.attempts = self.attempts.saturating_add(1);
         RestartDecision::Restart {
             delay,
             attempt: self.attempts,
         }
+    }
+
+    /// Whether another restart attempt is allowed.
+    ///
+    /// `max_restarts = 0` means unlimited, which is the reading users expect
+    /// and the one Compose and systemd use.  "Give up on the first failure" is
+    /// what `restart = "never"` is for.
+    fn budget_left(&self) -> bool {
+        self.max_restarts == 0 || self.attempts < self.max_restarts
     }
 
     fn should_restart(&self, reason: ExitReason) -> bool {
@@ -667,14 +682,41 @@ mod tests {
     }
 
     #[test]
-    fn zero_max_restarts_fails_immediately() {
+    fn zero_max_restarts_means_unlimited() {
         let mut t =
             RestartTracker::new(RestartPolicy::Always, SEC, SEC, 0, Duration::from_secs(60));
+        // Well past any plausible finite budget, including the old default.
+        for expected in 1..=50 {
+            assert_eq!(
+                t.decide(outcome(ExitReason::Code(1)), None),
+                RestartDecision::Restart {
+                    delay: SEC,
+                    attempt: expected
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn an_unlimited_budget_still_obeys_the_policy() {
+        // "Unlimited" is about the budget, not about the policy: a clean exit
+        // under `on-failure` is still not a reason to restart.
+        let mut t = RestartTracker::new(
+            RestartPolicy::OnFailure,
+            SEC,
+            SEC,
+            0,
+            Duration::from_secs(60),
+        );
+        assert_eq!(
+            t.decide(outcome(ExitReason::Code(0)), None),
+            RestartDecision::Stop
+        );
+
+        let mut t = RestartTracker::new(RestartPolicy::Never, SEC, SEC, 0, Duration::from_secs(60));
         assert_eq!(
             t.decide(outcome(ExitReason::Code(1)), None),
-            RestartDecision::Fail {
-                reason: ShutdownReason::RestartLimit
-            }
+            RestartDecision::Stop
         );
     }
 

--- a/crates/servicrab-core/src/lifecycle.rs
+++ b/crates/servicrab-core/src/lifecycle.rs
@@ -735,6 +735,65 @@ mod tests {
     }
 
     #[test]
+    fn an_unlimited_budget_still_stops_on_a_user_shutdown() {
+        // The interaction of two independently-added features: `max_restarts =
+        // 0` removes the only bound that would otherwise end the restart loop,
+        // so this pins that a user-requested stop still wins over an unlimited
+        // budget.
+        for reason in [
+            ShutdownReason::UserInterrupt,
+            ShutdownReason::Terminated,
+            ShutdownReason::HangUp,
+            ShutdownReason::Requested,
+        ] {
+            let mut t =
+                RestartTracker::new(RestartPolicy::Always, SEC, SEC, 0, Duration::from_secs(60));
+            // Crash a few times first, so the tracker is mid-loop rather than
+            // fresh when the shutdown arrives.
+            for _ in 0..3 {
+                t.decide(outcome(ExitReason::Code(1)), None);
+            }
+            assert_eq!(
+                t.decide(outcome(ExitReason::Code(1)), Some(reason)),
+                RestartDecision::Stop,
+                "unlimited budget must not survive {reason:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_user_shutdown_outranks_an_exhausted_budget() {
+        // This is what actually pins the order of the two checks in `decide`.
+        // Moving the user-requested short-circuit below the budget check leaves
+        // every other test green — including the unlimited case above, because
+        // an unlimited budget never reaches `Fail` — and only shows up here: a
+        // service the user stopped must report `Stop`, not blame the restart
+        // limit for a shutdown the user asked for.
+        let mut t =
+            RestartTracker::new(RestartPolicy::Always, SEC, SEC, 2, Duration::from_secs(60));
+        for _ in 0..2 {
+            assert!(matches!(
+                t.decide(outcome(ExitReason::Code(1)), None),
+                RestartDecision::Restart { .. }
+            ));
+        }
+        // The budget is now spent: without a shutdown this is a `Fail`.
+        assert_eq!(
+            t.clone().decide(outcome(ExitReason::Code(1)), None),
+            RestartDecision::Fail {
+                reason: ShutdownReason::RestartLimit
+            }
+        );
+        assert_eq!(
+            t.decide(
+                outcome(ExitReason::Code(1)),
+                Some(ShutdownReason::UserInterrupt)
+            ),
+            RestartDecision::Stop
+        );
+    }
+
+    #[test]
     fn stable_period_resets_attempt_counter() {
         let mut t = tracker(RestartPolicy::Always);
         // Two quick crashes advance the backoff.

--- a/crates/servicrab-core/src/lifecycle.rs
+++ b/crates/servicrab-core/src/lifecycle.rs
@@ -190,6 +190,12 @@ pub enum ShutdownReason {
     UserInterrupt,
     /// The supervisor itself received SIGTERM.
     Terminated,
+    /// The supervisor's controlling terminal went away (SIGHUP).
+    ///
+    /// Distinct from [`ShutdownReason::Terminated`] because the cause is
+    /// different — a closed terminal rather than a deliberate `kill` — and
+    /// because it maps to a different exit code.
+    HangUp,
     /// The restart limit was exhausted.
     RestartLimit,
     /// Another service in the stack failed and the whole stack is being torn
@@ -207,7 +213,10 @@ impl ShutdownReason {
     pub fn is_user_requested(self) -> bool {
         matches!(
             self,
-            ShutdownReason::UserInterrupt | ShutdownReason::Terminated | ShutdownReason::Requested
+            ShutdownReason::UserInterrupt
+                | ShutdownReason::Terminated
+                | ShutdownReason::HangUp
+                | ShutdownReason::Requested
         )
     }
 }
@@ -217,6 +226,7 @@ impl std::fmt::Display for ShutdownReason {
         match self {
             ShutdownReason::UserInterrupt => write!(f, "interrupted by user"),
             ShutdownReason::Terminated => write!(f, "supervisor terminated"),
+            ShutdownReason::HangUp => write!(f, "controlling terminal closed"),
             ShutdownReason::RestartLimit => write!(f, "restart limit exhausted"),
             ShutdownReason::StackFailure => write!(f, "another service failed"),
             ShutdownReason::Requested => write!(f, "stopped on request"),
@@ -593,7 +603,11 @@ mod tests {
 
     #[test]
     fn user_shutdown_never_restarts() {
-        for reason in [ShutdownReason::UserInterrupt, ShutdownReason::Terminated] {
+        for reason in [
+            ShutdownReason::UserInterrupt,
+            ShutdownReason::Terminated,
+            ShutdownReason::HangUp,
+        ] {
             let mut t = tracker(RestartPolicy::Always);
             assert_eq!(
                 t.decide(outcome(ExitReason::Code(1)), Some(reason)),
@@ -735,6 +749,9 @@ mod tests {
     fn restart_limit_shutdown_is_not_user_requested() {
         assert!(ShutdownReason::UserInterrupt.is_user_requested());
         assert!(ShutdownReason::Terminated.is_user_requested());
+        // A closed terminal is the user going away, not a failure to restart
+        // around: `restart = "always"` must not resurrect the service.
+        assert!(ShutdownReason::HangUp.is_user_requested());
         assert!(!ShutdownReason::RestartLimit.is_user_requested());
     }
 }

--- a/crates/servicrab-core/src/load.rs
+++ b/crates/servicrab-core/src/load.rs
@@ -43,6 +43,19 @@ pub fn load(path: &Path) -> Result<(Config, Vec<ConfigWarning>), Vec<ConfigError
         }]
     })?;
 
+    // Before the field-level parse, and this order is the whole point.  Every
+    // struct in `crate::raw` denies unknown fields, deliberately, so a typo is
+    // fatal — but a schema this build predates is *made of* fields it does not
+    // know, so `version = 2` used to be reported as `unknown field
+    // 'new_key_from_v2'` with not a word about the version.  The one message
+    // that tells an operator to upgrade servicrab was unreachable for exactly
+    // the files it was written for.
+    if let Some(version) = declared_version(&raw_str) {
+        if version != crate::validation::SUPPORTED_VERSION {
+            return Err(vec![ConfigError::UnsupportedVersion { version }]);
+        }
+    }
+
     let mut raw: RawConfig = toml::from_str(&raw_str).map_err(|e| {
         vec![ConfigError::Parse {
             path: path.to_path_buf(),
@@ -58,6 +71,25 @@ pub fn load(path: &Path) -> Result<(Config, Vec<ConfigWarning>), Vec<ConfigError
     }
 
     validate_raw(raw, path)
+}
+
+/// The `version` a file declares, ignoring everything else in it.
+///
+/// Deliberately the most forgiving read of the file that can still answer the
+/// question: nothing but `version` is named, so no key a future schema adds can
+/// stop it from being found.  `None` means the file did not say — a missing or
+/// non-numeric `version` is left to the ordinary parse, which already reports
+/// both, and better than a pre-pass could.
+fn declared_version(raw_str: &str) -> Option<u32> {
+    /// Everything but `version`, thrown away.
+    #[derive(serde::Deserialize)]
+    struct JustTheVersion {
+        version: u32,
+    }
+
+    toml::from_str::<JustTheVersion>(raw_str)
+        .ok()
+        .map(|declared| declared.version)
 }
 
 /// Resolve the configuration path: use `explicit` if provided, otherwise
@@ -152,5 +184,96 @@ mod tests {
         std::fs::write(&path, "this is NOT valid toml ][").unwrap();
         let errs = load(&path).unwrap_err();
         assert!(errs.iter().any(|e| matches!(e, ConfigError::Parse { .. })));
+    }
+
+    /// Load `toml` from a temp file and keep the errors it produced.
+    ///
+    /// The `TempDir` comes back because it holds the file those errors name; a
+    /// caller that dropped it would be reading about a path that no longer
+    /// exists.
+    fn errors_from(toml: &str) -> (TempDir, Vec<ConfigError>) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("servicrab.toml");
+        std::fs::write(&path, toml).unwrap();
+        let errors = load(&path).map(|_| ()).expect_err("expected errors");
+        (dir, errors)
+    }
+
+    /// The defect: a config written for a later schema is *made of* keys this
+    /// build does not know, and every struct in [`crate::raw`] denies unknown
+    /// fields, so the parse failed first and reported one of those keys as a
+    /// typo.  The one message that tells an operator to upgrade servicrab was
+    /// unreachable for exactly the files it was written for.
+    #[test]
+    fn a_config_from_a_later_schema_reports_its_version_not_its_keys() {
+        let (_dir, errs) = errors_from(
+            "version = 2\n[project]\nname = \"p\"\nnew_key_from_v2 = true\n\
+             [services.s]\ncommand = [\"echo\"]\n",
+        );
+
+        assert!(
+            errs.iter()
+                .any(|e| matches!(e, ConfigError::UnsupportedVersion { version: 2 })),
+            "{errs:?}"
+        );
+        // And only that: naming the key as well would be advice to delete the
+        // one line that is not the problem.
+        assert!(
+            !errs.iter().any(|e| matches!(e, ConfigError::Parse { .. })),
+            "{errs:?}"
+        );
+    }
+
+    /// Only the version changes.  An unrecognised key inside a `version = 1`
+    /// file is a typo, and being fatal is the protection that catches it — a
+    /// misspelled `comand` that loaded quietly would be far worse than one that
+    /// refuses.
+    #[test]
+    fn an_unknown_key_under_the_supported_version_is_still_fatal() {
+        let (_dir, errs) = errors_from(
+            "version = 1\n[project]\nname = \"p\"\nnew_key_from_v2 = true\n\
+             [services.s]\ncommand = [\"echo\"]\n",
+        );
+
+        assert!(
+            errs.iter().any(|e| matches!(e, ConfigError::Parse { .. })),
+            "{errs:?}"
+        );
+    }
+
+    /// The pre-pass answers one question and declines the rest.  A file with no
+    /// `version` at all, or one that is not a number, is the ordinary parse's
+    /// business — it reports both, and with the line and column a pre-pass
+    /// working on a whole-file deserialize could not.
+    #[test]
+    fn a_missing_or_unreadable_version_is_left_to_the_ordinary_parse() {
+        for toml in [
+            "[project]\nname = \"p\"\n[services.s]\ncommand = [\"echo\"]\n",
+            "version = \"two\"\n[project]\nname = \"p\"\n[services.s]\ncommand = [\"echo\"]\n",
+        ] {
+            let (_dir, errs) = errors_from(toml);
+
+            assert!(
+                errs.iter().any(|e| matches!(e, ConfigError::Parse { .. })),
+                "{toml:?} gave {errs:?}"
+            );
+        }
+    }
+
+    /// The version is read before anything else, so it is reported before
+    /// anything else — including an `include` that could not be read, which used
+    /// to be the first thing a `version = 2` file heard about.
+    #[test]
+    fn a_later_schema_is_reported_before_an_unreadable_include() {
+        let (_dir, errs) = errors_from(
+            "version = 2\ninclude = \"absent.toml\"\n[project]\nname = \"p\"\n\
+             [services.s]\ncommand = [\"echo\"]\n",
+        );
+
+        assert_eq!(errs.len(), 1, "{errs:?}");
+        assert!(
+            matches!(errs[0], ConfigError::UnsupportedVersion { version: 2 }),
+            "{errs:?}"
+        );
     }
 }

--- a/crates/servicrab-core/src/raw.rs
+++ b/crates/servicrab-core/src/raw.rs
@@ -280,7 +280,8 @@ pub struct RawService {
     #[serde(default)]
     pub restart_max_delay: Option<String>,
 
-    /// Maximum number of restarts before giving up.  Defaults to `10`.
+    /// Maximum number of restarts before giving up.  Defaults to `10`; `0`
+    /// means unlimited.
     #[serde(default)]
     pub max_restarts: Option<u32>,
 

--- a/crates/servicrab-core/src/runtime/event.rs
+++ b/crates/servicrab-core/src/runtime/event.rs
@@ -4,7 +4,14 @@
 //! lets the CLI decide how to render them.  This keeps process handling and
 //! user-facing presentation cleanly separated, and gives the future daemon a
 //! ready-made stream to forward over its socket.
+//!
+//! The channel is unbounded for everything the supervisor says *about* a
+//! service — that traffic is bounded by the number of services — but the
+//! captured output that flows through it is not, so log lines get an explicit
+//! allowance and an explicit drop policy.  See [`MAX_QUEUED_LOG_LINES`].
 
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -111,6 +118,12 @@ pub enum EventKind {
         /// How many files the watcher is willing to scan.
         limit: usize,
     },
+    /// Captured output was dropped because the service produced it faster than
+    /// the supervisor could consume it.
+    LogLinesDropped {
+        /// How many lines were dropped since this was last reported.
+        count: u64,
+    },
     /// The service failed fatally.
     Failed {
         /// A human-readable description of the failure.
@@ -134,14 +147,144 @@ impl ServiceEvent {
     }
 }
 
+/// How many captured log lines may be queued on one event channel.
+///
+/// The channel itself is unbounded, and stays that way for everything the
+/// supervisor sends about its services: the number of lifecycle, health and
+/// watch events in flight is bounded by the number of services.  Log lines are
+/// not — they are bounded only by what a child chooses to print — and they
+/// travel to a consumer that writes files, so a single noisy service could
+/// grow the supervisor's heap without limit.
+///
+/// The stack relays each service's events through a per-service channel into the
+/// global one, so the allowance is per channel and the supervisor's total is
+/// this many lines per running service plus this many on the global stream.
+/// That is a bound, which is the point; it is not a tight one.
+pub const MAX_QUEUED_LOG_LINES: usize = 1024;
+
+/// Report dropped lines at least this often while the flood continues.
+///
+/// A drop is normally reported as soon as a line gets through again; this is the
+/// backstop for a service that never stops flooding.
+const REPORT_DROPS_EVERY: u64 = 1024;
+
+/// The log-line allowance shared by one channel's senders and its receiver.
+#[derive(Debug, Default)]
+struct LogBudget {
+    /// Log lines handed to the channel but not taken out of it yet.
+    queued: AtomicUsize,
+    /// Lines dropped since the last [`EventKind::LogLinesDropped`].
+    dropped: AtomicU64,
+}
+
 /// Sending half of the runtime event stream.
-pub type EventSender = mpsc::UnboundedSender<ServiceEvent>;
+///
+/// Cheap to clone, and never blocks: a log line that does not fit in the
+/// channel's allowance is dropped rather than queued, and the loss is reported
+/// as an [`EventKind::LogLinesDropped`] event so it is visible in `up` and in
+/// `servicrab events` instead of being silent.
+#[derive(Debug, Clone)]
+pub struct EventSender {
+    inner: mpsc::UnboundedSender<ServiceEvent>,
+    budget: Arc<LogBudget>,
+}
+
+impl EventSender {
+    /// Publish one event.
+    ///
+    /// `Err` means the receiver is gone.  A dropped log line is *not* an error:
+    /// the channel is alive and the loss is reported through it.
+    pub fn send(&self, event: ServiceEvent) -> Result<(), ServiceEvent> {
+        if !matches!(event.kind, EventKind::Log { .. }) {
+            return self.inner.send(event).map_err(|err| err.0);
+        }
+
+        // Dropping the newest line rather than the oldest is what keeps the log
+        // in order: the queue is a channel, so the only line the sender can
+        // still choose to lose is the one in its hand.
+        let queued = self.budget.queued.fetch_add(1, Ordering::AcqRel);
+        if queued >= MAX_QUEUED_LOG_LINES {
+            self.budget.queued.fetch_sub(1, Ordering::AcqRel);
+            let dropped = self.budget.dropped.fetch_add(1, Ordering::AcqRel) + 1;
+            if dropped % REPORT_DROPS_EVERY == 0 {
+                self.report_drops(&event.service);
+            }
+            return Ok(());
+        }
+
+        // The flood let up, so say how much of it went missing.
+        if self.budget.dropped.load(Ordering::Acquire) > 0 {
+            self.report_drops(&event.service);
+        }
+
+        self.inner.send(event).map_err(|err| {
+            self.budget.queued.fetch_sub(1, Ordering::AcqRel);
+            err.0
+        })
+    }
+
+    /// Publish how many lines have been dropped since the last report.
+    ///
+    /// Sent straight down the channel: the report is one event per burst, not
+    /// per line, so it is never itself worth dropping.
+    fn report_drops(&self, service: &ServiceName) {
+        let count = self.budget.dropped.swap(0, Ordering::AcqRel);
+        if count == 0 {
+            return;
+        }
+        let _ = self.inner.send(ServiceEvent::new(
+            service.clone(),
+            EventKind::LogLinesDropped { count },
+        ));
+    }
+}
+
 /// Receiving half of the runtime event stream.
-pub type EventReceiver = mpsc::UnboundedReceiver<ServiceEvent>;
+#[derive(Debug)]
+pub struct EventReceiver {
+    inner: mpsc::UnboundedReceiver<ServiceEvent>,
+    budget: Arc<LogBudget>,
+}
+
+impl EventReceiver {
+    /// Wait for the next event, or `None` once every sender is gone.
+    pub async fn recv(&mut self) -> Option<ServiceEvent> {
+        let event = self.inner.recv().await;
+        if let Some(event) = &event {
+            self.release(event);
+        }
+        event
+    }
+
+    /// Take an event that is already queued.
+    pub fn try_recv(&mut self) -> Result<ServiceEvent, mpsc::error::TryRecvError> {
+        let event = self.inner.try_recv()?;
+        self.release(&event);
+        Ok(event)
+    }
+
+    /// Give a delivered log line's allowance back to the senders.
+    fn release(&self, event: &ServiceEvent) {
+        if matches!(event.kind, EventKind::Log { .. }) {
+            self.budget.queued.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+}
 
 /// Create a new event channel.
 pub fn event_channel() -> (EventSender, EventReceiver) {
-    mpsc::unbounded_channel()
+    let (inner_tx, inner_rx) = mpsc::unbounded_channel();
+    let budget = Arc::new(LogBudget::default());
+    (
+        EventSender {
+            inner: inner_tx,
+            budget: Arc::clone(&budget),
+        },
+        EventReceiver {
+            inner: inner_rx,
+            budget,
+        },
+    )
 }
 
 /// An optional event sink.
@@ -218,5 +361,105 @@ mod tests {
     fn streams_display_as_lowercase_names() {
         assert_eq!(Stream::Stdout.to_string(), "stdout");
         assert_eq!(Stream::Stderr.to_string(), "stderr");
+    }
+
+    fn log(line: &str) -> EventKind {
+        EventKind::Log {
+            stream: Stream::Stdout,
+            line: line.to_string(),
+        }
+    }
+
+    #[test]
+    fn queued_log_lines_are_capped_and_the_loss_is_reported() {
+        let (tx, mut rx) = event_channel();
+        let api = name("api");
+
+        // Nothing reads while the flood runs, so every line stays queued.
+        let flood = MAX_QUEUED_LOG_LINES + REPORT_DROPS_EVERY as usize;
+        for i in 0..flood {
+            tx.send(ServiceEvent::new(api.clone(), log(&format!("line {i}"))))
+                .expect("the channel is alive");
+        }
+
+        let mut lines = Vec::new();
+        let mut dropped = 0u64;
+        while let Ok(event) = rx.try_recv() {
+            match event.kind {
+                EventKind::Log { line, .. } => lines.push(line),
+                EventKind::LogLinesDropped { count } => dropped += count,
+                other => panic!("unexpected event {other:?}"),
+            }
+        }
+
+        // The heap is what this bounds, so the queue length is the assertion.
+        assert_eq!(lines.len(), MAX_QUEUED_LOG_LINES);
+        // The oldest lines are what survived, so the log stays in order.
+        let expected: Vec<String> = (0..MAX_QUEUED_LOG_LINES)
+            .map(|i| format!("line {i}"))
+            .collect();
+        assert_eq!(lines, expected);
+        assert_eq!(
+            dropped + lines.len() as u64,
+            flood as u64,
+            "every line is either delivered or counted as dropped"
+        );
+    }
+
+    #[test]
+    fn the_allowance_comes_back_once_a_line_is_delivered() {
+        let (tx, mut rx) = event_channel();
+        let api = name("api");
+
+        for i in 0..MAX_QUEUED_LOG_LINES {
+            tx.send(ServiceEvent::new(api.clone(), log(&format!("first {i}"))))
+                .unwrap();
+        }
+        // Full: one more line has to be dropped.
+        tx.send(ServiceEvent::new(api.clone(), log("dropped")))
+            .unwrap();
+
+        // Drain, which is what a consumer keeping up looks like, then flood
+        // again: the second burst must be delivered in full.
+        while rx.try_recv().is_ok() {}
+        for i in 0..MAX_QUEUED_LOG_LINES {
+            tx.send(ServiceEvent::new(api.clone(), log(&format!("second {i}"))))
+                .unwrap();
+        }
+
+        let mut lines = 0;
+        let mut reported = 0u64;
+        while let Ok(event) = rx.try_recv() {
+            match event.kind {
+                EventKind::Log { .. } => lines += 1,
+                EventKind::LogLinesDropped { count } => reported += count,
+                other => panic!("unexpected event {other:?}"),
+            }
+        }
+        assert_eq!(lines, MAX_QUEUED_LOG_LINES);
+        assert_eq!(reported, 1, "the earlier drop should be reported once");
+    }
+
+    #[test]
+    fn events_other_than_log_lines_are_never_dropped() {
+        let (tx, mut rx) = event_channel();
+        let api = name("api");
+
+        for i in 0..MAX_QUEUED_LOG_LINES {
+            tx.send(ServiceEvent::new(api.clone(), log(&format!("line {i}"))))
+                .unwrap();
+        }
+        // The queue is full of log lines; a lifecycle event still has to make
+        // it, because losing one would corrupt the status registry.
+        tx.send(ServiceEvent::new(
+            api.clone(),
+            EventKind::State(ServiceState::Running),
+        ))
+        .unwrap();
+
+        let states = std::iter::from_fn(|| rx.try_recv().ok())
+            .filter(|event| matches!(event.kind, EventKind::State(ServiceState::Running)))
+            .count();
+        assert_eq!(states, 1);
     }
 }

--- a/crates/servicrab-core/src/runtime/event.rs
+++ b/crates/servicrab-core/src/runtime/event.rs
@@ -164,9 +164,21 @@ pub const MAX_QUEUED_LOG_LINES: usize = 1024;
 
 /// Report dropped lines at least this often while the flood continues.
 ///
-/// A drop is normally reported as soon as a line gets through again; this is the
+/// A drop is normally reported as soon as the flood lets up; this is the
 /// backstop for a service that never stops flooding.
 const REPORT_DROPS_EVERY: u64 = 1024;
+
+/// How much of the allowance has to be free again before the flood counts as
+/// over.
+///
+/// A single line getting through is *not* a let-up: it frees exactly one slot,
+/// which a flood refills immediately, so treating it as one reports the loss
+/// once per **delivered** line.  That turns a bounded stream of log lines into
+/// an unbounded stream of reports — and the reports travel as ordinary events,
+/// which are deliberately never dropped, so the bound this whole mechanism
+/// exists to enforce is undone by the announcement of it.  Requiring half the
+/// allowance back is a let-up the consumer had to earn.
+const FLOOD_OVER_BELOW: usize = MAX_QUEUED_LOG_LINES / 2;
 
 /// The log-line allowance shared by one channel's senders and its receiver.
 #[derive(Debug, Default)]
@@ -212,8 +224,12 @@ impl EventSender {
             return Ok(());
         }
 
-        // The flood let up, so say how much of it went missing.
-        if self.budget.dropped.load(Ordering::Acquire) > 0 {
+        // The flood really let up — the consumer has won back a good part of
+        // the allowance, not just the one slot this line is about to take — so
+        // say how much went missing.  Reporting on the strength of a single
+        // free slot would emit one report per delivered line for as long as the
+        // flood lasts; see `FLOOD_OVER_BELOW`.
+        if queued < FLOOD_OVER_BELOW && self.budget.dropped.load(Ordering::Acquire) > 0 {
             self.report_drops(&event.service);
         }
 
@@ -438,6 +454,91 @@ mod tests {
         }
         assert_eq!(lines, MAX_QUEUED_LOG_LINES);
         assert_eq!(reported, 1, "the earlier drop should be reported once");
+    }
+
+    #[test]
+    fn a_sustained_flood_is_not_reported_once_per_delivered_line() {
+        // A consumer that is making slow progress frees one slot at a time, and
+        // the flood refills it at once.  Reporting the loss on the strength of a
+        // single delivered line therefore emits one `LogLinesDropped` per
+        // delivered line — and those reports are ordinary events, which are
+        // never dropped, so the flood escapes its own bound through them.  In
+        // `up` that meant thousands of report lines on a stderr nobody had
+        // asked for, enough to fill the pipe and wedge the renderer in a
+        // blocking write for good.
+        let (tx, mut rx) = event_channel();
+        let api = name("api");
+        let send = |i: usize| {
+            tx.send(ServiceEvent::new(api.clone(), log(&format!("line {i}"))))
+                .expect("the channel is alive")
+        };
+
+        // Fill the allowance, so from here on every send is a drop.
+        for i in 0..MAX_QUEUED_LOG_LINES {
+            send(i);
+        }
+
+        // One line out, two lines in, over and over: the queue never recovers,
+        // which is what a sustained flood past a slow consumer looks like.
+        const ROUNDS: usize = 4 * REPORT_DROPS_EVERY as usize;
+        let mut delivered = 0usize;
+        let mut reports = 0usize;
+        for i in 0..ROUNDS {
+            match rx.try_recv().expect("something is queued").kind {
+                EventKind::Log { .. } => delivered += 1,
+                EventKind::LogLinesDropped { .. } => reports += 1,
+                other => panic!("unexpected event {other:?}"),
+            }
+            send(MAX_QUEUED_LOG_LINES + 2 * i);
+            send(MAX_QUEUED_LOG_LINES + 2 * i + 1);
+        }
+
+        assert!(delivered > 0, "the consumer has to be making progress");
+        // The backstop is what reports during a flood, so the count is set by
+        // how much was dropped and not by how much got through.
+        let backstop = ROUNDS * 2 / REPORT_DROPS_EVERY as usize;
+        assert!(
+            reports <= backstop + 1,
+            "expected about {backstop} report(s) from the backstop, got {reports} \
+             after delivering {delivered} line(s): the loss is being reported per \
+             delivered line, which is not bounded by anything"
+        );
+        // Silence would be the other way to fail this: the operator still has
+        // to learn that output is going missing.
+        assert!(reports > 0, "a flood this long has to be reported at all");
+    }
+
+    #[test]
+    fn a_real_let_up_reports_the_loss_without_waiting_for_the_backstop() {
+        // The other half of the contract: once the consumer has genuinely
+        // caught up, the operator hears about the loss straight away rather
+        // than only after the next `REPORT_DROPS_EVERY` lines go missing.
+        let (tx, mut rx) = event_channel();
+        let api = name("api");
+        let send = |line: &str| {
+            tx.send(ServiceEvent::new(api.clone(), log(line)))
+                .expect("the channel is alive")
+        };
+
+        for i in 0..MAX_QUEUED_LOG_LINES {
+            send(&format!("line {i}"));
+        }
+        // One drop only — far too few for the backstop, which needs
+        // `REPORT_DROPS_EVERY` of them, so what reports here can only be the
+        // let-up.
+        send("dropped");
+
+        // The consumer catches up completely.
+        while rx.try_recv().is_ok() {}
+        send("after the let-up");
+
+        let reported: u64 = std::iter::from_fn(|| rx.try_recv().ok())
+            .filter_map(|event| match event.kind {
+                EventKind::LogLinesDropped { count } => Some(count),
+                _ => None,
+            })
+            .sum();
+        assert_eq!(reported, 1, "the drop should be reported once, promptly");
     }
 
     #[test]

--- a/crates/servicrab-core/src/runtime/filewatch.rs
+++ b/crates/servicrab-core/src/runtime/filewatch.rs
@@ -22,6 +22,24 @@ use crate::runtime::stack::{Control, ControlTx};
 /// cannot pin a core.
 const MAX_ENTRIES: usize = 20_000;
 
+/// Stop descending after this many directory levels.
+///
+/// [`MAX_ENTRIES`] bounds the number of *files*, not the depth, and [`walk`] is
+/// recursive: a pathologically deep tree would overflow the stack, which aborts
+/// the whole supervisor rather than failing a scan.  Sixty-four levels is far
+/// beyond any real source tree.
+const MAX_DEPTH: usize = 64;
+
+/// How many times the debounce loop may re-scan before it gives up on waiting
+/// for quiet.
+///
+/// Any file that changes faster than `debounce` — a log inside the watched
+/// tree, a build directory — keeps the tree from ever settling.  Without a cap
+/// the loop re-scans forever, `changed` grows without bound, and the restart the
+/// watcher exists to request is never made.  The pending change is not lost:
+/// hitting the cap simply forces the restart out now.
+const MAX_DEBOUNCE_ROUNDS: usize = 10;
+
 /// What a single scan recorded about one file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileStamp {
@@ -38,6 +56,8 @@ pub struct Scan {
     pub files: BTreeMap<PathBuf, FileStamp>,
     /// Whether the scan hit [`MAX_ENTRIES`] and stopped early.
     pub truncated: bool,
+    /// Whether the scan hit [`MAX_DEPTH`] and left a subtree unvisited.
+    pub too_deep: bool,
 }
 
 impl Scan {
@@ -63,11 +83,13 @@ impl Scan {
 /// Walk the configured paths and record a stamp for every file.
 ///
 /// Unreadable entries are skipped rather than reported: a file that vanishes
-/// mid-scan is a change, not an error, and the next scan will notice it.
+/// mid-scan is a change, not an error, and the next scan will notice it.  So is
+/// a subtree deeper than [`MAX_DEPTH`], which sets [`Scan::too_deep`] instead of
+/// risking a stack overflow.
 pub fn scan(settings: &WatchSettings) -> Scan {
     let mut out = Scan::default();
     for root in &settings.paths {
-        walk(root, root, settings, &mut out);
+        walk(root, root, 0, settings, &mut out);
         if out.truncated {
             break;
         }
@@ -75,7 +97,7 @@ pub fn scan(settings: &WatchSettings) -> Scan {
     out
 }
 
-fn walk(root: &Path, path: &Path, settings: &WatchSettings, out: &mut Scan) {
+fn walk(root: &Path, path: &Path, depth: usize, settings: &WatchSettings, out: &mut Scan) {
     if out.files.len() >= MAX_ENTRIES {
         out.truncated = true;
         return;
@@ -95,13 +117,25 @@ fn walk(root: &Path, path: &Path, settings: &WatchSettings, out: &mut Scan) {
     };
 
     if meta.is_dir() {
+        // Recursion is bounded here rather than by [`MAX_ENTRIES`]: a deep tree
+        // holding few files would still exhaust the stack, and a stack overflow
+        // is an abort the supervisor cannot catch.
+        if depth >= MAX_DEPTH {
+            out.too_deep = true;
+            tracing::warn!(
+                path = %path.display(),
+                limit = MAX_DEPTH,
+                "not descending any further into the watched tree"
+            );
+            return;
+        }
         let Ok(entries) = std::fs::read_dir(path) else {
             return;
         };
         let mut children: Vec<PathBuf> = entries.filter_map(|e| e.ok()).map(|e| e.path()).collect();
         children.sort();
         for child in children {
-            walk(root, &child, settings, out);
+            walk(root, &child, depth + 1, settings, out);
             if out.truncated {
                 return;
             }
@@ -122,7 +156,8 @@ fn walk(root: &Path, path: &Path, settings: &WatchSettings, out: &mut Scan) {
 ///
 /// After a change the watcher waits for `debounce` of quiet before asking for
 /// the restart, so a `cargo build` writing a hundred files causes one restart
-/// rather than a hundred.
+/// rather than a hundred.  It waits for quiet at most [`MAX_DEBOUNCE_ROUNDS`]
+/// times: a tree that never settles must still get its restart.
 pub async fn watch_service(
     service: ServiceName,
     settings: WatchSettings,
@@ -146,8 +181,11 @@ pub async fn watch_service(
             continue;
         }
 
-        // Wait for the tree to settle before acting on the first change.
-        loop {
+        // Wait for the tree to settle before acting on the first change — but
+        // only for a bounded number of rounds.  A file that changes faster than
+        // `debounce` (a log inside the tree, a build directory) would otherwise
+        // keep the loop here forever and the restart would never be requested.
+        for round in 0..MAX_DEBOUNCE_ROUNDS {
             tokio::time::sleep(settings.debounce).await;
             let settled = scan(&settings);
             let extra = current.changes(&settled);
@@ -156,6 +194,13 @@ pub async fn watch_service(
                 break;
             }
             changed.extend(extra);
+            if round + 1 == MAX_DEBOUNCE_ROUNDS {
+                tracing::warn!(
+                    service = %service,
+                    rounds = MAX_DEBOUNCE_ROUNDS,
+                    "the watched tree is still changing; restarting anyway"
+                );
+            }
         }
 
         changed.sort();
@@ -367,6 +412,49 @@ mod tests {
         });
         assert_eq!(s.files.len(), 1);
         assert!(s.files.contains_key(&file));
+    }
+
+    #[test]
+    fn a_tree_deeper_than_the_limit_is_reported_rather_than_overflowing_the_stack() {
+        // `MAX_ENTRIES` bounds files, not depth, and `walk` is recursive: a deep
+        // tree would abort the supervisor with a stack overflow.
+        let dir = TempDir::new().unwrap();
+        let mut deep = dir.path().to_path_buf();
+        for i in 0..(MAX_DEPTH + 5) {
+            deep = deep.join(format!("d{i}"));
+        }
+        std::fs::create_dir_all(&deep).unwrap();
+        std::fs::write(deep.join("buried.txt"), "x").unwrap();
+        std::fs::write(dir.path().join("shallow.txt"), "y").unwrap();
+
+        let s = scan(&settings(dir.path(), &[]));
+        assert!(s.too_deep, "the depth limit should be reported");
+        // What is reachable is still recorded, so the watcher keeps working.
+        assert!(
+            s.files.keys().any(|p| p.ends_with("shallow.txt")),
+            "{:?}",
+            s.files.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !s.files.keys().any(|p| p.ends_with("buried.txt")),
+            "the file below the limit should not have been visited"
+        );
+    }
+
+    #[test]
+    fn a_tree_within_the_depth_limit_is_scanned_whole() {
+        let dir = TempDir::new().unwrap();
+        let mut deep = dir.path().to_path_buf();
+        // The root itself is depth 0, so `MAX_DEPTH` levels of directories fit.
+        for i in 0..(MAX_DEPTH - 1) {
+            deep = deep.join(format!("d{i}"));
+        }
+        std::fs::create_dir_all(&deep).unwrap();
+        std::fs::write(deep.join("reachable.txt"), "x").unwrap();
+
+        let s = scan(&settings(dir.path(), &[]));
+        assert!(!s.too_deep, "a normal tree must not trip the limit");
+        assert_eq!(s.files.len(), 1);
     }
 
     #[test]

--- a/crates/servicrab-core/src/runtime/filewatch.rs
+++ b/crates/servicrab-core/src/runtime/filewatch.rs
@@ -10,6 +10,7 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use tokio::sync::oneshot;
@@ -86,6 +87,9 @@ impl Scan {
 /// mid-scan is a change, not an error, and the next scan will notice it.  So is
 /// a subtree deeper than [`MAX_DEPTH`], which sets [`Scan::too_deep`] instead of
 /// risking a stack overflow.
+///
+/// This is blocking work — up to [`MAX_ENTRIES`] `symlink_metadata` calls plus a
+/// `read_dir` per directory — so async callers go through [`scan_off_thread`].
 pub fn scan(settings: &WatchSettings) -> Scan {
     let mut out = Scan::default();
     for root in &settings.paths {
@@ -95,6 +99,25 @@ pub fn scan(settings: &WatchSettings) -> Scan {
         }
     }
     out
+}
+
+/// [`scan`], moved onto a blocking thread.
+///
+/// A scan can stall for a long time on a slow, full or network-backed file
+/// system, and the watcher shares its worker threads with the supervisor: a
+/// scan on an async worker is a worker not driving child `wait()`s, health
+/// probes or the control channel.
+///
+/// The scan is a pure function of the file system, so a cancelled caller can
+/// simply abandon it; the detached thread finishes and throws its result away.
+/// `None` means the blocking pool is gone — the runtime is shutting down — and
+/// is deliberately not reported as "every file disappeared", which would ask
+/// for a restart on the way out.
+async fn scan_off_thread(settings: &Arc<WatchSettings>) -> Option<Scan> {
+    let settings = Arc::clone(settings);
+    tokio::task::spawn_blocking(move || scan(&settings))
+        .await
+        .ok()
 }
 
 fn walk(root: &Path, path: &Path, depth: usize, settings: &WatchSettings, out: &mut Scan) {
@@ -158,13 +181,21 @@ fn walk(root: &Path, path: &Path, depth: usize, settings: &WatchSettings, out: &
 /// the restart, so a `cargo build` writing a hundred files causes one restart
 /// rather than a hundred.  It waits for quiet at most [`MAX_DEBOUNCE_ROUNDS`]
 /// times: a tree that never settles must still get its restart.
+///
+/// Every scan runs on a blocking thread; the loop itself only sleeps and talks
+/// to channels.
 pub async fn watch_service(
     service: ServiceName,
     settings: WatchSettings,
     control: ControlTx,
     events: EventSender,
 ) {
-    let mut previous = scan(&settings);
+    // Shared with each blocking scan rather than cloned for it.
+    let settings = Arc::new(settings);
+
+    let Some(mut previous) = scan_off_thread(&settings).await else {
+        return;
+    };
     if previous.truncated {
         let _ = events.send(ServiceEvent::new(
             service.clone(),
@@ -175,7 +206,9 @@ pub async fn watch_service(
     loop {
         tokio::time::sleep(settings.interval).await;
 
-        let mut current = scan(&settings);
+        let Some(mut current) = scan_off_thread(&settings).await else {
+            return;
+        };
         let mut changed = previous.changes(&current);
         if changed.is_empty() {
             continue;
@@ -187,7 +220,9 @@ pub async fn watch_service(
         // keep the loop here forever and the restart would never be requested.
         for round in 0..MAX_DEBOUNCE_ROUNDS {
             tokio::time::sleep(settings.debounce).await;
-            let settled = scan(&settings);
+            let Some(settled) = scan_off_thread(&settings).await else {
+                return;
+            };
             let extra = current.changes(&settled);
             current = settled;
             if extra.is_empty() {
@@ -241,7 +276,10 @@ pub async fn watch_service(
 
         // A restart rewrites files itself (pid files, sockets); re-scan so the
         // next comparison starts from the post-restart state.
-        previous = scan(&settings);
+        let Some(next) = scan_off_thread(&settings).await else {
+            return;
+        };
+        previous = next;
     }
 }
 
@@ -462,5 +500,53 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let s = scan(&settings(&dir.path().join("nope"), &[]));
         assert!(s.files.is_empty());
+    }
+
+    #[test]
+    fn a_scan_goes_through_the_blocking_pool_rather_than_the_worker() {
+        // Deterministic rather than timing-based: with room for exactly one
+        // blocking thread, an occupied pool must hold the scan up.  A scan that
+        // ran inline on the async worker would finish regardless, so the timeout
+        // below is the assertion.
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "a").unwrap();
+        let settings = Arc::new(settings(dir.path(), &[]));
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async move {
+            let (release, blocked) = std::sync::mpsc::channel::<()>();
+            let occupied = tokio::task::spawn_blocking(move || {
+                let _ = blocked.recv();
+            });
+            // Make sure the pool's one thread is actually taken before timing
+            // anything: `spawn_blocking` only queues.
+            tokio::task::yield_now().await;
+
+            let held_up = tokio::time::timeout(
+                Duration::from_millis(200),
+                scan_off_thread(&Arc::clone(&settings)),
+            )
+            .await;
+            assert!(
+                held_up.is_err(),
+                "the scan did not wait for the blocking pool, so it ran on the worker"
+            );
+
+            drop(release);
+            occupied.await.unwrap();
+            let scanned = tokio::time::timeout(
+                Duration::from_secs(5),
+                scan_off_thread(&Arc::clone(&settings)),
+            )
+            .await
+            .expect("the scan runs once the pool is free")
+            .expect("the pool is up");
+            assert_eq!(scanned.files.len(), 1);
+        });
     }
 }

--- a/crates/servicrab-core/src/runtime/filewatch.rs
+++ b/crates/servicrab-core/src/runtime/filewatch.rs
@@ -55,9 +55,10 @@ pub struct FileStamp {
 pub struct Scan {
     /// Every watched file, keyed by absolute path.
     pub files: BTreeMap<PathBuf, FileStamp>,
-    /// Whether the scan hit [`MAX_ENTRIES`] and stopped early.
+    /// Whether the scan hit the `MAX_ENTRIES` file limit and stopped early.
     pub truncated: bool,
-    /// Whether the scan hit [`MAX_DEPTH`] and left a subtree unvisited.
+    /// Whether the scan hit the `MAX_DEPTH` recursion limit and left a subtree
+    /// unvisited.
     pub too_deep: bool,
 }
 
@@ -85,11 +86,12 @@ impl Scan {
 ///
 /// Unreadable entries are skipped rather than reported: a file that vanishes
 /// mid-scan is a change, not an error, and the next scan will notice it.  So is
-/// a subtree deeper than [`MAX_DEPTH`], which sets [`Scan::too_deep`] instead of
-/// risking a stack overflow.
+/// a subtree deeper than the internal `MAX_DEPTH` limit (64 levels), which sets
+/// [`Scan::too_deep`] instead of risking a stack overflow.
 ///
-/// This is blocking work — up to [`MAX_ENTRIES`] `symlink_metadata` calls plus a
-/// `read_dir` per directory — so async callers go through [`scan_off_thread`].
+/// This is blocking work — up to `MAX_ENTRIES` (20 000) `symlink_metadata` calls
+/// plus a `read_dir` per directory — so async callers go through
+/// `scan_off_thread`.
 pub fn scan(settings: &WatchSettings) -> Scan {
     let mut out = Scan::default();
     for root in &settings.paths {
@@ -179,8 +181,9 @@ fn walk(root: &Path, path: &Path, depth: usize, settings: &WatchSettings, out: &
 ///
 /// After a change the watcher waits for `debounce` of quiet before asking for
 /// the restart, so a `cargo build` writing a hundred files causes one restart
-/// rather than a hundred.  It waits for quiet at most [`MAX_DEBOUNCE_ROUNDS`]
-/// times: a tree that never settles must still get its restart.
+/// rather than a hundred.  It waits for quiet at most ten rounds (the internal
+/// `MAX_DEBOUNCE_ROUNDS` cap): a tree that never settles must still get its
+/// restart.
 ///
 /// Every scan runs on a blocking thread; the loop itself only sleeps and talks
 /// to channels.

--- a/crates/servicrab-core/src/runtime/filewatch.rs
+++ b/crates/servicrab-core/src/runtime/filewatch.rs
@@ -266,10 +266,12 @@ pub async fn watch_service(
         }
 
         match ack_rx.await {
-            Ok(Err(message)) => {
+            Ok(Err(refusal)) => {
                 let _ = events.send(ServiceEvent::new(
                     service.clone(),
-                    EventKind::WatchFailed { message },
+                    EventKind::WatchFailed {
+                        message: refusal.to_string(),
+                    },
                 ));
             }
             Ok(Ok(_)) => {}

--- a/crates/servicrab-core/src/runtime/health.rs
+++ b/crates/servicrab-core/src/runtime/health.rs
@@ -255,7 +255,20 @@ impl HealthMonitor {
         let ceiling = MAX_CONSECUTIVE_FAILURES.max(self.check.retries);
 
         loop {
-            ticker.tick().await;
+            // Racing the tick against the channel's closure is what lets the
+            // monitor let go of its `EventSink` clone the moment the run that
+            // owns it ends.  Waiting for the next tick instead would hold the
+            // sink for as long as `interval`, which keeps the service's event
+            // channel open, which keeps its relay task alive, which delays the
+            // report the supervisor needs to answer a `stop`.  A probe already
+            // in flight is allowed to finish: it is bounded by `check.timeout`,
+            // and cancelling it would abandon a child mid-run.
+            tokio::select! {
+                _ = ticker.tick() => {}
+                () = tx.closed() => return,
+            }
+            // Also checked here, because `select!` picks arbitrarily when both
+            // branches are ready.
             if tx.is_closed() {
                 return;
             }
@@ -369,6 +382,58 @@ mod tests {
         assert!(probe_once(&probe, &ctx(), Duration::from_secs(5))
             .await
             .is_ok());
+    }
+
+    #[tokio::test]
+    async fn the_monitor_lets_go_of_its_sink_without_waiting_for_the_next_tick() {
+        // The monitor holds a clone of the service's `EventSink`, so how long it
+        // takes to notice that its run has ended is how long the service's event
+        // channel stays open — and the supervisor waits on that channel before
+        // it can report that the service stopped.  Noticing only on the next
+        // tick made every stop of a health-checked service pay the drain
+        // timeout: measured at ~2.02s against ~0.02s without a health check, and
+        // on the base this branch came from it exceeded the client's own timeout
+        // and failed the command outright.
+        let interval = Duration::from_secs(30);
+        let check = HealthCheck {
+            probe: HealthProbe::Command {
+                executable: "true".to_string(),
+                args: vec![],
+            },
+            interval,
+            timeout: Duration::from_secs(1),
+            retries: 3,
+            start_period: Duration::ZERO,
+            on_unhealthy: UnhealthyAction::Ignore,
+        };
+        // The monitor gets the only sender for this event channel, so the
+        // channel closing is exactly the observable "the monitor let go of its
+        // sink" — the thing the supervisor's relay waits for.
+        let (events_tx, mut events_rx) = crate::runtime::event::event_channel();
+        let monitor = HealthMonitor {
+            check,
+            ctx: ctx(),
+            name: ServiceName("probe".to_string()),
+            events: EventSink::new(events_tx),
+        };
+
+        let rx = monitor.spawn();
+        // The first tick fires immediately, so let the monitor reach the loop
+        // rather than racing its startup.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        drop(rx);
+
+        // Real time, deliberately: the claim is that no `interval` elapses.  The
+        // bound is far below 30s and far above the milliseconds this needs.
+        let closed = tokio::time::timeout(Duration::from_secs(5), async {
+            while events_rx.recv().await.is_some() {}
+        })
+        .await;
+        assert!(
+            closed.is_ok(),
+            "the monitor still held its sink 5s after its receiver was dropped, \
+             so it is waiting for the next tick"
+        );
     }
 
     #[tokio::test]

--- a/crates/servicrab-core/src/runtime/health.rs
+++ b/crates/servicrab-core/src/runtime/health.rs
@@ -25,6 +25,37 @@ use tracing::{debug, info, warn};
 use crate::config::{HealthCheck, HealthProbe, Service, ServiceName, UnhealthyAction};
 use crate::runtime::event::{EventKind, EventSink};
 
+/// Ceiling for the consecutive-failure counter.
+///
+/// A probe that is permanently dead under `on_unhealthy = "ignore"` keeps
+/// ticking for as long as the service runs, and the count stops carrying any
+/// information long before it stops fitting in a `u32`.  The effective ceiling
+/// is never below `retries`, so the "budget exhausted" transition is still
+/// reached.
+const MAX_CONSECUTIVE_FAILURES: u32 = 100_000;
+
+/// While a probe keeps failing, report every this many failures.
+///
+/// The first failure and the one that exhausts the retry budget are always
+/// reported; this bounds how sparse the rest is, so a long outage still leaves a
+/// trace without being a perpetual event source.
+const REPORT_FAILURE_EVERY: u32 = 100;
+
+/// Whether a failure at `consecutive` should be published.
+///
+/// The first failure always is — an operator must see that something broke —
+/// and so is the one that exhausts the retry budget, because that is the
+/// transition to unhealthy.  In between, at most one report per
+/// [`REPORT_FAILURE_EVERY`] failures: a probe that is permanently dead under
+/// `on_unhealthy = "ignore"` would otherwise be a perpetual event source,
+/// published to every `events` subscriber and written into the status registry
+/// on every single tick.
+fn should_report_failure(consecutive: u32, retries: u32, reported_at: u32) -> bool {
+    consecutive == 1
+        || consecutive == retries
+        || consecutive >= reported_at.saturating_add(REPORT_FAILURE_EVERY)
+}
+
 /// What a health monitor reports back to the service runner.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HealthSignal {
@@ -197,6 +228,11 @@ impl HealthMonitor {
 
     /// Probe until the monitor is dropped, reporting transitions on the
     /// returned channel.
+    ///
+    /// The channel is unbounded, deliberately: only *transitions* travel on it —
+    /// the first successful probe and each exhaustion of the retry budget — so a
+    /// permanently failing probe adds nothing to it per tick.  Only the log-line
+    /// path is bounded; see [`crate::runtime::event::MAX_QUEUED_LOG_LINES`].
     pub fn spawn(self) -> mpsc::UnboundedReceiver<HealthSignal> {
         let (tx, rx) = mpsc::unbounded_channel();
         tokio::spawn(async move { self.run(tx).await });
@@ -212,6 +248,11 @@ impl HealthMonitor {
         // as soon as the process is up so readiness is not delayed.
         let mut consecutive = 0u32;
         let mut ready = false;
+        // Which failure was last published, so the reports can be thinned out.
+        let mut reported_at = 0u32;
+        // Never below `retries`, so capping the counter cannot swallow the
+        // transition below.
+        let ceiling = MAX_CONSECUTIVE_FAILURES.max(self.check.retries);
 
         loop {
             ticker.tick().await;
@@ -222,6 +263,9 @@ impl HealthMonitor {
             match probe_once(&self.check.probe, &self.ctx, self.check.timeout).await {
                 Ok(()) => {
                     consecutive = 0;
+                    // A recovery makes the next failure a first failure again,
+                    // so it is reported rather than thinned out.
+                    reported_at = 0;
                     if !ready {
                         ready = true;
                         info!(service = %name, probe = %self.check.probe, "service is healthy");
@@ -245,7 +289,11 @@ impl HealthMonitor {
                         continue;
                     }
 
-                    consecutive += 1;
+                    // Saturating and capped: a permanently dead probe under
+                    // `on_unhealthy = "ignore"` keeps ticking forever, and the
+                    // count stops being interesting long before it stops
+                    // fitting.
+                    consecutive = consecutive.saturating_add(1).min(ceiling);
                     warn!(
                         service = %name,
                         %message,
@@ -253,14 +301,20 @@ impl HealthMonitor {
                         retries = self.check.retries,
                         "health probe failed"
                     );
-                    self.events.emit(
-                        &name,
-                        EventKind::HealthProbeFailed {
-                            message: message.clone(),
-                            consecutive,
-                            retries: self.check.retries,
-                        },
-                    );
+                    // Throttled; see `should_report_failure`.  Once the counter
+                    // sits at its ceiling nothing is reported any more, because
+                    // there is nothing new left to say.
+                    if should_report_failure(consecutive, self.check.retries, reported_at) {
+                        reported_at = consecutive;
+                        self.events.emit(
+                            &name,
+                            EventKind::HealthProbeFailed {
+                                message: message.clone(),
+                                consecutive,
+                                retries: self.check.retries,
+                            },
+                        );
+                    }
 
                     // Report the transition once, when the budget is first
                     // exhausted.  Monitoring continues so that a service left
@@ -422,5 +476,60 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("unhealthy HTTP status 503"), "{err}");
+    }
+
+    #[test]
+    fn the_first_failure_is_always_reported() {
+        assert!(should_report_failure(1, 3, 0));
+    }
+
+    #[test]
+    fn exhausting_the_retry_budget_is_reported() {
+        // 2 is neither the first failure nor a multiple of the throttle, but it
+        // is the transition to unhealthy, which nobody may miss.
+        assert!(!should_report_failure(2, 3, 1));
+        assert!(should_report_failure(3, 3, 1));
+    }
+
+    #[test]
+    fn a_permanently_dead_probe_is_reported_sparsely() {
+        // A run of 1 000 failures with `retries = 1`: the first is reported —
+        // it is both the first failure and the transition to unhealthy — and
+        // after that the reports thin out to one per `REPORT_FAILURE_EVERY`.
+        const TICKS: u32 = 1_000;
+        let mut reported = Vec::new();
+        let mut reported_at = 0u32;
+        for consecutive in 1..=TICKS {
+            if should_report_failure(consecutive, 1, reported_at) {
+                reported_at = consecutive;
+                reported.push(consecutive);
+            }
+        }
+        assert_eq!(reported.first(), Some(&1), "the first failure must be seen");
+        assert_eq!(
+            reported.len(),
+            (TICKS / REPORT_FAILURE_EVERY) as usize,
+            "a dead probe must not be a per-tick event source: {reported:?}"
+        );
+    }
+
+    #[test]
+    fn the_failure_counter_stops_at_its_ceiling() {
+        // The ceiling is what keeps `consecutive` from growing without bound on
+        // a probe that never recovers.
+        let ceiling = MAX_CONSECUTIVE_FAILURES.max(3);
+        let mut consecutive = ceiling - 1;
+        for _ in 0..5 {
+            consecutive = consecutive.saturating_add(1).min(ceiling);
+        }
+        assert_eq!(consecutive, ceiling);
+    }
+
+    #[test]
+    fn the_ceiling_never_hides_the_unhealthy_transition() {
+        // A `retries` above the ceiling would otherwise be unreachable, and the
+        // service would never be declared unhealthy at all.
+        let retries = MAX_CONSECUTIVE_FAILURES + 10;
+        assert_eq!(MAX_CONSECUTIVE_FAILURES.max(retries), retries);
     }
 }

--- a/crates/servicrab-core/src/runtime/logs.rs
+++ b/crates/servicrab-core/src/runtime/logs.rs
@@ -14,7 +14,7 @@
 //! Flushing is batched rather than per line: the writer flushes as soon as it has
 //! caught up with the queue — which for the modest volumes a supervised service
 //! produces is still after every single line — and, while a flood keeps the queue
-//! full, at least every [`FLUSH_EVERY_LINES`] lines.  Nothing is left in the
+//! full, at least every `FLUSH_EVERY_LINES` (256) lines.  Nothing is left in the
 //! buffer when the writer stops: it flushes when the queue ends and again when the
 //! file is dropped.
 //!
@@ -287,7 +287,7 @@ struct Entry {
 /// runtime.  Ordering per service is preserved: one queue, one writer, first in
 /// first out.
 ///
-/// [`LogSink::record`] never waits.  If the writer falls [`QUEUE_CAPACITY`]
+/// [`LogSink::record`] never waits.  If the writer falls `QUEUE_CAPACITY` (4096)
 /// lines behind, the line is dropped and said to be dropped: a supervisor that
 /// stops answering its control channel because a log file is slow is worse than
 /// a log with a hole in it.

--- a/crates/servicrab-core/src/runtime/logs.rs
+++ b/crates/servicrab-core/src/runtime/logs.rs
@@ -5,25 +5,54 @@
 //! file grows past `max_size` it is rotated to `<service>.log.1`, the previous
 //! `.1` becomes `.2`, and anything beyond `max_files` is deleted.
 //!
-//! The writer is deliberately synchronous and line-oriented: supervised
-//! services produce modest volumes, and flushing every line means the log on
-//! disk is always current — including right after a crash.
+//! The writer is line-oriented and synchronous, but it never runs on an async
+//! worker: [`LogSink`] hands the lines to a blocking task.  `create_dir_all`,
+//! `write_all` and `flush` can stall for a long time on a full or network-backed
+//! disk, and a worker stalled here is a worker not driving child `wait()`s,
+//! health probes or the control channel.
+//!
+//! Flushing is batched rather than per line: the writer flushes as soon as it has
+//! caught up with the queue — which for the modest volumes a supervised service
+//! produces is still after every single line — and, while a flood keeps the queue
+//! full, at least every [`FLUSH_EVERY_LINES`] lines.  Nothing is left in the
+//! buffer when the writer stops: it flushes when the queue ends and again when the
+//! file is dropped.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc;
 
 use crate::config::{LogSettings, ServiceName};
+
+/// Flush at least this often while a flood keeps the queue from draining.
+///
+/// Without a cap a service that never stops printing would never reach the
+/// "caught up, flush now" branch, and a crash would lose everything still
+/// buffered.
+const FLUSH_EVERY_LINES: usize = 256;
+
+/// How many lines may wait for the blocking writer.
+///
+/// The queue is bounded so a stalled disk cannot grow the supervisor's heap.
+/// Reaching the bound makes [`LogSink::record`] wait, which is back-pressure
+/// rather than loss: the drop policy lives one stage upstream, on the event
+/// channel, where the loss can be reported as an event.
+const QUEUE_CAPACITY: usize = 512;
 
 /// A rotating, append-only log file for one service.
 #[derive(Debug)]
 pub struct LogWriter {
     path: PathBuf,
-    file: File,
+    file: BufWriter<File>,
     size: u64,
     max_size: u64,
     max_files: u32,
+    /// Lines written since the last flush, so a flood still reaches the disk.
+    unflushed: usize,
 }
 
 impl LogWriter {
@@ -37,14 +66,18 @@ impl LogWriter {
         let size = file.metadata().map(|m| m.len()).unwrap_or(0);
         Ok(Self {
             path,
-            file,
+            file: BufWriter::new(file),
             size,
             max_size: settings.max_size,
             max_files: settings.max_files,
+            unflushed: 0,
         })
     }
 
     /// Append one line, rotating first when the line would not fit.
+    ///
+    /// The line is buffered, not necessarily on disk yet; [`LogWriter::flush`]
+    /// is what makes it durable, and [`Drop`] is the backstop.
     pub fn write_line(&mut self, line: &str) -> std::io::Result<()> {
         let needed = line.len() as u64 + 1;
         // Rotating before the write keeps whole lines together, so a log file
@@ -54,20 +87,37 @@ impl LogWriter {
         }
         self.file.write_all(line.as_bytes())?;
         self.file.write_all(b"\n")?;
-        self.file.flush()?;
         self.size += needed;
+        self.unflushed += 1;
+        // A flood never lets the writer catch up with its queue, so cap how
+        // much can be in flight regardless.
+        if self.unflushed >= FLUSH_EVERY_LINES {
+            self.flush()?;
+        }
         Ok(())
+    }
+
+    /// Push everything buffered out to the file.
+    pub fn flush(&mut self) -> std::io::Result<()> {
+        self.unflushed = 0;
+        self.file.flush()
     }
 
     /// Rotate the current file out of the way and start a fresh one.
     fn rotate(&mut self) -> std::io::Result<()> {
+        // Whatever is still buffered belongs to the file being rotated away,
+        // so it has to land before the rename.
+        self.flush()?;
+
         if self.max_files == 0 {
             // No history is kept: start over from an empty file.
-            self.file = OpenOptions::new()
-                .create(true)
-                .truncate(true)
-                .write(true)
-                .open(&self.path)?;
+            self.file = BufWriter::new(
+                OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(&self.path)?,
+            );
             self.size = 0;
             return Ok(());
         }
@@ -87,10 +137,12 @@ impl LogWriter {
         }
         fs::rename(&self.path, rotated(1))?;
 
-        self.file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)?;
+        self.file = BufWriter::new(
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.path)?,
+        );
         self.size = 0;
         Ok(())
     }
@@ -98,6 +150,16 @@ impl LogWriter {
     /// Path of the file currently being written.
     pub fn path(&self) -> &Path {
         &self.path
+    }
+}
+
+impl Drop for LogWriter {
+    fn drop(&mut self) {
+        // `BufWriter` flushes on drop too, but it swallows the result and only
+        // does so for the buffer it currently owns; being explicit keeps the
+        // "no line is lost when the writer goes away" promise where it can be
+        // read.
+        let _ = self.file.flush();
     }
 }
 
@@ -116,15 +178,16 @@ fn rotated_path(path: &Path, n: u32) -> PathBuf {
 pub struct LogRouter {
     settings: LogSettings,
     writers: BTreeMap<ServiceName, LogWriter>,
-    /// Services that opted out of file logging.
-    excluded: Vec<ServiceName>,
+    /// Services that opted out of file logging.  A set, not a list: this is
+    /// consulted for every single log line.
+    excluded: BTreeSet<ServiceName>,
     /// Reported once, so a broken log directory does not spam the terminal.
     reported_error: bool,
 }
 
 impl LogRouter {
     /// Build a router for the given settings.
-    pub fn new(settings: LogSettings, excluded: Vec<ServiceName>) -> Self {
+    pub fn new(settings: LogSettings, excluded: BTreeSet<ServiceName>) -> Self {
         Self {
             settings,
             writers: BTreeMap::new(),
@@ -134,6 +197,8 @@ impl LogRouter {
     }
 
     /// Record one output line for `service`.
+    ///
+    /// The line is buffered; [`LogRouter::flush`] is what puts it on disk.
     ///
     /// Returns an error message the first time writing fails; later failures
     /// are silent so a full disk cannot drown out the service's own output.
@@ -162,6 +227,27 @@ impl LogRouter {
         }
     }
 
+    /// Put every buffered line on disk.
+    ///
+    /// Reported the same way [`LogRouter::record`] reports: once.
+    pub fn flush(&mut self) -> Option<String> {
+        let mut failure = None;
+        for writer in self.writers.values_mut() {
+            if let Err(err) = writer.flush() {
+                failure = failure.or_else(|| {
+                    Some(format!(
+                        "could not write to {}: {err}",
+                        writer.path.display()
+                    ))
+                });
+            }
+        }
+        match failure {
+            Some(message) => self.report(message),
+            None => None,
+        }
+    }
+
     fn report(&mut self, message: String) -> Option<String> {
         if self.reported_error {
             return None;
@@ -178,6 +264,110 @@ impl LogRouter {
     /// The settings this router writes with.
     pub fn settings(&self) -> &LogSettings {
         &self.settings
+    }
+}
+
+/// One line on its way to the writer.
+#[derive(Debug)]
+struct Entry {
+    service: ServiceName,
+    line: String,
+}
+
+/// A [`LogRouter`] driven from a blocking task.
+///
+/// The async pumps that consume captured output hand their lines here instead of
+/// writing files themselves, so a slow disk delays the log rather than the
+/// runtime.  Ordering per service is preserved: one queue, one writer, first in
+/// first out.
+#[derive(Debug)]
+pub struct LogSink {
+    entries: mpsc::Sender<Entry>,
+    writer: tokio::task::JoinHandle<()>,
+    problem: Arc<Mutex<Option<String>>>,
+}
+
+impl LogSink {
+    /// Start the blocking writer for `router`.
+    ///
+    /// Must be called from within a Tokio runtime.
+    pub fn spawn(router: LogRouter) -> Self {
+        let (entries, queue) = mpsc::channel(QUEUE_CAPACITY);
+        let problem = Arc::new(Mutex::new(None));
+        let writer = tokio::task::spawn_blocking({
+            let problem = Arc::clone(&problem);
+            move || pump(queue, router, &problem)
+        });
+        Self {
+            entries,
+            writer,
+            problem,
+        }
+    }
+
+    /// Hand one line to the writer, waiting when the writer is behind.
+    ///
+    /// Returns a problem the writer ran into, the first time it happened.  The
+    /// report is necessarily one-sided in time: the writer is asynchronous now,
+    /// so the failure surfaces on a later call rather than on the one that
+    /// caused it.
+    pub async fn record(&self, service: &ServiceName, line: &str) -> Option<String> {
+        let entry = Entry {
+            service: service.clone(),
+            line: line.to_string(),
+        };
+        // A closed queue means the writer task is gone, which only happens when
+        // the runtime is shutting down; the line is not worth a diagnostic.
+        let _ = self.entries.send(entry).await;
+        self.take_problem()
+    }
+
+    /// Stop the writer once every queued line has been written and flushed.
+    pub async fn shutdown(self) -> Option<String> {
+        let Self {
+            entries,
+            writer,
+            problem,
+        } = self;
+        drop(entries);
+        // The writer drains what is queued, flushes, and returns; it never
+        // blocks on anything but the file system.
+        let _ = writer.await;
+        problem.lock().ok().and_then(|mut slot| slot.take())
+    }
+
+    fn take_problem(&self) -> Option<String> {
+        self.problem.lock().ok().and_then(|mut slot| slot.take())
+    }
+}
+
+/// Write queued lines until the queue ends, flushing whenever it runs dry.
+fn pump(mut queue: mpsc::Receiver<Entry>, mut router: LogRouter, problem: &Mutex<Option<String>>) {
+    loop {
+        let next = match queue.try_recv() {
+            Ok(entry) => Some(entry),
+            Err(mpsc::error::TryRecvError::Empty) => {
+                // Caught up: get everything on disk before parking, so the log
+                // of an ordinarily quiet service is just as current as it was
+                // when every line was flushed on its own.
+                remember(problem, router.flush());
+                queue.blocking_recv()
+            }
+            Err(mpsc::error::TryRecvError::Disconnected) => None,
+        };
+        let Some(entry) = next else { break };
+        remember(problem, router.record(&entry.service, &entry.line));
+    }
+
+    // Nothing more is coming, so this is the last chance to reach the disk.
+    remember(problem, router.flush());
+}
+
+/// Keep the first problem the writer reports, for the next caller to collect.
+fn remember(slot: &Mutex<Option<String>>, message: Option<String>) {
+    let Some(message) = message else { return };
+    if let Ok(mut slot) = slot.lock() {
+        slot.get_or_insert(message);
     }
 }
 
@@ -199,7 +389,7 @@ mod tests {
     }
 
     #[test]
-    fn lines_are_appended_and_flushed() {
+    fn lines_are_appended_in_order_when_flushed() {
         let dir = TempDir::new().unwrap();
         let settings = settings(dir.path(), 1024, 3);
         let name = service("api");
@@ -207,9 +397,68 @@ mod tests {
 
         writer.write_line("first").unwrap();
         writer.write_line("second").unwrap();
+        writer.flush().unwrap();
 
         let contents = fs::read_to_string(settings.file_for(&name)).unwrap();
         assert_eq!(contents, "first\nsecond\n");
+    }
+
+    #[test]
+    fn writing_a_line_does_not_cost_a_flush() {
+        // The batching is the point of the writer: one `flush` per batch
+        // instead of one per line is what keeps a slow disk off the hot path.
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), 1024, 3);
+        let name = service("api");
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+
+        writer.write_line("buffered").unwrap();
+        assert_eq!(
+            fs::read_to_string(settings.file_for(&name)).unwrap(),
+            "",
+            "the line should still be in the buffer"
+        );
+
+        writer.flush().unwrap();
+        assert_eq!(
+            fs::read_to_string(settings.file_for(&name)).unwrap(),
+            "buffered\n"
+        );
+    }
+
+    #[test]
+    fn a_flood_is_flushed_without_being_asked_to() {
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), 1 << 20, 3);
+        let name = service("api");
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+
+        for i in 0..FLUSH_EVERY_LINES {
+            writer.write_line(&format!("line {i}")).unwrap();
+        }
+
+        let contents = fs::read_to_string(settings.file_for(&name)).unwrap();
+        assert_eq!(
+            contents.lines().count(),
+            FLUSH_EVERY_LINES,
+            "a queue that never drains must still reach the disk"
+        );
+    }
+
+    #[test]
+    fn dropping_the_writer_flushes_what_is_left() {
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), 1024, 3);
+        let name = service("api");
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+
+        writer.write_line("last words").unwrap();
+        drop(writer);
+
+        assert_eq!(
+            fs::read_to_string(settings.file_for(&name)).unwrap(),
+            "last words\n"
+        );
     }
 
     #[test]
@@ -222,6 +471,7 @@ mod tests {
 
         let mut writer = LogWriter::open(&settings, &name).unwrap();
         writer.write_line("new").unwrap();
+        writer.flush().unwrap();
 
         let contents = fs::read_to_string(settings.file_for(&name)).unwrap();
         assert_eq!(contents, "old\nnew\n");
@@ -237,6 +487,7 @@ mod tests {
 
         writer.write_line("1234567").unwrap();
         writer.write_line("abcdefg").unwrap();
+        writer.flush().unwrap();
 
         assert_eq!(
             fs::read_to_string(settings.file_for(&name)).unwrap(),
@@ -245,6 +496,31 @@ mod tests {
         assert_eq!(
             fs::read_to_string(settings.rotated_file_for(&name, 1)).unwrap(),
             "1234567\n"
+        );
+    }
+
+    #[test]
+    fn rotation_takes_the_buffered_lines_with_the_old_file() {
+        // Rotation renames the file underneath the writer, so anything still
+        // buffered has to land before the rename or it would reappear at the
+        // head of the fresh file.
+        let dir = TempDir::new().unwrap();
+        let settings = settings(dir.path(), 8, 2);
+        let name = service("api");
+        let mut writer = LogWriter::open(&settings, &name).unwrap();
+
+        writer.write_line("1234567").unwrap();
+        // Not flushed by hand: the rotation the next line triggers must do it.
+        writer.write_line("abcdefg").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(
+            fs::read_to_string(settings.rotated_file_for(&name, 1)).unwrap(),
+            "1234567\n"
+        );
+        assert_eq!(
+            fs::read_to_string(settings.file_for(&name)).unwrap(),
+            "abcdefg\n"
         );
     }
 
@@ -258,6 +534,7 @@ mod tests {
         for line in ["aaaaaaa", "bbbbbbb", "ccccccc", "ddddddd"] {
             writer.write_line(line).unwrap();
         }
+        writer.flush().unwrap();
 
         assert_eq!(
             fs::read_to_string(settings.file_for(&name)).unwrap(),
@@ -286,6 +563,7 @@ mod tests {
 
         writer.write_line("1234567").unwrap();
         writer.write_line("abcdefg").unwrap();
+        writer.flush().unwrap();
 
         assert_eq!(
             fs::read_to_string(settings.file_for(&name)).unwrap(),
@@ -304,6 +582,7 @@ mod tests {
         writer
             .write_line("this line is definitely too long")
             .unwrap();
+        writer.flush().unwrap();
 
         assert_eq!(
             fs::read_to_string(settings.file_for(&name)).unwrap(),
@@ -314,10 +593,11 @@ mod tests {
     #[test]
     fn the_router_writes_one_file_per_service() {
         let dir = TempDir::new().unwrap();
-        let mut router = LogRouter::new(settings(dir.path(), 1024, 3), Vec::new());
+        let mut router = LogRouter::new(settings(dir.path(), 1024, 3), BTreeSet::new());
 
         assert!(router.record(&service("api"), "from api").is_none());
         assert!(router.record(&service("db"), "from db").is_none());
+        assert!(router.flush().is_none());
 
         assert_eq!(
             fs::read_to_string(dir.path().join("api.log")).unwrap(),
@@ -332,7 +612,10 @@ mod tests {
     #[test]
     fn excluded_services_are_not_written_to_disk() {
         let dir = TempDir::new().unwrap();
-        let mut router = LogRouter::new(settings(dir.path(), 1024, 3), vec![service("quiet")]);
+        let mut router = LogRouter::new(
+            settings(dir.path(), 1024, 3),
+            BTreeSet::from([service("quiet")]),
+        );
 
         router.record(&service("quiet"), "nothing to see");
 
@@ -345,9 +628,44 @@ mod tests {
         // A file where the directory should be makes every open fail.
         let blocked = dir.path().join("logs");
         fs::write(&blocked, "not a directory").unwrap();
-        let mut router = LogRouter::new(settings(&blocked, 1024, 3), Vec::new());
+        let mut router = LogRouter::new(settings(&blocked, 1024, 3), BTreeSet::new());
 
         assert!(router.record(&service("api"), "one").is_some());
         assert!(router.record(&service("api"), "two").is_none());
+    }
+
+    #[tokio::test]
+    async fn the_sink_writes_every_line_in_order_by_the_time_it_is_shut_down() {
+        let dir = TempDir::new().unwrap();
+        let name = service("api");
+        let sink = LogSink::spawn(LogRouter::new(
+            settings(dir.path(), 1 << 20, 3),
+            BTreeSet::new(),
+        ));
+
+        // More lines than the queue holds, so the handover has to wait at least
+        // once and the writer has to flush more than one batch.
+        let total = QUEUE_CAPACITY * 3;
+        for i in 0..total {
+            sink.record(&name, &format!("line {i}")).await;
+        }
+        assert!(sink.shutdown().await.is_none());
+
+        let contents = fs::read_to_string(dir.path().join("api.log")).unwrap();
+        let expected: Vec<String> = (0..total).map(|i| format!("line {i}")).collect();
+        assert_eq!(contents.lines().collect::<Vec<_>>(), expected);
+    }
+
+    #[tokio::test]
+    async fn the_sink_reports_a_broken_log_directory() {
+        let dir = TempDir::new().unwrap();
+        let blocked = dir.path().join("logs");
+        fs::write(&blocked, "not a directory").unwrap();
+        let sink = LogSink::spawn(LogRouter::new(settings(&blocked, 1024, 3), BTreeSet::new()));
+
+        sink.record(&service("api"), "one").await;
+        // The writer is asynchronous, so the problem may only be collected by
+        // the shutdown that waits for it.
+        assert!(sink.shutdown().await.is_some());
     }
 }

--- a/crates/servicrab-core/src/runtime/logs.rs
+++ b/crates/servicrab-core/src/runtime/logs.rs
@@ -17,11 +17,16 @@
 //! full, at least every [`FLUSH_EVERY_LINES`] lines.  Nothing is left in the
 //! buffer when the writer stops: it flushes when the queue ends and again when the
 //! file is dropped.
+//!
+//! Handing a line over never waits.  A file system that cannot keep up with a
+//! service's output at all costs log lines, loudly, rather than costing the
+//! supervisor its responsiveness.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc;
@@ -37,11 +42,12 @@ const FLUSH_EVERY_LINES: usize = 256;
 
 /// How many lines may wait for the blocking writer.
 ///
-/// The queue is bounded so a stalled disk cannot grow the supervisor's heap.
-/// Reaching the bound makes [`LogSink::record`] wait, which is back-pressure
-/// rather than loss: the drop policy lives one stage upstream, on the event
-/// channel, where the loss can be reported as an event.
-const QUEUE_CAPACITY: usize = 512;
+/// Reaching this bound means the file system is not keeping up with a service's
+/// output at all, and the line is dropped rather than made to wait: the callers
+/// of [`LogSink::record`] are the pumps that also keep the status registry
+/// current and feed the event stream, so making *them* wait for the disk is the
+/// very thing this module exists to avoid.
+const QUEUE_CAPACITY: usize = 4096;
 
 /// A rotating, append-only log file for one service.
 #[derive(Debug)]
@@ -280,11 +286,18 @@ struct Entry {
 /// writing files themselves, so a slow disk delays the log rather than the
 /// runtime.  Ordering per service is preserved: one queue, one writer, first in
 /// first out.
+///
+/// [`LogSink::record`] never waits.  If the writer falls [`QUEUE_CAPACITY`]
+/// lines behind, the line is dropped and said to be dropped: a supervisor that
+/// stops answering its control channel because a log file is slow is worse than
+/// a log with a hole in it.
 #[derive(Debug)]
 pub struct LogSink {
     entries: mpsc::Sender<Entry>,
     writer: tokio::task::JoinHandle<()>,
     problem: Arc<Mutex<Option<String>>>,
+    /// Lines the writer was too far behind to accept.
+    dropped: AtomicU64,
 }
 
 impl LogSink {
@@ -302,23 +315,37 @@ impl LogSink {
             entries,
             writer,
             problem,
+            dropped: AtomicU64::new(0),
         }
     }
 
-    /// Hand one line to the writer, waiting when the writer is behind.
+    /// Hand one line to the writer, dropping it if the writer is too far behind.
     ///
-    /// Returns a problem the writer ran into, the first time it happened.  The
-    /// report is necessarily one-sided in time: the writer is asynchronous now,
-    /// so the failure surfaces on a later call rather than on the one that
-    /// caused it.
-    pub async fn record(&self, service: &ServiceName, line: &str) -> Option<String> {
+    /// Returns something worth telling the operator: the first failure the
+    /// writer ran into, or how far behind it has fallen.  The report is
+    /// necessarily one-sided in time — the writer is asynchronous now, so a
+    /// failure surfaces on a later call rather than on the one that caused it.
+    pub fn record(&self, service: &ServiceName, line: &str) -> Option<String> {
         let entry = Entry {
             service: service.clone(),
             line: line.to_string(),
         };
-        // A closed queue means the writer task is gone, which only happens when
-        // the runtime is shutting down; the line is not worth a diagnostic.
-        let _ = self.entries.send(entry).await;
+        match self.entries.try_send(entry) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                let dropped = self.dropped.fetch_add(1, Ordering::AcqRel) + 1;
+                // The first one, then one report per queue's worth: a disk that
+                // stays stuck must not turn into its own flood of warnings.
+                if dropped == 1 || dropped % QUEUE_CAPACITY as u64 == 0 {
+                    return Some(format!(
+                        "the log writer cannot keep up; dropped {dropped} line(s) so far"
+                    ));
+                }
+            }
+            // A closed queue means the writer task is gone, which only happens
+            // when the runtime is shutting down; not worth a diagnostic.
+            Err(mpsc::error::TrySendError::Closed(_)) => {}
+        }
         self.take_problem()
     }
 
@@ -328,6 +355,7 @@ impl LogSink {
             entries,
             writer,
             problem,
+            ..
         } = self;
         drop(entries);
         // The writer drains what is queued, flushes, and returns; it never
@@ -643,17 +671,61 @@ mod tests {
             BTreeSet::new(),
         ));
 
-        // More lines than the queue holds, so the handover has to wait at least
-        // once and the writer has to flush more than one batch.
-        let total = QUEUE_CAPACITY * 3;
+        // Fewer lines than the queue holds, so nothing is dropped and the whole
+        // batch has to be on disk once the sink is shut down.
+        let total = QUEUE_CAPACITY / 2;
         for i in 0..total {
-            sink.record(&name, &format!("line {i}")).await;
+            sink.record(&name, &format!("line {i}"));
         }
         assert!(sink.shutdown().await.is_none());
 
         let contents = fs::read_to_string(dir.path().join("api.log")).unwrap();
         let expected: Vec<String> = (0..total).map(|i| format!("line {i}")).collect();
         assert_eq!(contents.lines().collect::<Vec<_>>(), expected);
+    }
+
+    #[test]
+    fn handing_a_line_over_never_waits_for_the_writer() {
+        // The whole point of the sink: the caller is an async pump that also
+        // drives the status registry and the event stream, so it must never be
+        // made to wait for a file system.  With the blocking pool's one thread
+        // occupied the writer cannot run at all, and `record` still has to
+        // return.
+        let dir = TempDir::new().unwrap();
+        let name = service("api");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async move {
+            let (release, blocked) = std::sync::mpsc::channel::<()>();
+            let occupied = tokio::task::spawn_blocking(move || {
+                let _ = blocked.recv();
+            });
+            tokio::task::yield_now().await;
+
+            let sink = LogSink::spawn(LogRouter::new(
+                settings(dir.path(), 1 << 20, 3),
+                BTreeSet::new(),
+            ));
+
+            let mut complaint = None;
+            // More than the queue holds, so the overflow has to be dropped
+            // rather than queued or waited on.
+            for i in 0..QUEUE_CAPACITY * 2 {
+                complaint = complaint.or(sink.record(&name, &format!("line {i}")));
+            }
+            assert!(
+                complaint.is_some_and(|c| c.contains("cannot keep up")),
+                "a sink that cannot keep up has to say so"
+            );
+
+            drop(release);
+            occupied.await.unwrap();
+            sink.shutdown().await;
+        });
     }
 
     #[tokio::test]
@@ -663,7 +735,7 @@ mod tests {
         fs::write(&blocked, "not a directory").unwrap();
         let sink = LogSink::spawn(LogRouter::new(settings(&blocked, 1024, 3), BTreeSet::new()));
 
-        sink.record(&service("api"), "one").await;
+        sink.record(&service("api"), "one");
         // The writer is asynchronous, so the problem may only be collected by
         // the shutdown that waits for it.
         assert!(sink.shutdown().await.is_some());

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -55,8 +55,8 @@ pub use plan::{
     known_profiles, known_services, lookup_service, plan_stack, with_dependents, Selection,
 };
 pub use stack::{
-    control_channel, Ack, Control, ControlRx, ControlTx, Readiness, ServiceReport, ServiceResult,
-    StackOptions, StackOutcome, StackSupervisor,
+    control_channel, Ack, Control, ControlOutcome, ControlRefusal, ControlRx, ControlTx, Readiness,
+    ServiceReport, ServiceResult, StackOptions, StackOutcome, StackSupervisor,
 };
 pub use status::{Health, ServiceStatus, StatusRegistry};
 

--- a/crates/servicrab-core/src/runtime/mod.rs
+++ b/crates/servicrab-core/src/runtime/mod.rs
@@ -50,7 +50,7 @@ pub use event::{
 pub use filewatch::{scan, spawn_watchers, watch_service, watched_services, FileStamp, Scan};
 #[cfg(unix)]
 pub use health::{HealthMonitor, HealthSignal};
-pub use logs::{LogRouter, LogWriter};
+pub use logs::{LogRouter, LogSink, LogWriter};
 pub use plan::{
     known_profiles, known_services, lookup_service, plan_stack, with_dependents, Selection,
 };

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -324,7 +324,17 @@ impl<'a> StackSupervisor<'a> {
                     break;
                 }
                 Some(report) = report_rx.recv() => {
-                    running -= 1;
+                    // Invariant: every report comes from a task that was
+                    // counted when it was spawned, so the counter is never at
+                    // zero here.  Saturate rather than wrap anyway: in a
+                    // release build an undercount would turn into `usize::MAX`
+                    // and `up` would never notice that its stack had finished.
+                    debug_assert!(
+                        running > 0,
+                        "report from {} has no matching spawn",
+                        report.service
+                    );
+                    running = running.saturating_sub(1);
                     let failed = report.result.is_failure();
                     tracing::debug!(service = %report.service, "service finished");
 
@@ -530,7 +540,25 @@ impl<'a> StackSupervisor<'a> {
             let Some(service) = config.services.get(name).cloned() else {
                 continue;
             };
-            state.insert_slot(name, Arc::new(service));
+            let service = Arc::new(service);
+            match state.slots.get_mut(name) {
+                // The slot is still there because an earlier reload dropped it
+                // and its supervision task has not reported back yet.  Revive
+                // that slot rather than replacing it: its `stop` channel and
+                // task handle are the only way the supervisor can still reach
+                // the process that is winding down, and `insert_slot` would
+                // throw both away.
+                Some(slot) => {
+                    debug_assert!(slot.retired, "a live slot for {name} was reported as added");
+                    slot.retired = false;
+                    slot.service = service;
+                    // The replacement is spawned once the old task reports —
+                    // the same hand-off a `restart` uses — so exactly one
+                    // process for this service is ever alive.
+                    slot.restart_when_stopped = slot.stop.is_some();
+                }
+                None => state.insert_slot(name, service),
+            }
         }
 
         for name in &diff.changed {
@@ -555,6 +583,11 @@ impl<'a> StackSupervisor<'a> {
 
         for name in &diff.added {
             if let Some(slot) = state.slots.get_mut(name) {
+                // A revived slot is waiting for its predecessor to report; the
+                // report arm spawns it then.
+                if slot.restart_when_stopped || slot.is_running() {
+                    continue;
+                }
                 slot.spawn(self.events.clone(), run_options, reports.clone());
                 *running += 1;
             }
@@ -584,7 +617,24 @@ impl RunState {
     ///
     /// Dependencies are wired up separately, once every slot exists: a
     /// service must be able to subscribe to slots added after it.
+    ///
+    /// Invariant: this never replaces a slot that still has a supervision task
+    /// behind it.  Overwriting one would discard the `stop` channel and the
+    /// `JoinHandle` that are the supervisor's only hold on a live process
+    /// group, leaving it to outlive the supervisor.  A reload that brings a
+    /// retiring service back revives its slot instead — see
+    /// [`StackSupervisor::reload`].
     fn insert_slot(&mut self, name: &ServiceName, service: Arc<Service>) {
+        debug_assert!(
+            !self
+                .slots
+                .get(name)
+                .is_some_and(|slot| slot.stop.is_some() || slot.handle.is_some()),
+            "insert_slot would overwrite the live slot for {name}"
+        );
+        // The initial receiver is dropped on purpose: a service with no
+        // dependents has no subscriber, and the sender is written with
+        // `send_modify` throughout so the value stays truthful anyway.
         let (state_tx, state_rx) = watch::channel(DependencyStatus::new());
         drop(state_rx);
         self.slots.insert(
@@ -1169,6 +1219,24 @@ command = ["sleep", "60"]
         let cfg = config(BASE);
         let plan = crate::runtime::plan_stack(&cfg, Selection::default()).unwrap();
         assert_eq!(state.diff(&cfg, &plan).added, vec![name("worker")]);
+    }
+
+    #[test]
+    #[should_panic(expected = "would overwrite the live slot")]
+    fn inserting_over_a_live_slot_is_a_bug() {
+        // A slot with a `stop` channel is the supervisor's only hold on a live
+        // process group; replacing it would leak that group.  The assertion
+        // makes a future regression fail here rather than in production.
+        let mut state = state_for(config(BASE));
+        let (stop, _rx) = shutdown_channel();
+        state
+            .slots
+            .get_mut(&name("worker"))
+            .expect("slot exists")
+            .stop = Some(stop);
+
+        let service = state.config.services[&name("worker")].clone();
+        state.insert_slot(&name("worker"), Arc::new(service));
     }
 
     #[test]

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -13,9 +13,12 @@
 //! its own connection attempts.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use nix::sys::signal::{killpg, Signal};
+use nix::unistd::Pid;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
@@ -160,6 +163,13 @@ struct Slot {
     service: Arc<Service>,
     deps: Vec<DependencyEdge>,
     readiness: Arc<watch::Sender<DependencyStatus>>,
+    /// The process group of the process currently running, or `0`.
+    ///
+    /// Written by the supervision task from the `Started` event and cleared
+    /// when the process ends, so [`stop_all`] can sweep the group of a task it
+    /// has to abort — `abort` alone only reaches the direct child, through
+    /// `kill_on_drop`.
+    pgid: Arc<AtomicI32>,
     /// Present exactly while a supervision task is alive.
     stop: Option<crate::runtime::ShutdownTx>,
     handle: Option<JoinHandle<()>>,
@@ -193,10 +203,12 @@ impl Slot {
 
         let (stop_tx, stop_rx) = shutdown_channel();
         self.stop = Some(stop_tx);
+        self.pgid.store(0, Ordering::Relaxed);
         self.handle = Some(tokio::spawn(supervise_service(
             Arc::clone(&self.service),
             self.deps.clone(),
             Arc::clone(&self.readiness),
+            Arc::clone(&self.pgid),
             stop_rx,
             events,
             options,
@@ -643,6 +655,7 @@ impl RunState {
                 service,
                 deps: Vec::new(),
                 readiness: Arc::new(state_tx),
+                pgid: Arc::new(AtomicI32::new(0)),
                 stop: None,
                 handle: None,
                 restart_when_stopped: false,
@@ -782,7 +795,33 @@ async fn stop_all(
 
         if tokio::time::timeout(grace, &mut handle).await.is_err() {
             tracing::warn!(service = %name, ?grace, "service did not stop in time; detaching");
+            // Invariant: no process group of ours outlives the supervisor.
+            // Aborting the task drops its `ProcessHandle`, and
+            // `kill_on_drop(true)` only reaches the direct child — a grandchild
+            // such as `node` under `npm` would be orphaned.  Sweep the group
+            // first, while there is still a task that knows about it.
+            sweep_group(name, state.slots.get(name));
             handle.abort();
+        }
+    }
+}
+
+/// `SIGKILL` the process group a slot last reported, if it still has one.
+fn sweep_group(name: &ServiceName, slot: Option<&Slot>) {
+    let Some(pgid) = slot.map(|slot| slot.pgid.load(Ordering::Relaxed)) else {
+        return;
+    };
+    // Zero means the service has no process running: either it never started
+    // or its last one has already been reaped, and the kernel is free to hand
+    // that group id to somebody else.
+    if pgid == 0 {
+        return;
+    }
+    match killpg(Pid::from_raw(pgid), Signal::SIGKILL) {
+        Ok(()) => tracing::warn!(service = %name, pgid, "swept the process group before detaching"),
+        Err(errno) if crate::runtime::unix::group_is_gone(errno) => {}
+        Err(errno) => {
+            tracing::warn!(service = %name, pgid, %errno, "could not sweep the process group")
         }
     }
 }
@@ -916,6 +955,7 @@ async fn supervise_service(
     service: Arc<Service>,
     deps: Vec<DependencyEdge>,
     readiness: Arc<watch::Sender<DependencyStatus>>,
+    pgid: Arc<AtomicI32>,
     mut stop: ShutdownRx,
     events: EventSender,
     options: RunOptions,
@@ -959,9 +999,21 @@ async fn supervise_service(
     let (tx, mut rx) = event_channel();
     let relay = {
         let global = events.clone();
+        let pgid = Arc::clone(&pgid);
         let mut tracker = ReadinessTracker::new();
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
+                // Publish the process group the supervisor may have to sweep if
+                // it ever has to abort this task, and take it away again as
+                // soon as the process is gone: the kernel is free to reuse the
+                // id once its leader has been reaped.
+                match &event.kind {
+                    EventKind::Started { pgid: group } => pgid.store(*group, Ordering::Relaxed),
+                    EventKind::Exited { .. } | EventKind::Finished { .. } => {
+                        pgid.store(0, Ordering::Relaxed)
+                    }
+                    _ => {}
+                }
                 if let Some(next) = tracker.observe(&event.kind) {
                     // `send_modify` rather than `send`, for the reason above.
                     readiness.send_modify(|status| *status = next);
@@ -979,6 +1031,9 @@ async fn supervise_service(
     };
 
     let _ = relay.await;
+    // The process is gone by the time the runner returns; nothing left to
+    // sweep even if this task is aborted from here on.
+    pgid.store(0, Ordering::Relaxed);
 
     let result = match result {
         Ok(outcome) => ServiceResult::Finished(outcome),
@@ -1072,6 +1127,7 @@ async fn wait_for_dependencies(deps: &[DependencyEdge], stop: &mut ShutdownRx) -
 mod tests {
     use super::*;
     use crate::runtime::Selection;
+    use std::os::unix::process::CommandExt;
 
     fn name(raw: &str) -> ServiceName {
         crate::validation::validate_service_name(raw).expect("valid test name")
@@ -1415,6 +1471,78 @@ command = ["sleep", "60"]
             Readiness::Ready,
             "a running service must look ready to a dependent added later"
         );
+    }
+
+    #[tokio::test]
+    async fn a_detached_service_has_its_process_group_swept() {
+        // Aborting the supervision task drops its `ProcessHandle`, and
+        // `kill_on_drop(true)` only reaches the direct child, so `stop_all`
+        // sweeps the group first.  Here the group is a real process tree the
+        // supervisor never gets to signal, standing in for a task that has
+        // wedged past its grace period.
+        let dir = tempfile::TempDir::new().unwrap();
+        let pidfile = dir.path().join("grandchild.pid");
+        let mut state = state_for(config(BASE));
+        let mut leader = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(format!(
+                "trap '' TERM INT; sleep 30 & echo $! > {}; wait",
+                pidfile.display()
+            ))
+            .process_group(0)
+            .spawn()
+            .expect("spawned a stand-in process group");
+        let pgid = leader.id() as i32;
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let grandchild = loop {
+            if let Ok(pid) = std::fs::read_to_string(&pidfile)
+                .unwrap_or_default()
+                .trim()
+                .parse::<i32>()
+            {
+                break pid;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the fixture never recorded its grandchild"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        };
+
+        let slot = state.slots.get_mut(&name("api")).expect("slot exists");
+        slot.pgid.store(pgid, Ordering::Relaxed);
+
+        // A task that never finishes: `stop_all` has to give up on it.
+        let (stop, stop_rx) = shutdown_channel();
+        let mut stops = BTreeMap::new();
+        stops.insert(name("api"), stop);
+        let mut handles = BTreeMap::new();
+        handles.insert(
+            name("api"),
+            tokio::spawn(async move {
+                let _rx = stop_rx;
+                std::future::pending::<()>().await;
+            }),
+        );
+
+        // `stop_all` waits out `shutdown_timeout + STOP_GRACE`; with a paused
+        // clock that costs no wall time and stays bounded.
+        tokio::time::pause();
+        stop_all(&state, ShutdownReason::Terminated, &stops, &mut handles).await;
+        tokio::time::resume();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while nix::sys::signal::kill(Pid::from_raw(grandchild), None).is_ok()
+            && std::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            nix::sys::signal::kill(Pid::from_raw(grandchild), None).is_err(),
+            "grandchild {grandchild} of the detached group {pgid} was orphaned"
+        );
+        let _ = leader.wait();
     }
 
     #[tokio::test]

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -1245,7 +1245,10 @@ mod tests {
         assert_eq!(ControlOutcome::Started.to_string(), "started");
         assert_eq!(ControlOutcome::Restarted.to_string(), "restarted");
         assert_eq!(ControlOutcome::Stopped.to_string(), "stopped");
-        assert_eq!(ControlOutcome::AlreadyStopped.to_string(), "already stopped");
+        assert_eq!(
+            ControlOutcome::AlreadyStopped.to_string(),
+            "already stopped"
+        );
         assert_eq!(
             ControlOutcome::Reloaded {
                 added: 0,

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -154,6 +154,12 @@ pub type ControlTx = mpsc::UnboundedSender<Control>;
 pub type ControlRx = mpsc::UnboundedReceiver<Control>;
 
 /// Create a control channel.
+///
+/// Unbounded on purpose: what travels here is one message per operator request
+/// or per watch-triggered restart, so its cardinality is bounded by the number
+/// of services rather than by anything a child process can produce.  Only the
+/// log-line path needs a bound; see
+/// [`crate::runtime::event::MAX_QUEUED_LOG_LINES`].
 pub fn control_channel() -> (ControlTx, ControlRx) {
     mpsc::unbounded_channel()
 }
@@ -292,6 +298,8 @@ impl<'a> StackSupervisor<'a> {
             output: OutputMode::Capture,
         };
 
+        // Unbounded like the control channel, and for the same reason: exactly
+        // one report per spawned service run.
         let (report_tx, mut report_rx) = mpsc::unbounded_channel::<ServiceReport>();
         let mut state = RunState {
             config: Arc::new(self.config.clone()),

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -114,11 +114,89 @@ impl StackOutcome {
     }
 }
 
+/// What a [`Control`] command did.
+///
+/// The supervisor used to answer with a sentence — `"started"`, `"already
+/// stopped"`, `"1 added, 0 changed, 2 removed"` — and everything above it, up to
+/// and including the daemon's socket clients, read that prose as an API.  The
+/// sentence is still available through [`Display`](std::fmt::Display), for
+/// exactly one purpose: showing it to a person.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ControlOutcome {
+    /// A service that was not running was spawned.
+    Started,
+    /// A running service was stopped and spawned again.
+    Restarted,
+    /// A running service was stopped.
+    Stopped,
+    /// Nothing was done: the service was not running to begin with.
+    AlreadyStopped,
+    /// A new configuration was applied to the running stack.
+    Reloaded {
+        /// Services started because the new configuration declares them.
+        added: usize,
+        /// Services restarted because their definition changed.
+        changed: usize,
+        /// Services stopped because the new configuration drops them.
+        removed: usize,
+    },
+}
+
+impl std::fmt::Display for ControlOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ControlOutcome::Started => f.write_str("started"),
+            ControlOutcome::Restarted => f.write_str("restarted"),
+            ControlOutcome::Stopped => f.write_str("stopped"),
+            ControlOutcome::AlreadyStopped => f.write_str("already stopped"),
+            ControlOutcome::Reloaded {
+                added: 0,
+                changed: 0,
+                removed: 0,
+            } => f.write_str("no changes"),
+            ControlOutcome::Reloaded {
+                added,
+                changed,
+                removed,
+            } => write!(f, "{added} added, {changed} changed, {removed} removed"),
+        }
+    }
+}
+
+/// Why a [`Control`] command was refused.
+///
+/// Refusals are the half a client has to branch on — retry, report, give up —
+/// so each reason is its own variant rather than a message to match against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ControlRefusal {
+    /// The stack does not supervise a service by that name.
+    UnknownService(ServiceName),
+    /// Another command for that service has not finished yet.
+    Busy(ServiceName),
+    /// The service is running already, so there was nothing to start.
+    AlreadyRunning(ServiceName),
+}
+
+impl std::fmt::Display for ControlRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ControlRefusal::UnknownService(service) => {
+                write!(f, "{service} is not part of the running stack")
+            }
+            ControlRefusal::Busy(service) => {
+                write!(f, "{service} is busy with another command")
+            }
+            ControlRefusal::AlreadyRunning(service) => write!(f, "{service} is already running"),
+        }
+    }
+}
+
 /// Acknowledgement channel for a [`Control`] command.
 ///
-/// The message describes what happened ("started", "restarted", …); an error
-/// explains why the command was refused.
-pub type Ack = tokio::sync::oneshot::Sender<Result<String, String>>;
+/// Answered with what the command did, or with why it was refused.
+pub type Ack = tokio::sync::oneshot::Sender<Result<ControlOutcome, ControlRefusal>>;
 
 /// A command an operator sends to a running stack.
 #[derive(Debug)]
@@ -238,7 +316,7 @@ impl Slot {
     }
 
     /// Answer the client waiting on this slot, if there is one.
-    fn answer(&mut self, result: Result<String, String>) {
+    fn answer(&mut self, result: Result<ControlOutcome, ControlRefusal>) {
         if let Some(ack) = self.pending.take() {
             let _ = ack.send(result);
         }
@@ -374,15 +452,15 @@ impl<'a> StackSupervisor<'a> {
                         slot.stop = None;
                         slot.handle = None;
                         if slot.retired {
-                            slot.answer(Ok("stopped".to_string()));
+                            slot.answer(Ok(ControlOutcome::Stopped));
                             retire = true;
                         } else if slot.restart_when_stopped {
                             slot.restart_when_stopped = false;
                             slot.spawn(self.events.clone(), run_options, report_tx.clone());
                             running += 1;
-                            slot.answer(Ok("restarted".to_string()));
+                            slot.answer(Ok(ControlOutcome::Restarted));
                         } else {
-                            slot.answer(Ok("stopped".to_string()));
+                            slot.answer(Ok(ControlOutcome::Stopped));
                         }
                     }
                     if retire {
@@ -473,7 +551,7 @@ impl<'a> StackSupervisor<'a> {
 
         let Some(slot) = state.slots.get_mut(&service) else {
             let ack = into_ack(command);
-            let _ = ack.send(Err(format!("{service} is not part of the running stack")));
+            let _ = ack.send(Err(ControlRefusal::UnknownService(service)));
             return;
         };
 
@@ -481,25 +559,23 @@ impl<'a> StackSupervisor<'a> {
         // make "stop then restart" ambiguous.
         if slot.pending.is_some() {
             let ack = into_ack(command);
-            let _ = ack.send(Err(format!(
-                "{service} is already busy with another command"
-            )));
+            let _ = ack.send(Err(ControlRefusal::Busy(service)));
             return;
         }
 
         match command {
             Control::Start { ack, .. } => {
                 if slot.is_running() {
-                    let _ = ack.send(Err(format!("{service} is already running")));
+                    let _ = ack.send(Err(ControlRefusal::AlreadyRunning(service)));
                     return;
                 }
                 slot.spawn(self.events.clone(), run_options, reports.clone());
                 *running += 1;
-                let _ = ack.send(Ok("started".to_string()));
+                let _ = ack.send(Ok(ControlOutcome::Started));
             }
             Control::Stop { ack, .. } => {
                 let Some(stop) = slot.stop.clone() else {
-                    let _ = ack.send(Ok("already stopped".to_string()));
+                    let _ = ack.send(Ok(ControlOutcome::AlreadyStopped));
                     return;
                 };
                 slot.pending = Some(ack);
@@ -509,7 +585,7 @@ impl<'a> StackSupervisor<'a> {
                 let Some(stop) = slot.stop.clone() else {
                     slot.spawn(self.events.clone(), run_options, reports.clone());
                     *running += 1;
-                    let _ = ack.send(Ok("started".to_string()));
+                    let _ = ack.send(Ok(ControlOutcome::Started));
                     return;
                 };
                 slot.restart_when_stopped = true;
@@ -534,7 +610,7 @@ impl<'a> StackSupervisor<'a> {
         plan: Vec<ServiceName>,
         run_options: RunOptions,
         reports: &mpsc::UnboundedSender<ServiceReport>,
-    ) -> Result<String, String> {
+    ) -> Result<ControlOutcome, ControlRefusal> {
         // Applying a difference on top of a half-finished command would make
         // the outcome depend on the order the two complete in.
         if let Some(busy) = state
@@ -543,7 +619,7 @@ impl<'a> StackSupervisor<'a> {
             .find(|(_, slot)| slot.pending.is_some())
             .map(|(name, _)| name.clone())
         {
-            return Err(format!("{busy} is busy with another command"));
+            return Err(ControlRefusal::Busy(busy));
         }
 
         let diff = state.diff(&config, &plan);
@@ -624,15 +700,11 @@ impl<'a> StackSupervisor<'a> {
             }
         }
 
-        if diff.is_empty() {
-            return Ok("no changes".to_string());
-        }
-        Ok(format!(
-            "{} added, {} changed, {} removed",
-            diff.added.len(),
-            diff.changed.len(),
-            diff.removed.len()
-        ))
+        Ok(ControlOutcome::Reloaded {
+            added: diff.added.len(),
+            changed: diff.changed.len(),
+            removed: diff.removed.len(),
+        })
     }
 }
 
@@ -771,12 +843,6 @@ struct ConfigDiff {
     added: Vec<ServiceName>,
     changed: Vec<ServiceName>,
     removed: Vec<ServiceName>,
-}
-
-impl ConfigDiff {
-    fn is_empty(&self) -> bool {
-        self.added.is_empty() && self.changed.is_empty() && self.removed.is_empty()
-    }
 }
 
 /// Stop the stack in reverse dependency order, waiting for each service
@@ -1172,6 +1238,50 @@ mod tests {
         crate::validation::validate_service_name(raw).expect("valid test name")
     }
 
+    /// The prose is what an operator reads, and the CLI still prints it, so it
+    /// has to stay what it was before the outcome became a type.
+    #[test]
+    fn an_outcome_still_reads_as_the_sentence_it_replaced() {
+        assert_eq!(ControlOutcome::Started.to_string(), "started");
+        assert_eq!(ControlOutcome::Restarted.to_string(), "restarted");
+        assert_eq!(ControlOutcome::Stopped.to_string(), "stopped");
+        assert_eq!(ControlOutcome::AlreadyStopped.to_string(), "already stopped");
+        assert_eq!(
+            ControlOutcome::Reloaded {
+                added: 0,
+                changed: 0,
+                removed: 0
+            }
+            .to_string(),
+            "no changes"
+        );
+        assert_eq!(
+            ControlOutcome::Reloaded {
+                added: 1,
+                changed: 2,
+                removed: 3
+            }
+            .to_string(),
+            "1 added, 2 changed, 3 removed"
+        );
+    }
+
+    #[test]
+    fn a_refusal_still_reads_as_the_sentence_it_replaced() {
+        assert_eq!(
+            ControlRefusal::UnknownService(name("api")).to_string(),
+            "api is not part of the running stack"
+        );
+        assert_eq!(
+            ControlRefusal::Busy(name("api")).to_string(),
+            "api is busy with another command"
+        );
+        assert_eq!(
+            ControlRefusal::AlreadyRunning(name("api")).to_string(),
+            "api is already running"
+        );
+    }
+
     /// Build a validated config from TOML, as if it had been read from disk.
     fn config(toml: &str) -> Config {
         let raw: crate::raw::RawConfig = toml::from_str(toml).expect("valid test toml");
@@ -1220,7 +1330,7 @@ command = ["sleep", "60"]
         let plan = crate::runtime::plan_stack(&cfg, Selection::default()).unwrap();
 
         let diff = state.diff(&cfg, &plan);
-        assert!(diff.is_empty(), "{diff:?}");
+        assert_eq!(diff, ConfigDiff::default(), "{diff:?}");
     }
 
     #[test]

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -35,6 +35,17 @@ use crate::runtime::{
 /// supervisor stops waiting for its task and detaches it.
 const STOP_GRACE: Duration = Duration::from_secs(5);
 
+/// How long a service's event relay may take to drain after its runner returned.
+///
+/// The relay ends when the last sender on the per-service event channel is
+/// dropped.  By that point the process is gone and the runner has let go of its
+/// sink, so the normal case is immediate; this only bounds the wait when a task
+/// that captured a clone of the sink is still winding down — an output reader
+/// that had to be aborted, or a health monitor between ticks.  Generous enough
+/// that a machine under load does not lose events, short enough that no
+/// operator command waits on it.
+const RELAY_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Options for a stack run.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StackOptions {
@@ -1038,7 +1049,27 @@ async fn supervise_service(
         // the relay task.
     };
 
-    let _ = relay.await;
+    // Waiting for the relay to drain is what keeps a service's last events in
+    // front of its report, so a dependent never sees the report first.  It is
+    // bounded, because the relay only ends when the last sender for this
+    // service's channel is gone and not every holder of one is under this
+    // task's control: an aborted output reader is dropped promptly, but a
+    // health monitor runs detached and only notices on its next tick, which is
+    // as far away as the configured interval.
+    //
+    // Losing the tail of one service's events is a cosmetic problem.  Never
+    // sending the report is not: the supervisor would keep the slot busy, the
+    // operator's `stop` would wait for an ack that cannot come, and `up` would
+    // never learn that its stack had finished.
+    if tokio::time::timeout(RELAY_DRAIN_TIMEOUT, relay)
+        .await
+        .is_err()
+    {
+        tracing::debug!(
+            service = %name,
+            "the event relay outlived its drain timeout; reporting the run anyway"
+        );
+    }
     // The process is gone by the time the runner returns; nothing left to
     // sweep even if this task is aborted from here on.
     pgid.store(0, Ordering::Relaxed);

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -1264,7 +1264,10 @@ command = ["sleep", "60"]
     }
 
     #[test]
-    fn a_retired_slot_is_added_again_rather_than_reused() {
+    fn a_retired_slot_is_reported_as_added_again() {
+        // The slot itself is revived rather than replaced (see
+        // `StackSupervisor::reload`), but as far as the diff is concerned the
+        // service is coming back, so it belongs in `added`.
         let mut state = state_for(config(BASE));
         state
             .slots

--- a/crates/servicrab-core/src/runtime/stack.rs
+++ b/crates/servicrab-core/src/runtime/stack.rs
@@ -182,7 +182,14 @@ impl Slot {
     ) {
         // A previous run may have left the status at something a dependent
         // would read as a verdict; it must not act on that stale news.
-        let _ = self.readiness.send(DependencyStatus::new());
+        //
+        // `send_modify` rather than `send`: the value has to be there for a
+        // dependent that subscribes later, even when nobody is watching yet.
+        // `send` returns `Err` *without writing* when there is no receiver, and
+        // a service with no dependents has none until a reload gives it one.
+        self.readiness.send_modify(|status| {
+            *status = DependencyStatus::new();
+        });
 
         let (stop_tx, stop_rx) = shutdown_channel();
         self.stop = Some(stop_tx);
@@ -894,6 +901,11 @@ async fn supervise_service(
 
     // Relay the runner's events to the stack-wide stream while deriving the
     // readiness signal that dependents are waiting on.
+    //
+    // The readiness value is kept up to date whether or not anybody is
+    // subscribed: a service with no dependents still has to hold a truthful
+    // status, because a reload can add a dependent at any moment and that
+    // dependent reads the current value before it ever sees a change.
     let (tx, mut rx) = event_channel();
     let relay = {
         let global = events.clone();
@@ -901,7 +913,8 @@ async fn supervise_service(
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
                 if let Some(next) = tracker.observe(&event.kind) {
-                    let _ = readiness.send(next);
+                    // `send_modify` rather than `send`, for the reason above.
+                    readiness.send_modify(|status| *status = next);
                 }
                 let _ = global.send(event);
             }
@@ -1296,6 +1309,44 @@ command = ["sleep", "60"]
             condition,
             status,
         }]
+    }
+
+    #[tokio::test]
+    async fn readiness_is_recorded_even_without_a_subscriber() {
+        // The relay writes the readiness of a service that nobody depends on;
+        // `watch::Sender::send` would refuse to write with no receiver, and a
+        // later `reload` adding a dependent would then read a stale `Pending`.
+        let state = state_for(config(BASE));
+        let readiness = state.slots[&name("api")].readiness.clone();
+        let (tx, mut rx) = event_channel();
+
+        let relay = {
+            let readiness = readiness.clone();
+            let mut tracker = ReadinessTracker::new();
+            tokio::spawn(async move {
+                while let Some(event) = rx.recv().await {
+                    if let Some(next) = tracker.observe(&event.kind) {
+                        readiness.send_modify(|status| *status = next);
+                    }
+                }
+            })
+        };
+
+        assert_eq!(readiness.receiver_count(), 0, "nothing depends on api");
+        for kind in started() {
+            tx.send(ServiceEvent::new(name("api"), kind))
+                .expect("relay alive");
+        }
+        drop(tx);
+        relay.await.expect("relay task");
+
+        assert_eq!(
+            readiness
+                .borrow()
+                .readiness(DependencyCondition::ServiceStarted),
+            Readiness::Ready,
+            "a running service must look ready to a dependent added later"
+        );
     }
 
     #[tokio::test]

--- a/crates/servicrab-core/src/runtime/stack_stub.rs
+++ b/crates/servicrab-core/src/runtime/stack_stub.rs
@@ -86,8 +86,79 @@ impl StackOutcome {
     }
 }
 
+/// What a [`Control`] command did.  See the Unix implementation for the real
+/// thing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ControlOutcome {
+    /// A service that was not running was spawned.
+    Started,
+    /// A running service was stopped and spawned again.
+    Restarted,
+    /// A running service was stopped.
+    Stopped,
+    /// Nothing was done: the service was not running to begin with.
+    AlreadyStopped,
+    /// A new configuration was applied to the running stack.
+    Reloaded {
+        /// Services started because the new configuration declares them.
+        added: usize,
+        /// Services restarted because their definition changed.
+        changed: usize,
+        /// Services stopped because the new configuration drops them.
+        removed: usize,
+    },
+}
+
+impl std::fmt::Display for ControlOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ControlOutcome::Started => f.write_str("started"),
+            ControlOutcome::Restarted => f.write_str("restarted"),
+            ControlOutcome::Stopped => f.write_str("stopped"),
+            ControlOutcome::AlreadyStopped => f.write_str("already stopped"),
+            ControlOutcome::Reloaded {
+                added: 0,
+                changed: 0,
+                removed: 0,
+            } => f.write_str("no changes"),
+            ControlOutcome::Reloaded {
+                added,
+                changed,
+                removed,
+            } => write!(f, "{added} added, {changed} changed, {removed} removed"),
+        }
+    }
+}
+
+/// Why a [`Control`] command was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ControlRefusal {
+    /// The stack does not supervise a service by that name.
+    UnknownService(ServiceName),
+    /// Another command for that service has not finished yet.
+    Busy(ServiceName),
+    /// The service is running already, so there was nothing to start.
+    AlreadyRunning(ServiceName),
+}
+
+impl std::fmt::Display for ControlRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ControlRefusal::UnknownService(service) => {
+                write!(f, "{service} is not part of the running stack")
+            }
+            ControlRefusal::Busy(service) => {
+                write!(f, "{service} is busy with another command")
+            }
+            ControlRefusal::AlreadyRunning(service) => write!(f, "{service} is already running"),
+        }
+    }
+}
+
 /// Acknowledgement channel for a [`Control`] command.
-pub type Ack = tokio::sync::oneshot::Sender<Result<String, String>>;
+pub type Ack = tokio::sync::oneshot::Sender<Result<ControlOutcome, ControlRefusal>>;
 
 /// A command an operator sends to a running stack.
 #[derive(Debug)]

--- a/crates/servicrab-core/src/runtime/status.rs
+++ b/crates/servicrab-core/src/runtime/status.rs
@@ -175,6 +175,9 @@ impl StatusRegistry {
                     "watch: more than {limit} files; narrow `paths` or add `ignore` entries"
                 ));
             }
+            EventKind::LogLinesDropped { count } => {
+                entry.message = Some(format!("dropped {count} output line(s)"));
+            }
             // Log lines are far too frequent to keep, and `Exited` is already
             // reflected by the state transition that follows it.
             EventKind::Log { .. } | EventKind::Exited { .. } | EventKind::Stopping { .. } => {}

--- a/crates/servicrab-core/src/runtime/unix.rs
+++ b/crates/servicrab-core/src/runtime/unix.rs
@@ -261,11 +261,16 @@ async fn next_unhealthy(health: &mut Option<mpsc::UnboundedReceiver<HealthSignal
     }
 }
 
-/// SIGINT/SIGTERM handling for the current process.
+/// SIGINT/SIGTERM/SIGHUP handling for the current process.
 ///
 /// The watcher forwards every signal it sees into a shutdown channel so that
 /// one or many [`ServiceRunner`]s can react to it.  A second signal is
 /// forwarded as well, which the runners interpret as "stop waiting, kill now".
+///
+/// SIGHUP has to be registered explicitly: its default disposition kills the
+/// supervisor outright, and every service's process group would then be left
+/// running — which is exactly what closing a terminal on a foreground `up`
+/// does.
 #[derive(Debug)]
 pub struct SignalWatcher {
     tx: ShutdownTx,
@@ -273,7 +278,7 @@ pub struct SignalWatcher {
 }
 
 impl SignalWatcher {
-    /// Install SIGINT and SIGTERM handlers.
+    /// Install SIGINT, SIGTERM and SIGHUP handlers.
     ///
     /// `label` only gives signal-registration errors a useful subject: a
     /// service name for `run`, the project name for `up`.
@@ -292,6 +297,13 @@ impl SignalWatcher {
                 source,
             }
         })?;
+        let mut sighup = signal(SignalKind::hangup()).map_err(|source| {
+            RuntimeError::SignalRegistrationFailed {
+                service: label.to_string(),
+                signal: "SIGHUP",
+                source,
+            }
+        })?;
 
         let (tx, _rx) = shutdown_channel();
         let sender = tx.clone();
@@ -300,6 +312,7 @@ impl SignalWatcher {
                 let reason = tokio::select! {
                     _ = sigint.recv() => ShutdownReason::UserInterrupt,
                     _ = sigterm.recv() => ShutdownReason::Terminated,
+                    _ = sighup.recv() => ShutdownReason::HangUp,
                 };
                 // `send` fails only when every receiver is gone, in which case
                 // there is nothing left to shut down.

--- a/crates/servicrab-core/src/runtime/unix.rs
+++ b/crates/servicrab-core/src/runtime/unix.rs
@@ -431,15 +431,33 @@ impl<'a> ServiceRunner<'a> {
 
     /// Wait for the output readers to finish, but never block shutdown on a
     /// descendant that inherited the pipe and refuses to close it.
+    ///
+    /// A reader that overruns the timeout is **aborted**, not merely dropped.
+    /// Dropping a [`JoinHandle`] detaches its task, and a detached reader keeps
+    /// the clone of the event sink it captured — which keeps the per-service
+    /// event channel open, which keeps the relay task that forwards from it
+    /// alive, which means the supervision task never gets past awaiting the
+    /// relay and never sends its report.  The operator's `stop` then waits for
+    /// an ack that nothing can ever send: the command times out and the slot
+    /// stays busy, while the service itself has already exited cleanly.
+    ///
+    /// Trailing output can be lost when this fires.  That is the trade this
+    /// timeout was always making; what it must not also trade away is the
+    /// supervisor's ability to report that the service stopped.
     async fn drain_readers(readers: Vec<JoinHandle<()>>) {
         for reader in readers {
+            // Taken before the handle is moved into the timeout, which is what
+            // consumes it.
+            let abort = reader.abort_handle();
             if tokio::time::timeout(READER_DRAIN_TIMEOUT, reader)
                 .await
                 .is_err()
             {
-                // The timeout dropped the JoinHandle, which detaches the task;
-                // it ends as soon as the pipe closes.
-                tracing::debug!("output reader did not finish within the drain timeout");
+                abort.abort();
+                tracing::debug!(
+                    "output reader did not finish within the drain timeout; \
+                     dropping the rest of its output"
+                );
             }
         }
     }
@@ -853,5 +871,41 @@ mod tests {
             exit_reason(std::process::ExitStatus::from_raw(9)),
             ExitReason::Signal(9)
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_stuck_output_reader_is_aborted_so_the_event_channel_can_close() {
+        // A reader that overruns its drain timeout used to be detached rather
+        // than aborted, and a detached reader keeps the clone of the event sink
+        // it captured.  That one live sender keeps the service's event channel
+        // open forever, which strands the relay task that forwards from it, and
+        // the supervision task waiting on that relay never sends its report —
+        // so an operator's `stop` waits for an ack that nobody can send.
+        let (tx, mut rx) = crate::runtime::event_channel();
+        let service = sh_service("stuck", "exit 0");
+        let runner = ServiceRunner::new(
+            &service,
+            RunOptions::default().with_output(OutputMode::Capture),
+        )
+        .with_events(EventSink::new(tx));
+
+        // The writing half stands in for a descendant that inherited the
+        // child's stdout and survived the group sweep: the reader can never
+        // reach end-of-file on its own.
+        let (writer, pipe) = tokio::io::duplex(64);
+        let reader = runner.spawn_reader(pipe, Stream::Stdout);
+
+        ServiceRunner::drain_readers(vec![reader]).await;
+        // What the supervision task does once its runner has returned.
+        drop(runner);
+
+        let drained = tokio::time::timeout(Duration::from_secs(30), rx.recv()).await;
+        assert_eq!(
+            drained,
+            Ok(None),
+            "the event channel must close once the runner is done, even with a \
+             reader stuck on a pipe that never reaches end-of-file"
+        );
+        drop(writer);
     }
 }

--- a/crates/servicrab-core/src/runtime/unix.rs
+++ b/crates/servicrab-core/src/runtime/unix.rs
@@ -11,7 +11,10 @@
 //! ```
 //!
 //! Signalling only the direct child would leave `node` and `esbuild` running,
-//! so every signal is delivered with `killpg(2)`.
+//! so every signal is delivered with `killpg(2)`, and [`ProcessHandle`] sweeps
+//! its group with `SIGKILL` when it is dropped without having been swept — an
+//! early return or an aborted supervision task must not orphan a grandchild
+//! either.  `kill_on_drop(true)` alone would only reach the direct child.
 //!
 //! [`ServiceRunner`] supervises exactly one service and is driven entirely by a
 //! shutdown channel, which makes it reusable both for the single-service `run`
@@ -66,11 +69,20 @@ fn spawn_error_is_retryable(err: &std::io::Error) -> bool {
 }
 
 /// A running service process and the process group it leads.
+///
+/// Dropping the handle sweeps the group with `SIGKILL` unless it has already
+/// been swept, so an early return — a failed `wait`, a rejected state
+/// transition, a cancelled supervision task — cannot leave a grandchild
+/// behind.  `kill_on_drop(true)` alone would only reach the direct child.
 #[derive(Debug)]
 pub struct ProcessHandle {
     child: Child,
     pgid: Pid,
     started_at: Instant,
+    /// Set once the group has been swept.  After that the leader has been
+    /// reaped and the kernel may hand its id to somebody else, so signalling
+    /// it again would be signalling a stranger.
+    swept: bool,
 }
 
 impl ProcessHandle {
@@ -121,6 +133,7 @@ impl ProcessHandle {
             child,
             pgid,
             started_at: Instant::now(),
+            swept: false,
         })
     }
 
@@ -152,7 +165,8 @@ impl ProcessHandle {
 
     /// `SIGKILL` any process left in the group, ignoring an already-empty
     /// group.  Used to make sure no descendant outlives the supervisor.
-    fn kill_group(&self, service: &str, timeout: Duration) -> Result<(), RuntimeError> {
+    fn kill_group(&mut self, service: &str, timeout: Duration) -> Result<(), RuntimeError> {
+        self.swept = true;
         match killpg(self.pgid, Signal::SIGKILL) {
             Ok(()) => Ok(()),
             Err(errno) if group_is_gone(errno) => {
@@ -184,6 +198,27 @@ impl ProcessHandle {
                 source,
             })?;
         Ok(exit_reason(status))
+    }
+}
+
+impl Drop for ProcessHandle {
+    fn drop(&mut self) {
+        // Invariant: no process group of ours outlives its handle.  The normal
+        // path sweeps the group explicitly and sets `swept`; this covers every
+        // other way the handle can go away — a `?` on a failed `wait` or a
+        // rejected state transition, or the supervision task being aborted.
+        if self.swept {
+            return;
+        }
+        if let Err(errno) = killpg(self.pgid, Signal::SIGKILL) {
+            if !group_is_gone(errno) {
+                tracing::warn!(
+                    pgid = self.pgid.as_raw(),
+                    %errno,
+                    "could not sweep the process group while dropping its handle"
+                );
+            }
+        }
     }
 }
 
@@ -668,13 +703,98 @@ impl<'a> ForegroundRunner<'a> {
 /// has been reaped and only unrelated processes could still claim the id.
 /// Either way there is no process of ours left to kill, and failing the run
 /// over it would turn a successful shutdown into a spurious error.
-fn group_is_gone(errno: nix::errno::Errno) -> bool {
+pub(crate) fn group_is_gone(errno: nix::errno::Errno) -> bool {
     matches!(errno, nix::errno::Errno::ESRCH | nix::errno::Errno::EPERM)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A validated service running `body` through `/bin/sh`.
+    fn sh_service(name: &str, body: &str) -> Service {
+        let toml = format!(
+            "version = 1\n[project]\nname = \"probe\"\n\
+             [services.{name}]\ncommand = [\"/bin/sh\", \"-c\", \"{body}\"]\n"
+        );
+        let raw: crate::raw::RawConfig = toml::from_str(&toml).expect("valid test toml");
+        let cfg = crate::validation::validate_raw(raw, std::path::Path::new("/tmp/servicrab.toml"))
+            .expect("valid test config")
+            .0;
+        cfg.services.values().next().cloned().expect("one service")
+    }
+
+    fn is_alive(pid: i32) -> bool {
+        nix::sys::signal::kill(Pid::from_raw(pid), None).is_ok()
+    }
+
+    /// Wait, with an upper bound, for `pid` to disappear.
+    fn wait_until_gone(pid: i32) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if !is_alive(pid) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        false
+    }
+
+    /// Read the grandchild's pid the fixture wrote, with an upper bound.
+    fn wait_for_pid(path: &std::path::Path) -> i32 {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if let Ok(text) = std::fs::read_to_string(path) {
+                if let Ok(pid) = text.trim().parse() {
+                    return pid;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        panic!("the fixture never recorded its grandchild");
+    }
+
+    #[tokio::test]
+    async fn dropping_a_handle_sweeps_the_whole_process_group() {
+        // Every `?` in `ServiceRunner::run` returns while the handle still owns
+        // a live group, and so does an aborted supervision task.
+        // `kill_on_drop(true)` would only reach the direct child, orphaning a
+        // grandchild that ignores the shutdown signal.
+        let dir = tempfile::TempDir::new().unwrap();
+        let pidfile = dir.path().join("grandchild.pid");
+        let service = sh_service(
+            "tree",
+            &format!(
+                "trap '' TERM INT; sleep 30 & echo $! > {}; wait",
+                pidfile.display()
+            ),
+        );
+
+        let handle = ProcessHandle::spawn(&service, OutputMode::Capture).expect("spawned");
+        let leader = handle.pgid();
+        let grandchild = wait_for_pid(&pidfile);
+        assert!(is_alive(grandchild));
+
+        drop(handle);
+
+        assert!(
+            wait_until_gone(grandchild),
+            "grandchild {grandchild} of group {leader} survived the handle"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_swept_group_is_not_signalled_again_on_drop() {
+        // Once the leader has been reaped the kernel may hand its group id to
+        // somebody else, so the drop guard has to stay out of the way.
+        let service = sh_service("quick", "exit 0");
+        let mut handle = ProcessHandle::spawn(&service, OutputMode::Capture).expect("spawned");
+        handle.wait("quick").await.expect("reaped");
+        handle
+            .kill_group("quick", Duration::from_secs(1))
+            .expect("sweeping an empty group is fine");
+        assert!(handle.swept);
+    }
 
     #[test]
     fn a_vanished_group_is_not_an_error() {

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -991,8 +991,20 @@ fn validate_health(
     };
 
     // `retries` is the number of consecutive failures needed to declare the
-    // service unhealthy, so it is always at least one probe.
-    let retries = raw.retries.unwrap_or(3).max(1);
+    // service unhealthy, so it is always at least one probe.  Zero used to be
+    // rewritten to one; it is an error now, like every other out-of-domain
+    // value in this file, because silently disagreeing with the config is a
+    // worse answer than refusing it.
+    let retries = match raw.retries {
+        Some(0) => {
+            errors.push(ConfigError::InvalidHealthRetries {
+                service: service.to_string(),
+            });
+            1
+        }
+        Some(retries) => retries,
+        None => 3,
+    };
 
     Some(HealthCheck {
         probe: probe?,
@@ -1562,21 +1574,21 @@ interval = "10ms""#,
     }
 
     #[test]
-    fn zero_retries_are_normalised_to_one() {
-        let (cfg, _) = load_from_str(&with_health(
+    fn zero_retries_are_rejected() {
+        // A service cannot be declared unhealthy without a single failed
+        // probe, so zero is out of domain rather than a value to be corrected.
+        let err = expect_one_error(&with_health(
             r#"tcp = "127.0.0.1:5432"
 retries = 0"#,
-        ))
-        .unwrap();
-        let health = cfg
-            .services
-            .values()
-            .next()
-            .unwrap()
-            .health
-            .clone()
-            .unwrap();
-        assert_eq!(health.retries, 1);
+        ));
+        assert!(
+            matches!(err, ConfigError::InvalidHealthRetries { .. }),
+            "{err:?}"
+        );
+        assert!(
+            err.to_string().contains("retries must be at least 1"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -251,6 +251,33 @@ pub fn validate_raw(
                     });
                 }
             }
+
+            // Not one of the fields above, because the setting is not inert:
+            // an unhealthy service still gets stopped, it just never comes
+            // back.  Only an explicit `restart` is warned about — the default
+            // covers the legitimate case of a health check used purely to gate
+            // dependents, where nothing is meant to be restarted.
+            let asks_for_restart = raw_svc
+                .health
+                .as_ref()
+                .is_some_and(|health| health.on_unhealthy.as_deref() == Some("restart"));
+            if asks_for_restart {
+                warnings.push(ConfigWarning::UnhealthyRestartWithoutPolicy {
+                    service: raw_name.clone(),
+                });
+            }
+        }
+
+        // Warning: a service that asks to be logged in a project that has no
+        // log directory.  `log_to_file` above is computed either way, but
+        // `LogRouter` is only built when `[project.logs]` exists, so the
+        // request is silently inert.  The raw table is what is checked, not the
+        // validated one, so a broken `[project.logs]` reports its own error
+        // instead of also producing this warning.
+        if raw.project.logs.is_none() && raw_svc.logs.as_ref().is_some_and(|logs| logs.enabled) {
+            warnings.push(ConfigWarning::LogsWithoutProjectLogs {
+                service: raw_name.clone(),
+            });
         }
 
         // Warning: executable not in PATH
@@ -2570,6 +2597,129 @@ max_restarts = 5
                 }
             )),
             "expected max_restarts warning, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn service_logs_warn_without_a_project_logs_table() {
+        let toml = r#"
+version = 1
+[project]
+name = "p"
+[services.s]
+command = ["echo"]
+[services.s.logs]
+enabled = true
+"#;
+        let (_, warnings) = load_from_str(toml).unwrap();
+        let warning = warnings
+            .iter()
+            .find(|w| matches!(w, ConfigWarning::LogsWithoutProjectLogs { .. }))
+            .unwrap_or_else(|| panic!("expected a logs warning, got: {warnings:?}"));
+        let msg = warning.to_string();
+        assert!(msg.contains("\"s\""), "{msg}");
+        assert!(msg.contains("[project.logs]"), "{msg}");
+    }
+
+    #[test]
+    fn service_logs_are_silent_when_the_project_declares_a_log_directory() {
+        let (_, warnings) = load_from_str(&with_logs("", "[services.api.logs]\nenabled = true"))
+            .expect("valid config");
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| matches!(w, ConfigWarning::LogsWithoutProjectLogs { .. })),
+            "{warnings:?}"
+        );
+    }
+
+    #[test]
+    fn disabled_service_logs_do_not_warn() {
+        // `enabled = false` is inert in exactly the same way, but it says the
+        // same thing the missing table does, so there is nothing to point out.
+        let toml = r#"
+version = 1
+[project]
+name = "p"
+[services.s]
+command = ["echo"]
+[services.s.logs]
+enabled = false
+"#;
+        let (_, warnings) = load_from_str(toml).unwrap();
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| matches!(w, ConfigWarning::LogsWithoutProjectLogs { .. })),
+            "{warnings:?}"
+        );
+    }
+
+    #[test]
+    fn on_unhealthy_restart_warns_when_restart_never() {
+        let toml = r#"
+version = 1
+[project]
+name = "p"
+[services.s]
+command = ["echo"]
+restart = "never"
+[services.s.health]
+tcp = "127.0.0.1:5432"
+on_unhealthy = "restart"
+"#;
+        let (_, warnings) = load_from_str(toml).unwrap();
+        let warning = warnings
+            .iter()
+            .find(|w| matches!(w, ConfigWarning::UnhealthyRestartWithoutPolicy { .. }))
+            .unwrap_or_else(|| panic!("expected an on_unhealthy warning, got: {warnings:?}"));
+        let msg = warning.to_string();
+        assert!(msg.contains("\"s\""), "{msg}");
+        assert!(msg.contains("on_unhealthy"), "{msg}");
+    }
+
+    #[test]
+    fn on_unhealthy_restart_is_silent_with_a_restart_policy() {
+        let toml = r#"
+version = 1
+[project]
+name = "p"
+[services.s]
+command = ["echo"]
+restart = "on-failure"
+[services.s.health]
+tcp = "127.0.0.1:5432"
+on_unhealthy = "restart"
+"#;
+        let (_, warnings) = load_from_str(toml).unwrap();
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| matches!(w, ConfigWarning::UnhealthyRestartWithoutPolicy { .. })),
+            "{warnings:?}"
+        );
+    }
+
+    #[test]
+    fn a_health_check_used_only_for_gating_does_not_warn() {
+        // No explicit `on_unhealthy`, so this is the readiness-gating case:
+        // `restart = "never"` is the intended configuration, not a trap.
+        let toml = r#"
+version = 1
+[project]
+name = "p"
+[services.s]
+command = ["echo"]
+restart = "never"
+[services.s.health]
+tcp = "127.0.0.1:5432"
+"#;
+        let (_, warnings) = load_from_str(toml).unwrap();
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| matches!(w, ConfigWarning::UnhealthyRestartWithoutPolicy { .. })),
+            "{warnings:?}"
         );
     }
 

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -19,7 +19,11 @@ use crate::raw::{
 };
 
 /// The only supported schema version.
-const SUPPORTED_VERSION: u32 = 1;
+///
+/// Read by [`crate::load::load`] too: the check there runs before the
+/// field-level parse, because a file written for a later schema is made of
+/// fields this build does not know and would otherwise be reported as a typo.
+pub(crate) const SUPPORTED_VERSION: u32 = 1;
 
 // Duration range constants
 const DUR_100MS: Duration = Duration::from_millis(100);

--- a/crates/servicrab-core/src/validation.rs
+++ b/crates/servicrab-core/src/validation.rs
@@ -187,6 +187,9 @@ pub fn validate_raw(
             &mut errors,
         );
 
+        // No range check to make: every `u32` is meaningful, and `0` is the
+        // unlimited budget rather than an out-of-domain value (see
+        // `RestartTracker::budget_left`).
         let max_restarts = raw_svc.max_restarts.unwrap_or(10);
 
         let stable_after = parse_duration_field(
@@ -2531,6 +2534,30 @@ restart_delay = "2s"
                 }
             )),
             "expected restart_delay warning"
+        );
+    }
+
+    #[test]
+    fn max_restarts_warns_when_restart_never() {
+        let toml = r#"
+version = 1
+[project]
+name = "p"
+[services.s]
+command = ["echo"]
+restart = "never"
+max_restarts = 5
+"#;
+        let (_, warnings) = load_from_str(toml).unwrap();
+        assert!(
+            warnings.iter().any(|w| matches!(
+                w,
+                ConfigWarning::RestartSettingsIgnored {
+                    field: "max_restarts",
+                    ..
+                }
+            )),
+            "expected max_restarts warning, got: {warnings:?}"
         );
     }
 

--- a/crates/servicrab-protocol/src/frame.rs
+++ b/crates/servicrab-protocol/src/frame.rs
@@ -95,6 +95,18 @@ mod tests {
     }
 
     #[test]
+    fn a_dropped_line_notice_survives_a_round_trip() {
+        let response = Response::Event {
+            service: "api".to_string(),
+            event: crate::Event::LogLinesDropped { count: 42 },
+        };
+        let line = encode(&response).unwrap();
+        assert!(line.contains("\"kind\":\"log_lines_dropped\""), "{line}");
+        assert!(line.contains("\"count\":42"), "{line}");
+        assert_eq!(decode::<Response>(&line).unwrap(), response);
+    }
+
+    #[test]
     fn event_payloads_omit_absent_exit_details() {
         let response = Response::Event {
             service: "api".to_string(),

--- a/crates/servicrab-protocol/src/frame.rs
+++ b/crates/servicrab-protocol/src/frame.rs
@@ -46,6 +46,7 @@ mod tests {
         let response = Response::Pong {
             project: "demo".to_string(),
             pid: 42,
+            version: Some(crate::PROTOCOL_VERSION),
         };
         let line = encode(&response).unwrap();
         assert_eq!(decode::<Response>(&line).unwrap(), response);
@@ -54,7 +55,10 @@ mod tests {
     #[test]
     fn carriage_returns_are_tolerated() {
         let line = "{\"type\":\"ping\"}\r\n";
-        assert_eq!(decode::<Request>(line).unwrap(), Request::Ping);
+        assert_eq!(
+            decode::<Request>(line).unwrap(),
+            Request::Ping { version: None }
+        );
     }
 
     #[test]
@@ -134,6 +138,154 @@ mod tests {
     #[test]
     fn garbage_is_reported_not_panicked_on() {
         assert!(decode::<Request>("not json").is_err());
-        assert!(decode::<Request>("{\"type\":\"fly\"}").is_err());
+        assert!(decode::<Request>("[1,2,3]").is_err());
+        assert!(decode::<Request>("{}").is_err());
+    }
+
+    /// The one that used to assert the opposite.
+    ///
+    /// `#[non_exhaustive]` is a promise to downstream *crates*, and serde's
+    /// internally tagged representation rejects an unrecognised tag outright, so
+    /// a newer client's request used to come back as `malformed message: unknown
+    /// variant …` — and the daemon's own "an older daemon can still be asked
+    /// something it does not know" arm was unreachable from a socket.
+    #[test]
+    fn an_unknown_request_decodes_instead_of_failing() {
+        assert_eq!(
+            decode::<Request>("{\"type\":\"fly\"}").unwrap(),
+            Request::Unknown
+        );
+        // Whatever it carried, too: a future request will not be a bare tag.
+        assert_eq!(
+            decode::<Request>("{\"type\":\"fly\",\"altitude\":9000}").unwrap(),
+            Request::Unknown
+        );
+    }
+
+    /// A `ping` is the one exchange both sides can rely on across versions, so
+    /// it is where the version goes — and it has to survive both directions of
+    /// skew, because 0.3 sends no number and will be answered by daemons that
+    /// do.
+    #[test]
+    fn a_version_travels_with_a_ping_but_is_not_required() {
+        let line = encode(&Request::ping()).unwrap();
+        assert!(line.contains("\"version\":1"), "{line}");
+
+        assert_eq!(
+            decode::<Request>("{\"type\":\"ping\"}").unwrap(),
+            Request::Ping { version: None },
+            "a 0.3 client sends no version and must still be understood"
+        );
+        assert_eq!(
+            decode::<Request>("{\"type\":\"ping\",\"version\":7}").unwrap(),
+            Request::Ping { version: Some(7) },
+            "a newer client's version must arrive intact, not be rounded down"
+        );
+    }
+
+    /// The same for the answer: a 0.3 daemon's `pong` has no version, and a
+    /// client that treated silence as a mismatch would refuse to talk to one.
+    #[test]
+    fn a_pong_without_a_version_is_still_a_pong() {
+        let reply =
+            decode::<Response>("{\"type\":\"pong\",\"project\":\"demo\",\"pid\":7}").unwrap();
+
+        assert_eq!(
+            reply,
+            Response::Pong {
+                project: "demo".to_string(),
+                pid: 7,
+                version: None,
+            }
+        );
+    }
+
+    /// The defect this exists to prevent: one line a client cannot name used to
+    /// end the whole event stream, so a single new event kind in 1.1 would have
+    /// killed `servicrab events` on every 1.0 client, mid-run.
+    #[test]
+    fn an_unknown_event_kind_decodes_instead_of_ending_the_stream() {
+        let line = r#"{"type":"event","service":"api","event":{"kind":"teleported","to":"mars"}}"#;
+
+        let response =
+            decode::<Response>(line).expect("an unknown event kind is not a broken line");
+
+        assert_eq!(
+            response,
+            Response::Event {
+                service: "api".to_string(),
+                event: crate::Event::Unknown,
+            },
+            "the service still has to survive, or a client cannot even say who the event was about"
+        );
+    }
+
+    #[test]
+    fn an_unknown_response_type_decodes_instead_of_ending_the_stream() {
+        assert_eq!(
+            decode::<Response>("{\"type\":\"weather\",\"outlook\":\"grim\"}").unwrap(),
+            Response::Unknown
+        );
+    }
+
+    /// A status snapshot is a `pong`'s worth of forward compatibility spread
+    /// over every service: one state or health verdict this build cannot name
+    /// used to fail the whole `Response::Status`, so `status`, `start --wait`
+    /// and `down` all reported a parse error rather than what they were told.
+    #[test]
+    fn an_unknown_state_or_health_leaves_the_rest_of_a_status_readable() {
+        let line = r#"{"type":"status","services":[
+            {"name":"api","state":"hibernating","restarts":0,"health":"degraded"},
+            {"name":"db","state":"running","restarts":2,"health":"healthy"}
+        ]}"#;
+
+        let Response::Status { services } =
+            decode::<Response>(line).expect("one unknown state must not fail the snapshot")
+        else {
+            panic!("expected a status");
+        };
+
+        assert_eq!(services[0].state, crate::ServiceState::Unknown);
+        assert_eq!(services[0].health, crate::Health::Unknown);
+        // The point of decoding it at all: everything else is still there.
+        assert_eq!(services[1].name, "db");
+        assert_eq!(services[1].state, crate::ServiceState::Running);
+        assert_eq!(services[1].restarts, 2);
+    }
+
+    #[test]
+    fn an_unknown_log_stream_still_carries_its_line() {
+        let line = r#"{"type":"event","service":"api","event":{"kind":"log","stream":"trace","line":"boom"}}"#;
+
+        let response = decode::<Response>(line).expect("an unknown stream is not a broken line");
+
+        assert_eq!(
+            response,
+            Response::Event {
+                service: "api".to_string(),
+                event: crate::Event::Log {
+                    stream: crate::Stream::Unknown,
+                    line: "boom".to_string(),
+                },
+            }
+        );
+    }
+
+    /// `unknown` is a reserved word in the wire format as a consequence of the
+    /// fallbacks: a future release that named a real variant `unknown` would be
+    /// silently classified as "not understood" by every earlier client, which is
+    /// exactly the silence these fallbacks were added to remove.
+    #[test]
+    fn the_fallback_tag_round_trips_so_it_cannot_be_reused() {
+        for line in [
+            encode(&Response::Unknown).unwrap(),
+            encode(&Request::Unknown).unwrap(),
+        ] {
+            assert!(line.contains(crate::UNKNOWN), "{line}");
+        }
+        assert_eq!(
+            decode::<Response>(&format!("{{\"type\":\"{}\"}}", crate::UNKNOWN)).unwrap(),
+            Response::Unknown
+        );
     }
 }

--- a/crates/servicrab-protocol/src/frame.rs
+++ b/crates/servicrab-protocol/src/frame.rs
@@ -28,6 +28,37 @@ pub fn decode<T: DeserializeOwned>(line: &str) -> Result<T, FrameError> {
     Ok(serde_json::from_str(line.trim_end_matches(['\r', '\n']))?)
 }
 
+/// How much of a `type` tag [`tag`] will hand back.
+///
+/// Every tag either side of this protocol will ever use is a word.  The bound
+/// exists because the caller of `tag` is quoting an unrecognised one back to
+/// whoever sent it, and a line may be tens of kilobytes: without it, a peer
+/// could make a refusal carry its own payload back out again.
+///
+/// Public because it is the promise `tag` makes about its result, and a caller
+/// sizing a message around that result needs the number rather than a guess.
+pub const MAX_TAG: usize = 48;
+
+/// The `type` a line claims to be, when that is all a caller needs from it.
+///
+/// [`decode`] answers what a line *means*, and for a message from a later
+/// release the answer is an `Unknown` fallback — which by construction cannot
+/// carry the tag, because `#[serde(other)]` only applies to a unit variant.  So
+/// the tag has to come back out of the line, and this is the one place that
+/// knows how: the same trimming rule as `decode`, `type` because that is the
+/// discriminant both directions are tagged by, and a string because a tag that
+/// is not one could never have named a variant.
+///
+/// Truncated to [`MAX_TAG`] characters — characters rather than bytes, so a
+/// multi-byte tag is cut where it can still be printed.  `None` for a line that
+/// is not a JSON object, or has no string `type`.
+pub fn tag(line: &str) -> Option<String> {
+    let value: serde_json::Value =
+        serde_json::from_str(line.trim_end_matches(['\r', '\n'])).ok()?;
+    let named = value.get("type")?.as_str()?;
+    Some(named.chars().take(MAX_TAG).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,6 +164,55 @@ mod tests {
         let line = encode(&response).unwrap();
         assert!(line.contains("\"type\":\"lagged\""));
         assert_eq!(decode::<Response>(&line).unwrap(), response);
+    }
+
+    /// The tag has to come back out of the line because the decoded value
+    /// cannot carry it: `#[serde(other)]` only applies to a unit variant, so
+    /// `Request::Unknown` is all the daemon has to go on when it wants to quote
+    /// an unrecognised request back to whoever sent it.
+    #[test]
+    fn the_type_of_a_line_can_be_recovered_after_it_decodes_to_the_fallback() {
+        assert_eq!(
+            tag("{\"type\":\"strat\",\"name\":\"api\"}"),
+            Some("strat".into())
+        );
+        // The same trimming rule as `decode`, or a tag would come back with the
+        // newline still attached to it.
+        assert_eq!(tag("{\"type\":\"drain\"}\r\n"), Some("drain".into()));
+        assert_eq!(tag("{\"type\":\"ping\"}"), Some("ping".into()));
+    }
+
+    /// A caller quotes the tag back to the peer that sent it, so a line with
+    /// nothing usable in it has to be answerable without one.
+    #[test]
+    fn a_line_with_no_usable_type_has_no_tag() {
+        for line in [
+            "not json",
+            "[1,2,3]",
+            "{}",
+            "{\"type\":7}",
+            "{\"type\":null}",
+            "{\"kind\":\"log\"}",
+        ] {
+            assert_eq!(tag(line), None, "{line:?}");
+        }
+    }
+
+    /// The refusal that quotes a tag is written back down the same socket the
+    /// tag arrived on, and a line may be tens of kilobytes.  Without a bound, a
+    /// peer could use the refusal to carry its own payload back out again.
+    #[test]
+    fn an_absurd_tag_is_truncated_rather_than_quoted_in_full() {
+        let huge = "x".repeat(4096);
+        let line = format!("{{\"type\":\"{huge}\"}}");
+
+        let recovered = tag(&line).expect("a long tag is still a tag");
+
+        assert_eq!(recovered.len(), MAX_TAG);
+        // Cut by characters, not bytes, so a multi-byte tag stays printable.
+        let wide = "\u{1f980}".repeat(200);
+        let recovered = tag(&format!("{{\"type\":\"{wide}\"}}")).expect("a wide tag");
+        assert_eq!(recovered.chars().count(), MAX_TAG);
     }
 
     #[test]

--- a/crates/servicrab-protocol/src/frame.rs
+++ b/crates/servicrab-protocol/src/frame.rs
@@ -63,7 +63,7 @@ mod tests {
         assert_eq!(
             request,
             Request::Subscribe {
-                services: Vec::new(),
+                services: std::collections::BTreeSet::new(),
                 logs: true,
             }
         );
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn a_subscribe_request_survives_a_round_trip() {
         let request = Request::Subscribe {
-            services: vec!["api".to_string()],
+            services: ["api".to_string()].into_iter().collect(),
             logs: false,
         };
         let line = encode(&request).unwrap();

--- a/crates/servicrab-protocol/src/lib.rs
+++ b/crates/servicrab-protocol/src/lib.rs
@@ -18,4 +18,7 @@ pub mod response;
 
 pub use frame::{decode, encode, FrameError};
 pub use request::Request;
-pub use response::{Event, Health, Response, ServiceInfo, ServiceState, Stream};
+pub use response::{
+    Event, Health, ReloadChanges, Response, ServiceInfo, ServiceState, Stream, ErrorCode,
+    SCHEMA_VERSION,
+};

--- a/crates/servicrab-protocol/src/lib.rs
+++ b/crates/servicrab-protocol/src/lib.rs
@@ -19,6 +19,6 @@ pub mod response;
 pub use frame::{decode, encode, FrameError};
 pub use request::Request;
 pub use response::{
-    Event, Health, ReloadChanges, Response, ServiceInfo, ServiceState, Stream, ErrorCode,
+    ErrorCode, Event, Health, ReloadChanges, Response, ServiceInfo, ServiceState, Stream,
     SCHEMA_VERSION,
 };

--- a/crates/servicrab-protocol/src/lib.rs
+++ b/crates/servicrab-protocol/src/lib.rs
@@ -18,4 +18,18 @@ pub mod response;
 
 pub use frame::{decode, encode, FrameError};
 pub use request::Request;
-pub use response::{Event, Health, Response, ServiceInfo, ServiceState, Stream};
+pub use response::{Event, Health, Response, ServiceInfo, ServiceState, Stream, UNKNOWN};
+
+/// Which revision of this wire format this build speaks.
+///
+/// It is not the crate version: the two move independently, and a release that
+/// changes nothing on the socket must not make every daemon look mismatched.
+/// It travels in the `ping`/`pong` exchange as an `Option`, because 0.3 spoke
+/// this format without naming it and "did not say" has to stay distinguishable
+/// from "said 0".
+///
+/// Nothing refuses to talk on the strength of this number.  Both sides decode
+/// leniently — see [`UNKNOWN`] — so a mismatch is a thing to report, not a thing
+/// to fail on, and the report is what turns "my command silently did nothing
+/// useful" into "this daemon is older than this client".
+pub const PROTOCOL_VERSION: u32 = 1;

--- a/crates/servicrab-protocol/src/request.rs
+++ b/crates/servicrab-protocol/src/request.rs
@@ -19,7 +19,17 @@ pub const MAX_SUBSCRIBE_SERVICES: usize = 256;
 #[non_exhaustive]
 pub enum Request {
     /// Ask the daemon whether it is alive.
-    Ping,
+    Ping {
+        /// Which revision of this wire format the client speaks.
+        ///
+        /// Optional because a 0.3 client does not send it, and the daemon has to
+        /// keep answering those: absent means "did not say", not "version 0".
+        /// A daemon that hears a number below its own says so in its log, which
+        /// is the one place an operator looking at a version-skew problem will
+        /// already be.  See [`crate::PROTOCOL_VERSION`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<u32>,
+    },
 
     /// Ask the daemon for the current state of every service.
     Status,
@@ -72,6 +82,35 @@ pub enum Request {
         #[serde(default = "yes")]
         logs: bool,
     },
+
+    /// A request this build has no name for, because a newer client sent it.
+    ///
+    /// Without this the daemon answered `malformed message: unknown variant …`
+    /// and counted the line against the connection, so the wildcard arm in its
+    /// dispatcher — the one whose comment promised that "an older daemon can
+    /// still be asked something it does not know about" — could not be reached
+    /// from a socket at all.  A newer client now hears that this daemon does
+    /// not support the request, which is the difference between "upgrade the
+    /// daemon" and "your client is broken".
+    ///
+    /// It still costs the connection a strike: a request nobody can act on is
+    /// as good a sign of a broken or probing client as a malformed line, and
+    /// three of them is enough courtesy either way.  The cost of dropping that
+    /// is a connection that can be talked to forever for free.
+    #[serde(other)]
+    Unknown,
+}
+
+impl Request {
+    /// A ping that says which wire format this build speaks.
+    ///
+    /// Every caller wants the same thing, and one that spelled the field out
+    /// would be the one that forgot to update it.
+    pub fn ping() -> Self {
+        Request::Ping {
+            version: Some(crate::PROTOCOL_VERSION),
+        }
+    }
 }
 
 /// Deserialize a subscribe filter, keeping at most [`MAX_SUBSCRIBE_SERVICES`]

--- a/crates/servicrab-protocol/src/request.rs
+++ b/crates/servicrab-protocol/src/request.rs
@@ -1,6 +1,17 @@
 //! Request types sent from the CLI (or other clients) to the daemon.
 
+use std::collections::BTreeSet;
+
 use serde::{Deserialize, Serialize};
+
+/// How many services one `subscribe` may name.
+///
+/// The filter is consulted for every event and every subscriber, and the list
+/// arrives from the socket before anything has authenticated it, so it needs a
+/// bound.  A project with more services than this exists, but a subscriber that
+/// wants that many is asking for all of them — which an empty list already says,
+/// at no cost.
+pub const MAX_SUBSCRIBE_SERVICES: usize = 256;
 
 /// A request that a client sends to the servicrab daemon.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -44,8 +55,18 @@ pub enum Request {
     /// is the only request that turns a connection one-way.
     Subscribe {
         /// Only report these services; empty means all of them.
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        services: Vec<String>,
+        ///
+        /// A set rather than a list: the daemon has to answer "is this service
+        /// wanted?" for every event and every subscriber, and duplicates in the
+        /// request would otherwise be paid for on each one.  Truncated to
+        /// [`MAX_SUBSCRIBE_SERVICES`] names on decoding, because the request
+        /// arrives before anything has vouched for it.
+        #[serde(
+            default,
+            deserialize_with = "bounded_services",
+            skip_serializing_if = "BTreeSet::is_empty"
+        )]
+        services: BTreeSet<String>,
 
         /// Whether captured stdout/stderr lines are part of the stream.
         #[serde(default = "yes")]
@@ -53,7 +74,63 @@ pub enum Request {
     },
 }
 
+/// Deserialize a subscribe filter, keeping at most [`MAX_SUBSCRIBE_SERVICES`]
+/// names.
+///
+/// Truncating rather than rejecting: a client that names too many services
+/// wants a stream, and the extra names are indistinguishable from asking for
+/// everything.  The daemon logs it so the surprise is not silent.
+fn bounded_services<'de, D>(deserializer: D) -> Result<BTreeSet<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let mut names = BTreeSet::<String>::deserialize(deserializer)?;
+    while names.len() > MAX_SUBSCRIBE_SERVICES {
+        names.pop_last();
+    }
+    Ok(names)
+}
+
 /// Serde default for flags that are on unless a client says otherwise.
 fn yes() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_service_names_collapse() {
+        let request: Request = serde_json::from_str(
+            r#"{"type":"subscribe","services":["api","api","db"],"logs":true}"#,
+        )
+        .expect("valid subscribe");
+
+        let Request::Subscribe { services, .. } = request else {
+            panic!("expected a subscribe");
+        };
+        assert_eq!(services.len(), 2);
+    }
+
+    /// The list arrives from the socket before anything has vouched for it, and
+    /// the filter is consulted for every event and every subscriber.
+    #[test]
+    fn an_oversized_service_list_is_truncated() {
+        let names: Vec<String> = (0..MAX_SUBSCRIBE_SERVICES * 3)
+            .map(|n| format!("svc-{n:06}"))
+            .collect();
+        let payload = serde_json::json!({ "type": "subscribe", "services": names });
+
+        let request: Request =
+            serde_json::from_value(payload).expect("an oversized list is accepted, not rejected");
+
+        let Request::Subscribe { services, .. } = request else {
+            panic!("expected a subscribe");
+        };
+        assert_eq!(services.len(), MAX_SUBSCRIBE_SERVICES);
+        // The names that survive are the first ones in order, so the truncation
+        // is at least predictable.
+        assert!(services.contains("svc-000000"));
+    }
 }

--- a/crates/servicrab-protocol/src/request.rs
+++ b/crates/servicrab-protocol/src/request.rs
@@ -102,6 +102,31 @@ pub enum Request {
 }
 
 impl Request {
+    /// The `type` tags this build understands, in the order the README
+    /// documents them.
+    ///
+    /// It exists because the tag is the one thing a refusal cannot recover from
+    /// the decoded value: `#[serde(other)]` needs a unit variant, so
+    /// [`Request::Unknown`] carries nothing.  Quoting the tag back tells a
+    /// client author about their typo; listing these tells them what to write
+    /// instead, which is what serde's own `expected one of …` used to do for
+    /// free before an unrecognised request stopped being an error.
+    ///
+    /// A list beside an enum is a list that can go stale, so it is not trusted
+    /// on its word: `every_supported_tag_decodes_to_a_real_request` proves each
+    /// entry still names a variant, and `every_variant_is_listed_as_supported`
+    /// fails to compile if a variant is added without being named here.
+    pub const SUPPORTED: &'static [&'static str] = &[
+        "ping",
+        "status",
+        "shutdown",
+        "start_service",
+        "stop_service",
+        "restart_service",
+        "reload",
+        "subscribe",
+    ];
+
     /// A ping that says which wire format this build speaks.
     ///
     /// Every caller wants the same thing, and one that spelled the field out
@@ -150,6 +175,79 @@ mod tests {
             panic!("expected a subscribe");
         };
         assert_eq!(services.len(), 2);
+    }
+
+    /// Half of what keeps [`Request::SUPPORTED`] honest: every entry still has
+    /// to name a variant this build handles, so a renamed or removed request
+    /// cannot leave a tag behind that the daemon then advertises.
+    #[test]
+    fn every_supported_tag_decodes_to_a_real_request() {
+        for tag in Request::SUPPORTED {
+            // Every request is either bare or takes a `name`; handing over one
+            // that is not wanted is ignored, which keeps this table-driven.
+            let line = format!("{{\"type\":\"{tag}\",\"name\":\"api\"}}");
+
+            let request: Request = serde_json::from_str(&line)
+                .unwrap_or_else(|e| panic!("{tag:?} is listed as supported but {e}"));
+
+            assert_ne!(
+                request,
+                Request::Unknown,
+                "{tag:?} is listed as supported but decodes to the fallback"
+            );
+        }
+    }
+
+    /// The other half, and the one that cannot be forgotten: this match has no
+    /// wildcard, so adding a variant to [`Request`] stops the crate compiling
+    /// until it is named — and the arm you are made to write is right next to
+    /// the assertion that it belongs in [`Request::SUPPORTED`].
+    ///
+    /// `#[non_exhaustive]` is what would otherwise make this impossible, and it
+    /// does not apply inside the crate that declares the enum.
+    #[test]
+    fn every_variant_is_listed_as_supported() {
+        fn tag_of(request: &Request) -> Option<&'static str> {
+            match request {
+                Request::Ping { .. } => Some("ping"),
+                Request::Status => Some("status"),
+                Request::Shutdown => Some("shutdown"),
+                Request::StartService { .. } => Some("start_service"),
+                Request::StopService { .. } => Some("stop_service"),
+                Request::RestartService { .. } => Some("restart_service"),
+                Request::Reload => Some("reload"),
+                Request::Subscribe { .. } => Some("subscribe"),
+                // The fallback is not a request anyone may send, so it is the
+                // one variant that must never be advertised.
+                Request::Unknown => None,
+            }
+        }
+
+        let every_variant = [
+            Request::ping(),
+            Request::Status,
+            Request::Shutdown,
+            Request::StartService {
+                name: "api".to_string(),
+            },
+            Request::StopService {
+                name: "api".to_string(),
+            },
+            Request::RestartService {
+                name: "api".to_string(),
+            },
+            Request::Reload,
+            Request::Subscribe {
+                services: BTreeSet::new(),
+                logs: true,
+            },
+            Request::Unknown,
+        ];
+
+        let advertised: Vec<&str> = every_variant.iter().filter_map(tag_of).collect();
+
+        assert_eq!(advertised, Request::SUPPORTED);
+        assert!(!Request::SUPPORTED.contains(&crate::UNKNOWN));
     }
 
     /// The list arrives from the socket before anything has vouched for it, and

--- a/crates/servicrab-protocol/src/response.rs
+++ b/crates/servicrab-protocol/src/response.rs
@@ -207,6 +207,12 @@ pub enum Event {
         /// How many files the watcher is willing to scan.
         limit: usize,
     },
+    /// Captured output was dropped because the service produced it faster than
+    /// the supervisor could consume it.
+    LogLinesDropped {
+        /// How many lines were dropped since this was last reported.
+        count: u64,
+    },
     /// The service failed fatally.
     Failed {
         /// A human-readable description of the failure.

--- a/crates/servicrab-protocol/src/response.rs
+++ b/crates/servicrab-protocol/src/response.rs
@@ -2,6 +2,30 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The tag every enum here falls back to when the daemon names something this
+/// build has never heard of.
+///
+/// `#[non_exhaustive]` buys nothing on a socket.  It stops a downstream crate
+/// from writing an exhaustive `match`, which is a promise about *source*
+/// compatibility, and says nothing at all about a line of JSON: serde's
+/// internally tagged representation rejects an unrecognised tag outright, so
+/// before these fallbacks existed a single new event kind from a 1.1 daemon
+/// failed to decode and took the whole event stream down with it — on every
+/// client of every earlier release, mid-run.  Every wildcard arm written on the
+/// strength of `#[non_exhaustive]` was therefore unreachable from the wire, and
+/// the comments explaining them were describing something that could not
+/// happen.
+///
+/// The fallbacks are what make those arms real.  A client decodes what it
+/// understands, keeps reading, and hands the rest on untouched — the raw line is
+/// still what `--json` prints, so nothing is lost to a consumer that knows more
+/// than this build does.
+///
+/// It is a reserved word in the wire format as a consequence: a future release
+/// must not name a real variant `unknown`, or older clients would silently
+/// classify it as one of these instead of reporting it.
+pub const UNKNOWN: &str = "unknown";
+
 /// The lifecycle state of a service, as reported by the daemon.
 ///
 /// This mirrors `servicrab_core::ServiceState`, but the protocol crate stays
@@ -26,6 +50,11 @@ pub enum ServiceState {
     Exited,
     /// The service failed fatally.
     Failed,
+    /// A state this build has no name for, because a newer daemon reported it.
+    ///
+    /// See [`UNKNOWN`] for why every enum on this side of the wire has one.
+    #[serde(other)]
+    Unknown,
 }
 
 impl std::fmt::Display for ServiceState {
@@ -39,6 +68,7 @@ impl std::fmt::Display for ServiceState {
             ServiceState::Stopped => "stopped",
             ServiceState::Exited => "exited",
             ServiceState::Failed => "failed",
+            ServiceState::Unknown => UNKNOWN,
         };
         f.write_str(text)
     }
@@ -57,6 +87,11 @@ pub enum Health {
     Healthy,
     /// The service exhausted its retry budget.
     Unhealthy,
+    /// A verdict this build has no name for, because a newer daemon reported it.
+    ///
+    /// See [`UNKNOWN`].
+    #[serde(other)]
+    Unknown,
 }
 
 impl std::fmt::Display for Health {
@@ -66,6 +101,7 @@ impl std::fmt::Display for Health {
             Health::Starting => "starting",
             Health::Healthy => "healthy",
             Health::Unhealthy => "unhealthy",
+            Health::Unknown => UNKNOWN,
         };
         f.write_str(text)
     }
@@ -102,6 +138,11 @@ pub enum Stream {
     Stdout,
     /// The service's standard error.
     Stderr,
+    /// A stream this build has no name for, because a newer daemon named it.
+    ///
+    /// See [`UNKNOWN`].
+    #[serde(other)]
+    Unknown,
 }
 
 impl std::fmt::Display for Stream {
@@ -109,6 +150,7 @@ impl std::fmt::Display for Stream {
         match self {
             Stream::Stdout => f.write_str("stdout"),
             Stream::Stderr => f.write_str("stderr"),
+            Stream::Unknown => f.write_str(UNKNOWN),
         }
     }
 }
@@ -218,6 +260,14 @@ pub enum Event {
         /// A human-readable description of the failure.
         message: String,
     },
+    /// Something a newer daemon reported that this build has no name for.
+    ///
+    /// See [`UNKNOWN`].  The payload is dropped rather than kept: a client that
+    /// wants the detail of an event it does not understand wants the line the
+    /// daemon sent, not a half-interpreted copy of it, and that line is what
+    /// [`crate::Response`] consumers are handed alongside the decoded value.
+    #[serde(other)]
+    Unknown,
 }
 
 /// A response returned by the servicrab daemon to a client.
@@ -238,6 +288,13 @@ pub enum Response {
         project: String,
         /// The daemon's own process id.
         pid: u32,
+        /// Which revision of this wire format the daemon speaks.
+        ///
+        /// Optional, and absent means "did not say": a 0.3 daemon has no such
+        /// field, and a client that treated silence as a mismatch would refuse
+        /// to talk to one.  See [`crate::PROTOCOL_VERSION`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<u32>,
     },
 
     /// Answer to [`crate::Request::Status`].
@@ -265,4 +322,12 @@ pub enum Response {
         /// Human-readable description of what went wrong.
         message: String,
     },
+
+    /// A reply this build has no name for, because a newer daemon sent it.
+    ///
+    /// See [`UNKNOWN`].  This is the variant that keeps a subscriber alive: an
+    /// event stream is read until the daemon goes away, so a line it cannot
+    /// name has to be something it can skip rather than something it dies on.
+    #[serde(other)]
+    Unknown,
 }

--- a/crates/servicrab-protocol/src/response.rs
+++ b/crates/servicrab-protocol/src/response.rs
@@ -79,6 +79,16 @@ pub struct ServiceInfo {
     /// Current lifecycle state.
     pub state: ServiceState,
     /// Process-group id of the running process, when there is one.
+    ///
+    /// The same number [`Event::Started`] calls `pgid`, under the name it has
+    /// always had here.  Every service runs in its own process group whose
+    /// leader is the direct child, so this is a pid as well — but signalling it
+    /// as one reaches only the leader, which is the mistake the name invites.
+    /// Read [`ServiceInfo::pgid`] instead; this field stays because removing it
+    /// would break every existing reader.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pgid: Option<i32>,
+    /// Deprecated alias for [`ServiceInfo::pgid`], carrying the same value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pid: Option<i32>,
     /// How long the current process has been running, in seconds.
@@ -220,6 +230,92 @@ pub enum Event {
     },
 }
 
+/// The version of the machine-readable output contract.
+///
+/// Carried by every `--json` document the CLI prints, so a script can refuse a
+/// stream it was not written for instead of guessing.  It is bumped only when a
+/// shape changes in a way that an existing reader would misread; adding an
+/// optional field is not such a change.
+///
+/// The socket protocol's own responses do not carry it: they are tagged by
+/// `type` and versioned by the daemon that speaks them, and a subscriber reads
+/// thousands of event lines where the number would be pure repetition.  It
+/// appears once, in the `ok` line that answers `subscribe`.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// A stable, machine-readable classification of a failed request.
+///
+/// The point of this existing at all is that [`Response::Error::message`] does
+/// not: the message is written for the operator reading it and is free to be
+/// reworded, while a script matching on `code` keeps working.  Compared as a
+/// string in JSON (`"unknown_service"`), so the set can grow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ErrorCode {
+    /// The request named a service this daemon does not supervise.
+    UnknownService,
+    /// The service is in the middle of another command.
+    Busy,
+    /// Nothing is listening: no daemon is running for this project.
+    NotRunning,
+    /// The service, or the daemon, is already running.
+    AlreadyRunning,
+    /// The configuration file did not load, or did not validate.
+    ValidationFailed,
+    /// The command is not supported on this platform, or by this daemon.
+    Unsupported,
+    /// The request failed for a reason with no code of its own.
+    ///
+    /// Also what a response that predates this field decodes to: such a
+    /// response says no more than that the request failed.
+    #[default]
+    Failed,
+}
+
+impl ErrorCode {
+    /// The code as it appears on the wire.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ErrorCode::UnknownService => "unknown_service",
+            ErrorCode::Busy => "busy",
+            ErrorCode::NotRunning => "not_running",
+            ErrorCode::AlreadyRunning => "already_running",
+            ErrorCode::ValidationFailed => "validation_failed",
+            ErrorCode::Unsupported => "unsupported",
+            ErrorCode::Failed => "failed",
+        }
+    }
+}
+
+impl std::fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// How many services a reload added, changed and removed.
+///
+/// The same three numbers the reload's message spells out in prose, as numbers,
+/// because "1 added, 0 changed, 2 removed" is a sentence and a caller that
+/// wants to know whether anything happened should not have to parse one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ReloadChanges {
+    /// Services that were started because the new configuration declares them.
+    pub added: usize,
+    /// Services that were restarted because their definition changed.
+    pub changed: usize,
+    /// Services that were stopped because the new configuration drops them.
+    pub removed: usize,
+}
+
+impl ReloadChanges {
+    /// Whether the reload changed nothing at all.
+    pub fn is_empty(&self) -> bool {
+        self.added == 0 && self.changed == 0 && self.removed == 0
+    }
+}
+
 /// A response returned by the servicrab daemon to a client.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -227,9 +323,28 @@ pub enum Event {
 pub enum Response {
     /// The requested operation completed successfully.
     Ok {
-        /// Optional human-readable message.
+        /// What happened, in prose, for a person to read.
+        ///
+        /// Explicitly **not** part of the API: the wording ("api started",
+        /// "reloaded demo: 1 added, 0 changed, 0 removed") is free to change
+        /// between releases.  Anything a program needs to act on is a field of
+        /// its own — see [`Response::Ok::changes`].
         #[serde(default, skip_serializing_if = "Option::is_none")]
         message: Option<String>,
+
+        /// What a reload changed, present only in the answer to
+        /// [`crate::Request::Reload`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        changes: Option<ReloadChanges>,
+
+        /// The output contract this daemon speaks, present in the `ok` that
+        /// answers [`crate::Request::Subscribe`].
+        ///
+        /// It is on this one response because that is the handshake: a
+        /// subscriber learns the version once and then reads events, rather
+        /// than being told again on every line.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        schema_version: Option<u32>,
     },
 
     /// Answer to [`crate::Request::Ping`].
@@ -262,7 +377,176 @@ pub enum Response {
 
     /// The requested operation failed.
     Error {
-        /// Human-readable description of what went wrong.
+        /// Why it failed, as something to match on.
+        ///
+        /// This is the field a script should read.  Missing from responses
+        /// written before it existed, which decode as [`ErrorCode::Failed`].
+        #[serde(default)]
+        code: ErrorCode,
+
+        /// Why it failed, in prose, for a person to read.  Not part of the
+        /// API; the wording may change between releases.
         message: String,
+
+        /// The individual problems, when there is more than one.
+        ///
+        /// A configuration that does not validate has one entry per error,
+        /// rather than one string with newlines in it that a caller would have
+        /// to split.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        errors: Vec<String>,
     },
+}
+
+impl Response {
+    /// A bare success, with nothing to say about it.
+    pub fn ok() -> Self {
+        Response::Ok {
+            message: None,
+            changes: None,
+            schema_version: None,
+        }
+    }
+
+    /// A success with a message for the operator.
+    pub fn message(message: impl Into<String>) -> Self {
+        Response::Ok {
+            message: Some(message.into()),
+            changes: None,
+            schema_version: None,
+        }
+    }
+
+    /// A failure with a code to match on and a message to read.
+    pub fn error(code: ErrorCode, message: impl Into<String>) -> Self {
+        Response::Error {
+            code,
+            message: message.into(),
+            errors: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole reason `pid` survives: a client written against 0.x reads that
+    /// field and must keep finding the number there.
+    #[test]
+    fn a_status_entry_reports_the_process_group_under_both_names() {
+        let info = ServiceInfo {
+            name: "api".to_string(),
+            state: ServiceState::Running,
+            pgid: Some(4242),
+            pid: Some(4242),
+            uptime_secs: Some(3),
+            restarts: 0,
+            health: Health::None,
+            message: None,
+        };
+
+        let json = serde_json::to_value(&info).expect("serialize");
+        assert_eq!(json["pgid"], 4242);
+        assert_eq!(json["pid"], 4242, "the deprecated alias carries the value");
+    }
+
+    /// A reader that only knows `pid` is exactly the reader this alias is for,
+    /// and one that only knows `pgid` is the reader it is being replaced by.
+    #[test]
+    fn a_status_entry_decodes_from_either_field_alone() {
+        let old: ServiceInfo = serde_json::from_str(
+            r#"{"name":"api","state":"running","pid":7,"restarts":0,"health":"none"}"#,
+        )
+        .expect("a 0.x status entry");
+        assert_eq!(old.pid, Some(7));
+
+        let new: ServiceInfo = serde_json::from_str(
+            r#"{"name":"api","state":"running","pgid":7,"restarts":0,"health":"none"}"#,
+        )
+        .expect("a status entry with only the new name");
+        assert_eq!(new.pgid, Some(7));
+    }
+
+    /// The point of the field: `1 added, 0 changed, 2 removed` is a sentence,
+    /// and a caller deciding whether to act should read numbers instead.
+    #[test]
+    fn a_reload_reports_its_counts_as_numbers() {
+        let response = Response::Ok {
+            message: Some("reloaded demo: 1 added, 0 changed, 2 removed".to_string()),
+            changes: Some(ReloadChanges {
+                added: 1,
+                changed: 0,
+                removed: 2,
+            }),
+            schema_version: None,
+        };
+
+        let json = serde_json::to_value(&response).expect("serialize");
+        assert_eq!(json["changes"]["added"], 1);
+        assert_eq!(json["changes"]["changed"], 0);
+        assert_eq!(json["changes"]["removed"], 2);
+    }
+
+    /// Every other `ok` keeps the shape it had, so a reader of those lines sees
+    /// no new keys at all.
+    #[test]
+    fn an_ok_with_nothing_to_add_carries_no_extra_fields() {
+        let json = serde_json::to_value(Response::message("api started")).expect("serialize");
+
+        assert_eq!(json["type"], "ok");
+        assert_eq!(json["message"], "api started");
+        assert!(json.get("changes").is_none(), "{json}");
+        assert!(json.get("schema_version").is_none(), "{json}");
+    }
+
+    #[test]
+    fn an_error_carries_a_code_beside_its_message() {
+        let json = serde_json::to_value(Response::error(
+            ErrorCode::UnknownService,
+            "unknown service \"web\"",
+        ))
+        .expect("serialize");
+
+        assert_eq!(json["code"], "unknown_service");
+        assert_eq!(json["message"], "unknown service \"web\"");
+        assert!(json.get("errors").is_none(), "no list to report: {json}");
+    }
+
+    /// A validation failure used to be one string with newlines and bullets in
+    /// it, which every caller had to take apart again.
+    #[test]
+    fn a_validation_failure_lists_its_errors_separately() {
+        let response = Response::Error {
+            code: ErrorCode::ValidationFailed,
+            message: "servicrab.toml has 2 error(s); the stack was left untouched".to_string(),
+            errors: vec![
+                "services.api: command must not be empty".to_string(),
+                "services.db: unknown dependency \"cache\"".to_string(),
+            ],
+        };
+
+        let json = serde_json::to_value(&response).expect("serialize");
+        assert_eq!(json["code"], "validation_failed");
+        assert_eq!(json["errors"].as_array().expect("a list").len(), 2);
+        assert!(
+            !json["message"].as_str().expect("a message").contains('\n'),
+            "the message is one line now: {json}"
+        );
+    }
+
+    /// An error line from a daemon that predates the field still decodes, and
+    /// says no more than that the request failed.
+    #[test]
+    fn an_error_without_a_code_decodes_as_a_plain_failure() {
+        let response: Response =
+            serde_json::from_str(r#"{"type":"error","message":"it went wrong"}"#)
+                .expect("a 0.x error line");
+
+        let Response::Error { code, errors, .. } = response else {
+            panic!("expected an error");
+        };
+        assert_eq!(code, ErrorCode::Failed);
+        assert!(errors.is_empty());
+    }
 }


### PR DESCRIPTION
Everything on the way to 1.0 except the two rounds still outstanding: freezing the
protocol/JSON/exit-code contracts, and making the documentation true. Opening it now
so CI finally sees this work — all 46 commits have so far been verified only on one
macOS machine, and **never compiled on Linux at all**, which matters because this
branch adds a lot of platform-conditional code.

The version stays at `0.3.0` here on purpose: the release workflow gates a tag
against the workspace version, and the bump belongs in the release commit.

## What is in it

**Correctness in the supervisor**

- Readiness updates were dropped when no dependent was listening yet.
- `reload` overwrote a slot that was still shutting down, instead of reviving it.
- The `stop_all` abort path skipped its `killpg` sweep, so grandchildren survived.
- SIGHUP killed the supervisor outright and orphaned every process group it owned.
- `max_restarts = 0` now means unlimited, the reading Compose and systemd use.
- The filewatch debounce loop could livelock, and the walk recursed without bound.

**Four bugs no single round could see, found while integrating**

- A detached output reader kept an event sink alive, which kept a channel open,
  which stranded the relay, so the supervisor never reported that a service had
  stopped and the operator's `stop` waited for an ack nobody could send.
- A health check held its sink until its next tick, so stopping a health-checked
  service paid a fixed penalty: measured 2.02s against 0.02s without one, and on
  the old code the same configuration failed the command outright.
- A losing `start` polled the winner's socket and reported success for a daemon it
  had not started.
- A flood reported its own losses once per delivered line, and those reports are
  never dropped — so the bound the log allowance exists to enforce collapsed
  through the announcement of it. 1536 reports for 2560 lines.

**Blocking I/O off the async workers**

Log writes, the filewatch scan and the health probes no longer share a worker with
child `wait()`s and the control channel. The captured-output path is bounded and
says what it dropped.

**Daemon hardening**

- One daemon per project, decided by `flock` rather than by a check another start
  could slip past.
- The socket is private from the instant it exists (`umask` around `bind`), and the
  predictable `/tmp` fallback is gone: the search is `.servicrab/`, then
  `$XDG_RUNTIME_DIR`, then a `$TMPDIR` validated to be absolute, a directory, owned
  by this user and with no group or other bits.
- `SO_PEERCRED`/`LOCAL_PEERCRED`, so a daemon answers only the user that started
  it, with a refusal that names both uids instead of closing the connection.
- Frame-size, idle, connection and malformed-line limits on the socket.
- `.servicrab/stopped` is written atomically, with a version header, and stale
  names are reconciled at startup.
- Shutdown signals are claimed before the daemon becomes reachable, so a signal
  during startup no longer kills it and strands the socket.
- `up` honours Ctrl+C even when nobody is reading its output.

**Release engineering**

Tag-vs-version check, a gate on CI being green for the tagged commit, build
provenance, prerelease handling that keeps `latest` pointing at a real release,
a `cargo doc` check, concurrency, and cache keys that include the toolchain.

## Test plan

- 568 tests, green on repeated consecutive runs; `fmt`, `clippy -D warnings` and
  `cargo doc -D warnings` clean.
- Every fix has a test that fails without it. The three riskiest were verified by
  mutation in both directions: the order of the shutdown and budget checks, the
  flood-report guard, and the health monitor releasing its sink.
- Flake work: the daemon suite went from roughly one failing run in ten to clean,
  and `a_flooding_service_has_its_output_dropped_and_says_so` from 3 failures in 30
  to 0 in 40. A test race introduced by this branch was caught and fixed too
  (6 in 150 → 0 in 200).
- **What CI has to tell us**, because this machine cannot: that it builds and passes
  on Linux, and specifically that the `$XDG_RUNTIME_DIR` branch of the socket search
  works — that variable is unset on macOS, so on Linux the primary fallback is the
  least exercised code here.

## Not in this PR

Protocol/JSON/exit-code contracts, and the documentation corrections. The README
still claims things that are not true (`zero-dependency`, `cross-platform`, `down`
does not exist yet), and no range limit is documented anywhere.